### PR TITLE
Update privacy and terms of service documents

### DIFF
--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -73,11 +73,11 @@
 
     <h4>Security Measures</h4>
     <ul>
-      <li>All sensitive data is encrypted at rest.</li>
-      <li>Authentication credentials are hashed using industry-standard algorithms with per-record salts and a global pepper.</li>
-      <li>All communications use HTTPS/TLS to encrypt data in transit.</li>
-      <li>Session management includes idle timeouts and no persistent cookies to prevent unauthorized access.</li>
-      <li>All hashed data is one-way; no party, including administrators, can reverse the hashes to recover original values.</li>
+      <li><strong>Encryption at Rest</strong>: All sensitive data is encrypted at rest to protect it from unauthorized access.</li>
+      <li><strong>State-of-the-Art Hashing</strong>: We use industry-leading algorithms to protect your credentials. Passwords and PINs are hashed using <strong>Argon2</strong>, a key derivation function that is highly resistant to brute-force and rainbow table attacks. Other sensitive identifiers are hashed using <strong>HMAC-SHA256</strong> with a per-record salt and a global pepper, ensuring that each hash is unique and secure.</li>
+      <li><strong>Encrypted Transit</strong>: All data transmitted between your device and our servers is protected using HTTPS/TLS, preventing eavesdropping or tampering.</li>
+      - <strong>Secure Session Management</strong>: The application enforces idle timeouts and avoids persistent cookies to minimize the risk of unauthorized access from unattended devices.</li>
+      <li><strong>Irreversible Hashes</strong>: All hashing is one-way, meaning that original values cannot be recovered from the stored hashes by anyone, including administrators.</li>
     </ul>
 
     <h4>Student Rights & Access</h4>

--- a/templates/tos.html
+++ b/templates/tos.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Terms of Service - Classroom Token Hub</title>
+  <title>Terms of Service - Classroom Economy</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
@@ -25,9 +25,6 @@
     h4 {
       margin-top: 1.5rem;
     }
