### PR TITLE
Update config initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,15 +12,22 @@ import pyotp
 import urllib.parse
 import os
 
+required_env_vars = ["SECRET_KEY", "DATABASE_URL", "FLASK_ENV"]
+missing_vars = [var for var in required_env_vars if not os.getenv(var)]
+if missing_vars:
+    raise RuntimeError(
+        "Missing required environment variables: " + ", ".join(missing_vars)
+    )
+
 app = Flask(__name__)
-app.config['DEBUG']=False
-app.config['ENV']='production'
-app.config.update(
+app.config.from_mapping(
+    DEBUG=False,
+    ENV=os.environ["FLASK_ENV"],
+    SECRET_KEY=os.environ["SECRET_KEY"],
+    SQLALCHEMY_DATABASE_URI=os.environ["DATABASE_URL"],
     SESSION_COOKIE_SECURE=True,
-    SESSION_COOKIE_SAMESITE="None"
+    SESSION_COOKIE_SAMESITE="None",
 )
-app.secret_key = os.environ.get("FLASK_SECRET_KEY", "1%Inspiration&99%Effort")
-app.config["SQLALCHEMY_DATABASE_URI"] = os.environ["DATABASE_URL"]
 
 def url_encode_filter(s):
     return urllib.parse.quote_plus(s)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 import os
 import sys
+# Set required environment variables for tests before importing the app
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("FLASK_ENV", "testing")
 # Add the project root to PYTHONPATH so tests can import application modules
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import pytest


### PR DESCRIPTION
## Summary
- enforce presence of required environment variables
- configure Flask using `from_mapping`
- update tests to provide the env vars

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c3a01cd0833382d62cf0ed66856e