### PR TITLE
Switch to username-based student login

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An interactive banking and classroom management platform for students. The appli
 ## Features
 
 ### Implemented & manually tested
-- Student login with QR ID and PIN
+- Student login with username and PIN
 - New user setup to create PIN and passphrase
 - Two-factor transfer between checking and savings accounts
 - Attendance tracking for Period A and B with tap in/out and automatic timers

--- a/hash_utils.py
+++ b/hash_utils.py
@@ -1,0 +1,40 @@
+import hmac
+import os
+import secrets
+from hashlib import sha256
+
+
+_PEPPER = os.environ.get("PEPPER", "pepper").encode()
+
+
+def hash_hmac(value: bytes, salt: bytes) -> str:
+    """Return HMAC-SHA256 hex digest of ``salt + value`` using a pepper."""
+    return hmac.new(_PEPPER, salt + value, sha256).hexdigest()
+
+
+def hash_username(username: str, salt: bytes) -> str:
+    return hash_hmac(username.encode(), salt)
+
+
+def get_random_salt() -> bytes:
+    """Return 16 random bytes."""
+    try:
+        import requests
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "generateBlobs",
+            "params": {
+                "apiKey": os.environ.get("RANDOM_ORG_API_KEY", ""),
+                "n": 1,
+                "size": 16,
+            },
+            "id": 1,
+        }
+        resp = requests.post("https://api.random.org/json-rpc/4/invoke", json=payload, timeout=5)
+        resp.raise_for_status()
+        blob = resp.json()["result"]["random"]["data"][0]
+        return bytes.fromhex(blob)
+    except Exception:
+        return secrets.token_bytes(16)
+

--- a/templates/admin_students.html
+++ b/templates/admin_students.html
@@ -28,8 +28,6 @@
         <thead class="table-dark">
             <tr>
                 <th>Name</th>
-                <th>Email</th>
-                <th>QR ID</th>
                 <th>Passes Left</th>
                 <th>Checking Balance</th>
                 <th>Last Tap In</th>
@@ -42,11 +40,9 @@
             <tr>
                 <td>
                     <a href="{{ url_for('student_detail', student_id=student.id) }}">
-                        {{ student.name }}
+                        {{ student.full_name }}
                     </a>
                 </td>
-                <td>{{ student.email or '—' }}</td>
-                <td>{{ student.qr_id or '—' }}</td>
                 <td>{{ student.passes_left if student.passes_left is not none else '—' }}</td>
                 <td>${{ "%.2f"|format(student.checking_balance) }}</td>
                 <td>

--- a/templates/student_dashboard.html
+++ b/templates/student_dashboard.html
@@ -93,11 +93,11 @@
 
     {% set current_hour = now.hour %}
     {% if current_hour < 12 %}
-    <h1 class="mb-4 text-center">Good morning, {{ student.name }}!</h1>
+    <h1 class="mb-4 text-center">Good morning, {{ student.full_name }}!</h1>
     {% elif current_hour < 18 %}
-    <h1 class="mb-4 text-center">Good afternoon, {{ student.name }}!</h1>
+    <h1 class="mb-4 text-center">Good afternoon, {{ student.full_name }}!</h1>
     {% else %}
-    <h1 class="mb-4 text-center">Good evening, {{ student.name }}!</h1>
+    <h1 class="mb-4 text-center">Good evening, {{ student.full_name }}!</h1>
     {% endif %}
 
     <div class="mb-4">
@@ -120,7 +120,6 @@
 
     <!-- Basic Info -->
     <div class="mb-4">
-        <p><strong>Email:</strong> {{ student.email }}</p>
         <p><strong>Block:</strong> {{ student.block }}</p>
     </div>
 

--- a/templates/student_detail.html
+++ b/templates/student_detail.html
@@ -6,7 +6,7 @@
 </head>
 <body class="p-4">
     <div id="flashToastContainer" class="position-fixed bottom-0 end-0 p-3" style="z-index:1050;"></div>
-    <h2>🧑‍🎓 {{ student.name }} (Block {{ student.block }})</h2>
+    <h2>🧑‍🎓 {{ student.full_name }} (Block {{ student.block }})</h2>
 
     <!-- SECTION 1: STUDENT INFO -->
     <div class="card mb-4">
@@ -14,8 +14,6 @@
         <div class="card-body">
             <p><strong>ID:</strong> {{ student.id }}</p>
             <p><strong>PIN:</strong> ****</p>
-            <p><strong>Email:</strong> {{ student.email }}</p>
-            <p><strong>QR Code ID:</strong> {{ student.qr_id }}</p>
             <p><strong>Checking Balance:</strong> ${{ "%.2f"|format(student.checking_balance) }}</p>
             <p><strong>Savings Balance:</strong> ${{ "%.2f"|format(student.savings_balance) }}</p>
             <hr>

