### PR TITLE
Fix student login pepper regression

### DIFF
--- a/hash_utils.py
+++ b/hash_utils.py
@@ -2,21 +2,77 @@ import hmac
 import os
 import secrets
 from hashlib import sha256
-
-# PEPPER_KEY is now a required environment variable, checked in app.py.
-# No default is provided here to ensure it fails fast if not set.
-_PEPPER = os.environ["PEPPER_KEY"].encode()
+from typing import Iterator, Tuple
 
 
-def hash_hmac(value: bytes, salt: bytes) -> str:
-    """Return HMAC-SHA256 hex digest of ``salt + value`` using a pepper."""
-    return hmac.new(_PEPPER, salt + value, sha256).hexdigest()
+def _load_peppers() -> Tuple[bytes, Tuple[bytes, ...]]:
+    """Return the primary pepper and any legacy peppers as byte strings."""
+
+    primary = os.environ.get("PEPPER_KEY")
+    if not primary:
+        raise KeyError("PEPPER_KEY")
+
+    primary_bytes = primary.encode()
+
+    legacy_values = []
+    legacy_csv = os.environ.get("PEPPER_LEGACY_KEYS")
+    if legacy_csv:
+        legacy_values.extend(value.strip() for value in legacy_csv.split(",") if value.strip())
+
+    # Support the historical environment variable name automatically.
+    legacy_env = os.environ.get("PEPPER")
+    if legacy_env:
+        legacy_values.append(legacy_env)
+
+    legacy_bytes = []
+    for value in legacy_values:
+        encoded = value.encode()
+        if encoded != primary_bytes and encoded not in legacy_bytes:
+            legacy_bytes.append(encoded)
+
+    return primary_bytes, tuple(legacy_bytes)
 
 
-def hash_username(username: str, salt: bytes) -> str:
-    return hash_hmac(username.encode(), salt)
+_PEPPER, _LEGACY_PEPPERS = _load_peppers()
+
+
+def get_primary_pepper() -> bytes:
+    """Return the configured primary pepper."""
+
+    return _PEPPER
+
+
+def get_legacy_peppers() -> Tuple[bytes, ...]:
+    """Return any configured legacy peppers."""
+
+    return _LEGACY_PEPPERS
+
+
+def get_all_peppers() -> Tuple[bytes, ...]:
+    """Return a tuple containing the primary pepper followed by any legacy peppers."""
+
+    return (_PEPPER, *_LEGACY_PEPPERS)
+
+
+def hash_hmac(value: bytes, salt: bytes, pepper: bytes | None = None) -> str:
+    """Return HMAC-SHA256 hex digest of ``salt + value`` using the provided pepper."""
+
+    pepper_bytes = pepper or _PEPPER
+    return hmac.new(pepper_bytes, salt + value, sha256).hexdigest()
+
+
+def hash_username(username: str, salt: bytes, pepper: bytes | None = None) -> str:
+    return hash_hmac(username.encode(), salt, pepper)
+
+
+def iter_username_hashes(username: str, salt: bytes) -> Iterator[tuple[str, bytes]]:
+    """Yield ``(hash, pepper)`` pairs for the username using all configured peppers."""
+
+    for pepper in get_all_peppers():
+        yield hash_username(username, salt, pepper=pepper), pepper
 
 
 def get_random_salt() -> bytes:
     """Return 16 cryptographically secure random bytes."""
+
     return secrets.token_bytes(16)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ import sys
 os.environ["SECRET_KEY"] = "test-secret"
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 os.environ["FLASK_ENV"] = "testing"
+os.environ["PEPPER_KEY"] = "test-primary-pepper"
+os.environ["PEPPER_LEGACY_KEYS"] = "legacy-pepper"
+os.environ.setdefault("PEPPER", "legacy-pepper")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_login_redirect.py
+++ b/tests/test_login_redirect.py
@@ -1,7 +1,7 @@
 import pytest
 from app import db, Student
 from werkzeug.security import generate_password_hash
-from hash_utils import hash_username, get_random_salt
+from hash_utils import get_legacy_peppers, get_random_salt, hash_username
 
 def test_student_login_next_redirect(client):
     salt = get_random_salt()
@@ -27,3 +27,29 @@ def test_student_login_next_redirect(client):
     login_resp = client.post('/student/login?next=/student/dashboard', data={'username': 'stu1', 'pin': '1234'})
     assert login_resp.status_code == 302
     assert login_resp.headers['Location'].endswith('/student/dashboard')
+
+
+def test_student_login_with_legacy_pepper_rotation(client):
+    salt = get_random_salt()
+    legacy_peppers = list(get_legacy_peppers())
+    assert legacy_peppers, "Expected at least one legacy pepper for rotation test"
+    legacy_pepper = legacy_peppers[0]
+
+    username = "legacy_user"
+    stu = Student(
+        first_name="Legacy",
+        last_initial="L",
+        block="B",
+        salt=salt,
+        username_hash=hash_username(username, salt, pepper=legacy_pepper),
+        pin_hash=generate_password_hash("1234"),
+        has_completed_setup=True,
+    )
+    db.session.add(stu)
+    db.session.commit()
+
+    resp = client.post('/student/login', data={'username': username, 'pin': '1234'})
+    assert resp.status_code == 302
+
+    updated = db.session.get(Student, stu.id)
+    assert updated.username_hash == hash_username(username, salt)


### PR DESCRIPTION
## Summary
- add legacy pepper support in `hash_utils` so existing student hashes continue to validate after the pepper rename
- update student login and account claim flows to try legacy peppers and transparently migrate hashes to the current secret
- align student upload with the shared helpers and extend tests to cover legacy pepper rotation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e34761b4b8833399731bc484169258