### PR TITLE
Add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ flask run
 ```
 Seed data can be generated with `python seed_students.py`.
 
+### Environment variables
+The application respects several optional variables:
+
+- `LOG_LEVEL` – logging level (defaults to `INFO`).
+- `LOG_FORMAT` – format for log messages.
+- `LOG_FILE` – file used for rotating logs when `FLASK_ENV=production`.
+
 ## Roadmap
 - Mobile‑friendly redesign
 - Classroom store & inventory system


### PR DESCRIPTION
## Summary
- add configurable logging with optional rotating log file in production
- document LOG_LEVEL, LOG_FORMAT and LOG_FILE variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c3a6d2b883338b32f31b72775526