### PR TITLE
Deploy app from GitHub to DigitalOcean

### DIFF
--- a/migrations/versions/a1b2c3d4e5f6_add_rent_system.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_rent_system.py
@@ -1,7 +1,7 @@
 """Add rent system with per-period tracking
 
 Revision ID: a1b2c3d4e5f6
-Revises: f5a1e3e4d7c8
+Revises: merge_001
 Create Date: 2025-11-16 06:00:00.000000
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision = 'a1b2c3d4e5f6'
-down_revision = 'f5a1e3e4d7c8'
+down_revision = 'merge_001'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Fixed migration dependency issue that was causing deployment failures. The rent system migration now correctly depends on the merge migration instead of the hall pass branch, creating a single valid migration head.

Changes:
- Updated a1b2c3d4e5f6_add_rent_system.py down_revision from f5a1e3e4d7c8 to merge_001
- This ensures proper migration chain: merge_001 → a1b2c3d4e5f6
- Resolves KeyError: '7ed94f24520a' during Digital Ocean deployment

Migration chain is now:
- Main branch + Hall pass branch → merge_001 → rent system (a1b2c3d4e5f6)
- Single head with no broken dependencies