### PR TITLE
Handle SQLAlchemy errors in payroll

### DIFF
--- a/app.py
+++ b/app.py
@@ -989,8 +989,9 @@ def run_payroll():
         if is_json:
             return jsonify(status="success", message=f"Payroll complete. Paid {len(summary)} students.")
         flash(f"✅ Payroll complete. Paid {len(summary)} students.", "admin_success")
-    except Exception as e:
-        app.logger.error(f"❌ Payroll error: {e}")
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        app.logger.error(f"❌ Payroll error: {e}", exc_info=True)
         if is_json:
             return jsonify(status="error", message="Payroll error occurred. Check logs."), 500
         flash("Payroll error occurred. Check logs.", "admin_error")


### PR DESCRIPTION
## Summary
- add SQLAlchemyError handler in `run_payroll`
- include `exc_info=True` when logging the payroll failure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685601de32508333b9ca771cb78d757b