### PR TITLE
Add /health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ flask run
 ```
 Seed data can be generated with `python seed_students.py`.
 
+## Deployment & Monitoring
+Deploy behind a production web server such as Gunicorn and NGINX.
+For uptime checks, call the `/health` endpoint which returns HTTP 200 if the
+database is reachable.
+
 ## Roadmap
 - Mobile‑friendly redesign
 - Classroom store & inventory system

--- a/app.py
+++ b/app.py
@@ -1156,6 +1156,17 @@ def handle_tap():
     return jsonify({"status": "ok"})
 
 
+@app.route('/health')
+def health_check():
+    """Simple health check endpoint for uptime monitoring."""
+    try:
+        db.session.execute(text('SELECT 1'))
+        return 'ok', 200
+    except Exception:
+        app.logger.exception('Health check failed')
+        return 'db error', 500
+
+
 @app.route('/debug/filters')
 def debug_filters():
     return jsonify(list(app.jinja_env.filters.keys()))


### PR DESCRIPTION
## Summary
- implement `/health` endpoint for DB status
- update README with deployment/monitoring notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c3a613f883338cb4c276eeb62348