### PR TITLE
Fix spelling in transaction template

### DIFF
--- a/templates/admin_transactions.html
+++ b/templates/admin_transactions.html
@@ -1,5 +1,5 @@
 {% extends "layout_admin.html" %}
-{% set page_title = "Transaction Hisotry" %}
+{% set page_title = "Transaction History" %}
 {% block title %}Transaction History{% endblock %}
 {% block content %}
 <div class="container-fluid">


### PR DESCRIPTION
## Summary
- fix misspelled page title in **admin_transactions.html**

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -q -r requirements.txt` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855c3a7ea888333a5d004eaf6894b87