### PR TITLE
Fix attribute error in admin student interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,10 +150,12 @@ if os.getenv("FLASK_ENV", app.config.get("ENV")) == "production":
 
 # ---- Jinja2 filter: Format UTC datetime to user's local time ----
 import pytz
+from datetime import datetime, date
 def format_datetime(value, fmt='%Y-%m-%d %I:%M %p'):
     """
     Convert a UTC datetime to the user's timezone (from session) and format it.
     Defaults to Pacific Time if no timezone is set in the session.
+    Handles both datetime and date objects.
     """
     if not value:
         return ''
@@ -167,6 +169,10 @@ def format_datetime(value, fmt='%Y-%m-%d %I:%M %p'):
         target_tz = pytz.timezone('America/Los_Angeles')
 
     utc = pytz.utc
+
+    # Convert date objects to datetime objects at midnight
+    if isinstance(value, date) and not isinstance(value, datetime):
+        value = datetime.combine(value, datetime.min.time())
 
     # Localize naive datetimes as UTC before converting
     dt = value if getattr(value, 'tzinfo', None) else utc.localize(value)


### PR DESCRIPTION
…lter

The format_datetime filter was attempting to call pytz.localize() on date objects, which only works with datetime objects. This caused an AttributeError when viewing newly created students from the admin interface, as rent_due_date and property_tax_due_date are set as date objects.

Updated the filter to:
- Import datetime and date classes
- Check if value is a date object (but not datetime, since datetime is a subclass)
- Convert date objects to datetime objects at midnight before timezone processing
- Handle both date and datetime objects seamlessly

Fixes the error: AttributeError: 'datetime.date' object has no attribute 'tzinfo'