### PR TITLE
Handle DB failures in /health

### DIFF
--- a/app.py
+++ b/app.py
@@ -1236,9 +1236,9 @@ def health_check():
     try:
         db.session.execute(text('SELECT 1'))
         return 'ok', 200
-    except Exception:
+    except SQLAlchemyError as e:
         app.logger.exception('Health check failed')
-        return 'db error', 500
+        return jsonify(error='Database error'), 500
 
 
 @app.route('/debug/filters')

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,19 @@
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from app import db
+
+
+def test_health_ok(client):
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.data == b'ok'
+
+
+def test_health_db_error(monkeypatch, client):
+    def raise_error(*args, **kwargs):
+        raise SQLAlchemyError("fail")
+    monkeypatch.setattr(db.session, 'execute', raise_error)
+    resp = client.get('/health')
+    assert resp.status_code == 500
+    assert resp.is_json
+    assert resp.json['error'] == 'Database error'


### PR DESCRIPTION
## Summary
- catch `SQLAlchemyError` in the `/health` endpoint
- return JSON with `Database error` and status 500
- add basic tests for health check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685601e038608333bbca0f7e1ee7dd70