### PR TITLE
Align startup command with Procfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ flask run
 ```
 Seed data can be generated with `python seed_students.py`.
 
+## Deployment
+The included `Procfile` launches the app with:
+
+```bash
+gunicorn --bind=0.0.0.0 --timeout 600 app:app
+```
+
+`startup.txt` mirrors this command for platforms that read from it. Use this
+entrypoint when deploying to ensure the Flask application starts correctly.
+
 ## Roadmap
 - Mobile‑friendly redesign
 - Classroom store & inventory system

--- a/startup.txt
+++ b/startup.txt
@@ -1,1 +1,1 @@
-gunicorn --bind=0.0.0.0 --timeout 600 app_full:app
+gunicorn --bind=0.0.0.0 --timeout 600 app:app


### PR DESCRIPTION
## Summary
- fix `startup.txt` so it uses the same gunicorn command as the Procfile
- document the proper deployment entrypoint in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c3a24a90833392bb66f2e1e28e9b