### PR TITLE
Add per-row CSV upload error logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1140,7 +1140,9 @@ def admin_upload_students():
                 )
                 db.session.add(new_student)
                 added_count += 1
-            except Exception as e:
+            except (ValueError, SQLAlchemyError) as e:
+                db.session.rollback()
+                app.logger.error(f"Error processing row {row}: {e}", exc_info=True)
                 flash(f"Error processing row: {e}", "admin_error")
         db.session.commit()
         flash(f"Uploaded {added_count} students successfully!", "admin_success")


### PR DESCRIPTION
## Summary
- catch `ValueError` or `SQLAlchemyError` when uploading students
- log each failure with `app.logger.error` and rollback the session

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685601df1930833386b5dc0beb523f95