### PR TITLE
Add CLI command to create default admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ pip install -r requirements.txt
 flask run
 ```
 Seed data can be generated with `python seed_students.py`.
+Run `flask ensure-admin` to create the default admin account using the
+`ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables.
 
 ## Roadmap
 - Mobile‑friendly redesign

--- a/app.py
+++ b/app.py
@@ -178,6 +178,7 @@ class Admin(db.Model):
         return check_password_hash(self.password_hash, pw)
 
 # after your models are defined but before you start serving requests
+from flask.cli import with_appcontext
 from app import db, Admin
 import os
 
@@ -192,9 +193,15 @@ def ensure_default_admin():
         app.logger.info(f"🚀 Created default admin '{user}'")
 
 
-# Bootstrap default admin within application context
-with app.app_context():
+# ---- Flask CLI command to manually ensure default admin ----
+@app.cli.command("ensure-admin")
+@with_appcontext
+def ensure_admin_command():
+    """Create the default admin user if credentials are provided."""
     ensure_default_admin()
+
+
+
 
 
 # -------------------- AUTH HELPERS --------------------


### PR DESCRIPTION
## Summary
- provide `flask ensure-admin` CLI command
- remove automatic admin creation on import
- document the CLI usage in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c39d795c8333974b84288fb0bdf4