-    h5 {
-      margin-top: 1rem;
-    }
     p, ul {
       margin-top: 0.5rem;
       font-size: 1rem;
@@ -43,54 +40,48 @@
 </head>
 <body>
   <div class="container">
-    <h2 class="mb-4">📜 Classroom Token Hub Terms of Service</h2>
+    <h2 class="mb-4">Terms of Service</h2>
 
-    <h4>Introduction</h4>
-    <p>Welcome to Classroom Token Hub. These Terms of Service govern your use of the application and outline the rights and responsibilities of all users.</p>
+    <h4>1. Acceptance of Terms</h4>
+    <p>By accessing or using the Classroom Economy application ("Service"), you agree to be bound by these Terms of Service ("Terms"). If you disagree with any part of the terms, you may not access the Service.</p>
 
-    <h4>Acceptance of Terms</h4>
-    <p>By accessing or using Classroom Token Hub, you agree to be bound by these Terms of Service. If you do not agree, please do not use the service.</p>
+    <h4>2. Description of Service</h4>
+    <p>Classroom Economy is a web-based application designed for educational purposes to simulate a classroom economy. The Service allows educators to manage virtual currency, student participation, and other related activities.</p>
 
-    <h4>Use of Service</h4>
-    <p>Classroom Token Hub grants you a limited, non-exclusive license to use the service in accordance with these Terms. You must not misuse, modify, or hack the service.</p>
+    <h4>3. User Accounts</h4>
+    <p>To use certain features of the Service, you must create an account. You are responsible for safeguarding your account credentials, including your username, PIN, and passphrase. You agree not to disclose your credentials to any third party. You must notify us immediately upon becoming aware of any breach of security or unauthorized use of your account.</p>
 
-    <h4>Acceptable Use</h4>
+    <h4>4. User Conduct</h4>
+    <p>You agree not to use the Service to:</p>
     <ul>
-      <li>Do not attempt unauthorized access or interfere with the service or other users.</li>
-      <li>Do not upload harmful, illegal, or infringing content.</li>
-      <li>Comply with all applicable laws and regulations while using the service.</li>
+      <li>Violate any local, state, national, or international law.</li>
+      <li>Impersonate any person or entity or falsely state or otherwise misrepresent your affiliation with a person or entity.</li>
+      <li>Interfere with or disrupt the Service or servers or networks connected to the Service.</li>
+      <li>Attempt to gain unauthorized access to the Service, other accounts, or computer systems or networks connected to the Service.</li>
     </ul>
 
-    <h4>Ownership &amp; Content</h4>
-    <p>All content provided by Classroom Token Hub is owned by the service or its licensors. Student-generated data remains the property of the respective users or institutions.</p>
+    <h4>5. Intellectual Property and License</h4>
+    <p>The Service and its original content, features, and functionality are and will remain the exclusive property of Timothy Chang and its licensors. The Service is protected by copyright, trademark, and other laws of both the United States and foreign countries.</p>
+    <p>This application is licensed under the <strong>PolyForm Noncommercial License 1.0.0</strong>. You may use, copy, and modify the software for non-commercial educational purposes only. A copy of the license is available at <a href="https://polyformproject.org/licenses/noncommercial/1.0.0/">https://polyformproject.org/licenses/noncommercial/1.0.0/</a>.</p>
+    <p>The source code is available on GitHub at <a href="https://github.com/timwonderer/classroom-economy">https://github.com/timwonderer/classroom-economy</a>.</p>
 
-    <h4>License</h4>
-    <p>This application is licensed under the <a href="https://polyformproject.org/licenses/noncommercial/1.0.0/">PolyForm Noncommercial License 1.0.0</a>. You may use, copy, and modify the software for non-commercial educational purposes only.</p>
-    <p>Developers can clone the repository at <a href="https://github.com/timwonderer/classroom-economy">https://github.com/timwonderer/classroom-economy</a>. Once the app is in full production, the repository will be made public.</p>
+    <h4>6. Termination</h4>
+    <p>We may terminate or suspend your account and bar access to the Service immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not to a breach of the Terms.</p>
 
-    <h4>Disclaimer of Warranties</h4>
-    <p>The service is provided "as is" without any warranties, express or implied. Use it at your own risk.</p>
+    <h4>7. Disclaimer of Warranties</h4>
+    <p>The Service is provided on an "AS IS" and "AS AVAILABLE" basis. Your use of the Service is at your sole risk. The Service is provided without warranties of any kind, whether express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose, non-infringement, or course of performance.</p>
 
-    <h4>Limitation of Liability</h4>
-    <p>Classroom Token Hub and its creators shall not be liable for any damages arising from the use or inability to use the service.</p>
+    <h4>8. Limitation of Liability</h4>
+    <p>In no event shall Timothy Chang, nor its directors, employees, partners, agents, suppliers, or affiliates, be liable for any indirect, incidental, special, consequential or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from your access to or use of or inability to access or use the Service.</p>
 
-    <h4>User Responsibilities</h4>
-    <ul>
-      <li>Users are responsible for maintaining the security of their own credentials and devices. Never share your username, PIN, or passphrase and always sign out when finished.</li>
-      <li>Classroom Token Hub employs industry-standard security measures, but we are not liable for unauthorized access or data loss resulting from user negligence, compromised devices, or insecure practices.</li>
-    </ul>
+    <h4>9. Governing Law</h4>
+    <p>These Terms shall be governed and construed in accordance with the laws of the jurisdiction in which the service is operated, without regard to its conflict of law provisions.</p>
 
-    <h4>Changes to Terms</h4>
-    <p>We reserve the right to modify these Terms of Service at any time. Significant changes will be communicated to users.</p>
+    <h4>10. Changes to Terms</h4>
+    <p>We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material, we will provide at least 30 days' notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion.</p>
 
-    <h4>Governing Law</h4>
-    <p>These Terms shall be governed by and construed in accordance with the laws of the relevant jurisdiction.</p>
-
-    <h4>Contact Information</h4>
-    <p>If you have any questions about these Terms, please contact:<br>
-       Timothy Chang: <a href="mailto:timothy.cs.chang@gmail.com">timothy.cs.chang@gmail.com</a><br>
-       
-    </p>
+    <h4>11. Contact Us</h4>
+    <p>If you have any questions about these Terms, please contact Timothy Chang at <a href="mailto:timothy.cs.chang@gmail.com">timothy.cs.chang@gmail.com</a>.</p>
 
     <a href="{{ url_for('student_login') }}" class="btn btn-secondary mt-4">← Back to Login</a>
   </div>


### PR DESCRIPTION
This commit updates two key legal documents:

1.  **privacy.html**: The security measures section has been updated to be more transparent about the specific technologies used. It now explicitly mentions the use of Argon2 for password hashing and HMAC-SHA256 with salting and peppering for other sensitive data.

2.  **tos.html**: The terms of service page has been completely rewritten with more standard, boilerplate language to provide a more comprehensive and professional legal framework. The existing PolyForm Noncommercial License 1.0.0 information has been retained and integrated into the new structure.