### PR TITLE
Add SQL migration for admin invite codes and MFA

### DIFF
--- a/migrations/sql/20250710_admin_invites.sql
+++ b/migrations/sql/20250710_admin_invites.sql
@@ -1,0 +1,21 @@
+-- Migration to add admin invite codes and admins table with MFA
+
+-- Ensure uuid generation function is available
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE admin_invite_codes (
+    code TEXT PRIMARY KEY,
+    expires_at TIMESTAMP,
+    used BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    used_at TIMESTAMP
+);
+
+CREATE TABLE admins (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    totp_secret TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+


### PR DESCRIPTION
## Summary
- add a SQL migration script to introduce `admin_invite_codes` and new `admins` table with MFA support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c2ea8d348333963197b0858e946c