--- a/templates/student_login.html
+++ b/templates/student_login.html
@@ -12,8 +12,8 @@
     {% endif %}
     <form method="POST">
       <div class="mb-3">
-        <label for="qr_id" class="form-label">QR Code ID</label>
-        <input type="text" class="form-control" id="qr_id" name="qr_id" required>
+        <label for="username" class="form-label">Username</label>
+        <input type="text" class="form-control" id="username" name="username" required>
       </div>
       <div class="mb-3">
         <label for="pin" class="form-label">PIN</label>

--- a/templates/student_setup.html
+++ b/templates/student_setup.html
@@ -85,7 +85,7 @@
 </head>
 <body>
     <div class="setup-container">
-        <h1>Hi, {{ student.name }}!</h1>
+        <h1>Hi, {{ student.full_name }}!</h1>
         <p class="description">Let’s finish setting up your account with a PIN and a secure passphrase.</p>
         <p class="description">PIN is required when you sign in to your Class Economy account. You also need it to tap in and out for attendance. It should not be something easy to guess and should never be your birthdate.</p>
         <p class="description">Passphrase is required when you take actions involving spending or moving money. A passphrase should be long and easy to remember.</p> 

--- a/templates/student_setup_totp.html
+++ b/templates/student_setup_totp.html
@@ -68,7 +68,7 @@
 </head>
 <body>
 <div class="container">
-    <h2>One Last Step, {{ student.name }}</h2>
+    <h2>One Last Step, {{ student.full_name }}</h2>
     <p>Scan the QR code below using your authenticator app (like Google Authenticator or Authy), or enter the code manually.</p>
 
     {% if error %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,48 +1,46 @@
 import os
 import sys
-# Set required environment variables for tests before importing the app
-os.environ.setdefault("SECRET_KEY", "test-secret")
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-os.environ.setdefault("FLASK_ENV", "testing")
-# Add the project root to PYTHONPATH so tests can import application modules
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Override env vars for testing
+os.environ["SECRET_KEY"] = "test-secret"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["FLASK_ENV"] = "testing"
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import pytest
 from app import app, db
 
+
 @pytest.fixture
 def client():
-    # Configure testing & disable CSRF
-    app.config.update({
-        "TESTING": True,
-        "WTF_CSRF_ENABLED": False,
-        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"
-    })
-    # Push application context
+    app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
     ctx = app.app_context()
     ctx.push()
-
-    # Create tables and test client
     db.create_all()
     client = app.test_client()
-
     yield client
-
-    # Teardown
     db.drop_all()
     ctx.pop()
 
 
 @pytest.fixture
 def test_student():
-    from app import Student
-    # Create and return a default test student
-    stu = Student(
-        name="Test Student",
-        email="test@student.com",
-        qr_id="T1",
+    from hash_utils import hash_username, get_random_salt
+    salt = get_random_salt()
+    stu = app.Student(
+        first_name="Test",
+        last_initial="S",
+        block="A",
+        salt=salt,
+        username_hash=hash_username("test", salt),
         pin_hash="fake-hash",
-        block="A"
     )
     db.session.add(stu)
     db.session.commit()
     return stu
+

--- a/tests/test_login_redirect.py
+++ b/tests/test_login_redirect.py
@@ -1,10 +1,20 @@
 import pytest
 from app import db, Student, Admin
 from werkzeug.security import generate_password_hash
+from hash_utils import hash_username, get_random_salt
 
 def test_student_login_next_redirect(client):
-    # Create student with hashed pin
-    stu = Student(name="Stu", email="s@example.com", qr_id="S1", pin_hash=generate_password_hash("1234"), block="A", has_completed_setup=True)
+    salt = get_random_salt()
+    username = "stu1"
+    stu = Student(
+        first_name="Stu",
+        last_initial="S",
+        block="A",
+        salt=salt,
+        username_hash=hash_username(username, salt),
+        pin_hash=generate_password_hash("1234"),
+        has_completed_setup=True,
+    )
     db.session.add(stu)
     db.session.commit()
 
@@ -14,7 +24,7 @@ def test_student_login_next_redirect(client):
     assert '/student/login?next=%2Fstudent%2Fdashboard' in resp.headers['Location']
 
     # Login and expect redirect back
-    login_resp = client.post('/student/login?next=/student/dashboard', data={'qr_id': 'S1', 'pin': '1234'})
+    login_resp = client.post('/student/login?next=/student/dashboard', data={'username': 'stu1', 'pin': '1234'})
     assert login_resp.status_code == 302
     assert login_resp.headers['Location'].endswith('/student/dashboard')
 


### PR DESCRIPTION
## Summary
- add helpers for username hashing and random salt
- refactor `Student` model for plaintext first/last and hashed identifiers
- update login flow to use username instead of QR id
- fix templates for username based auth
- update README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68605c02da04833388d283841039716a