### PR TITLE
Add automatic db migration before server start

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --bind=0.0.0.0 --timeout 600 app:app
+web: bash -c 'flask db upgrade && gunicorn --bind=0.0.0.0 --timeout 600 app:app'

--- a/README.md
+++ b/README.md
@@ -61,3 +61,18 @@ This project is licensed under the [PolyForm Noncommercial License 1.0.0](https:
 > - Incorporate it into any offering that generates revenue (e.g., paid courses, tutoring platforms)
 > - Use it internally within a for-profit business, even if not publicly distributed
 
+## Deployment on Azure
+Add `flask db upgrade` before launching Gunicorn so the database schema is up to date:
+
+```
+web: bash -c 'flask db upgrade && gunicorn --bind=0.0.0.0 --timeout 600 app:app'
+```
+Configure your Azure App Service startup command or Procfile with this line.
+
+## Deployment on DigitalOcean
+When deploying on DigitalOcean, run migrations before starting Gunicorn:
+
+```bash
+FLASK_APP=app flask db upgrade
+gunicorn --bind=0.0.0.0 --timeout 600 app:app
+```


### PR DESCRIPTION
## Summary
- ensure Gunicorn runs after `flask db upgrade`
- describe migration step for Azure and DigitalOcean deployment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c3a93d9c833380fb41baa91fab6a