### PR TITLE
Separate permanent block and cooldown period for insurance repurchase

### DIFF
--- a/app.py
+++ b/app.py
@@ -435,8 +435,9 @@ class InsurancePolicy(db.Model):
     is_monetary = db.Column(db.Boolean, default=True)  # True = monetary claims, False = item/service claims
 
     # Special rules
-    no_repurchase_after_cancel = db.Column(db.Boolean, default=False)
-    repurchase_wait_days = db.Column(db.Integer, default=30)  # Days to wait after cancel
+    no_repurchase_after_cancel = db.Column(db.Boolean, default=False)  # Permanent block on repurchase
+    enable_repurchase_cooldown = db.Column(db.Boolean, default=False)  # Enable temporary cooldown period
+    repurchase_wait_days = db.Column(db.Integer, default=30)  # Days to wait after cancel (if cooldown enabled)
     auto_cancel_nonpay_days = db.Column(db.Integer, default=7)  # Days of non-payment before cancel
     claim_time_limit_days = db.Column(db.Integer, default=30)  # Days from incident to file claim
 
@@ -1014,14 +1015,20 @@ def student_purchase_insurance(policy_id):
         return redirect(url_for('student_insurance_marketplace'))
 
     # Check repurchase restrictions
-    if policy.no_repurchase_after_cancel:
-        cancelled = StudentInsurance.query.filter_by(
-            student_id=student.id,
-            policy_id=policy.id,
-            status='cancelled'
-        ).order_by(StudentInsurance.cancel_date.desc()).first()
+    cancelled = StudentInsurance.query.filter_by(
+        student_id=student.id,
+        policy_id=policy.id,
+        status='cancelled'
+    ).order_by(StudentInsurance.cancel_date.desc()).first()
 
-        if cancelled and cancelled.cancel_date:
+    if cancelled:
+        # Check for permanent block (no repurchase allowed EVER)
+        if policy.no_repurchase_after_cancel:
+            flash("This policy cannot be repurchased after cancellation.", "danger")
+            return redirect(url_for('student_insurance_marketplace'))
+
+        # Check for cooldown period (temporary restriction)
+        if policy.enable_repurchase_cooldown and cancelled.cancel_date:
             days_since_cancel = (datetime.utcnow() - cancelled.cancel_date).days
             if days_since_cancel < policy.repurchase_wait_days:
                 flash(f"You must wait {policy.repurchase_wait_days - days_since_cancel} more days before repurchasing this policy.", "warning")
@@ -2087,6 +2094,7 @@ def admin_edit_insurance_policy(policy_id):
         policy.max_claim_amount = form.max_claim_amount.data
         policy.is_monetary = form.is_monetary.data
         policy.no_repurchase_after_cancel = form.no_repurchase_after_cancel.data
+        policy.enable_repurchase_cooldown = form.enable_repurchase_cooldown.data
         policy.repurchase_wait_days = form.repurchase_wait_days.data
         policy.auto_cancel_nonpay_days = form.auto_cancel_nonpay_days.data
         policy.claim_time_limit_days = form.claim_time_limit_days.data

--- a/forms.py
+++ b/forms.py
@@ -94,8 +94,9 @@ class InsurancePolicyForm(FlaskForm):
     is_monetary = BooleanField('Monetary Claims (students claim dollar amounts)', default=True)
 
     # Special rules
-    no_repurchase_after_cancel = BooleanField('Prevent repurchase after cancellation', default=False)
-    repurchase_wait_days = IntegerField('Days to wait before repurchase', default=30)
+    no_repurchase_after_cancel = BooleanField('Prevent repurchase after cancellation (permanent block)', default=False)
+    enable_repurchase_cooldown = BooleanField('Enable forced cooldown period', default=False)
+    repurchase_wait_days = IntegerField('Cooldown days before repurchase allowed', default=30)
     auto_cancel_nonpay_days = IntegerField('Auto-cancel after days of non-payment', default=7)
     claim_time_limit_days = IntegerField('Time limit to file claim (days from incident)', default=30)
 

--- a/templates/admin_edit_insurance_policy.html
+++ b/templates/admin_edit_insurance_policy.html
@@ -157,17 +157,31 @@
               <div class="card-body">
                 <!-- Repurchase Rules -->
                 <div class="mb-3 pb-3 border-bottom">
+                  <h6 class="fw-bold mb-2"><i class="bi bi-ban me-1"></i>Repurchase Restrictions</h6>
+
+                  <!-- Permanent Block -->
                   <div class="form-check form-switch mb-2">
-                    {{ form.no_repurchase_after_cancel(class="form-check-input", role="switch", id="cooldownToggle") }}
+                    {{ form.no_repurchase_after_cancel(class="form-check-input", role="switch", id="permanentBlockToggle") }}
                     {{ form.no_repurchase_after_cancel.label(class="form-check-label fw-bold") }}
                   </div>
-                  <div id="cooldownDays">
-                    {{ form.repurchase_wait_days.label(class="form-label fw-bold small") }}
-                    <div class="input-group input-group-sm">
-                      {{ form.repurchase_wait_days(class="form-control", placeholder="0") }}
-                      <span class="input-group-text">days</span>
+                  <small class="text-muted d-block mb-3">Students can NEVER repurchase after canceling</small>
+
+                  <!-- Cooldown Period -->
+                  <div id="cooldownSection">
+                    <div class="form-check form-switch mb-2">
+                      {{ form.enable_repurchase_cooldown(class="form-check-input", role="switch", id="cooldownToggle") }}
+                      {{ form.enable_repurchase_cooldown.label(class="form-check-label fw-bold") }}
                     </div>
-                    <small class="text-muted">Cooldown period for repurchase</small>
+                    <small class="text-muted d-block mb-2">Students must wait before repurchasing</small>
+
+                    <div id="cooldownDays" style="display: none;">
+                      {{ form.repurchase_wait_days.label(class="form-label fw-bold small") }}
+                      <div class="input-group input-group-sm">
+                        {{ form.repurchase_wait_days(class="form-control", placeholder="30") }}
+                        <span class="input-group-text">days</span>
+                      </div>
+                      <small class="text-muted">Cooldown period for repurchase</small>
+                    </div>
                   </div>
                 </div>
 
@@ -330,21 +344,39 @@ document.addEventListener('DOMContentLoaded', function() {
   // Initialize on load
   updateBundleIds();
 
-  // Toggle cooldown days visibility
+  // Handle mutually exclusive repurchase restrictions
+  const permanentBlockToggle = document.getElementById('permanentBlockToggle');
   const cooldownToggle = document.getElementById('cooldownToggle');
+  const cooldownSection = document.getElementById('cooldownSection');
   const cooldownDays = document.getElementById('cooldownDays');
 
-  function toggleCooldown() {
-    if (cooldownToggle.checked) {
-      cooldownDays.style.display = 'block';
-    } else {
+  function updateRepurchaseRestrictions() {
+    if (permanentBlockToggle.checked) {
+      // Permanent block is ON - disable and hide cooldown section
+      cooldownSection.style.opacity = '0.5';
+      cooldownSection.style.pointerEvents = 'none';
+      cooldownToggle.checked = false;
+      cooldownToggle.disabled = true;
       cooldownDays.style.display = 'none';
+    } else {
+      // Permanent block is OFF - enable cooldown section
+      cooldownSection.style.opacity = '1';
+      cooldownSection.style.pointerEvents = 'auto';
+      cooldownToggle.disabled = false;
+
+      // Show/hide days field based on cooldown toggle
+      if (cooldownToggle.checked) {
+        cooldownDays.style.display = 'block';
+      } else {
+        cooldownDays.style.display = 'none';
+      }
     }
   }
 
-  if (cooldownToggle) {
-    cooldownToggle.addEventListener('change', toggleCooldown);
-    toggleCooldown(); // Initialize on load
+  if (permanentBlockToggle && cooldownToggle) {
+    permanentBlockToggle.addEventListener('change', updateRepurchaseRestrictions);
+    cooldownToggle.addEventListener('change', updateRepurchaseRestrictions);
+    updateRepurchaseRestrictions(); // Initialize on load
   }
 });
 </script>


### PR DESCRIPTION
Changed repurchase restrictions to be mutually exclusive options:

1. Form Updates (forms.py):
   - Renamed: "Prevent repurchase after cancellation" → "Prevent repurchase after cancellation (permanent block)"
   - Added: "enable_repurchase_cooldown" BooleanField - new toggle for cooldown
   - Updated: "repurchase_wait_days" label to clarify it's for cooldown only
   - These options are now mutually exclusive

2. Database Model (app.py):
   - Added: enable_repurchase_cooldown Boolean column
   - Updated comments to clarify:
     * no_repurchase_after_cancel = Permanent block on repurchase
     * enable_repurchase_cooldown = Enable temporary cooldown period
     * repurchase_wait_days = Days to wait (only if cooldown enabled)

3. Backend Logic (app.py - student_purchase_insurance):
   - Restructured repurchase check logic:
     * First checks for permanent block → Shows "cannot be repurchased" error
     * Then checks for cooldown period (if enabled) → Shows "wait X days" message
   - Permanent block takes precedence over cooldown
   - Route now saves enable_repurchase_cooldown field

4. UI/UX Improvements (admin_edit_insurance_policy.html):
   - Added section header: "Repurchase Restrictions"
   - Two separate toggles:
     * "Prevent repurchase (permanent block)" - NEVER allow repurchase
     * "Enable forced cooldown period" - Allow after X days
   - Clear descriptions under each toggle
   - Cooldown days field only shows when cooldown toggle is ON

5. JavaScript Logic:
   - When permanent block is ON:
     * Cooldown section becomes disabled and grayed out (opacity 0.5)
     * Cooldown toggle is disabled and unchecked
     * Days field is hidden
   - When permanent block is OFF:
     * Cooldown section is enabled
     * Teacher can toggle cooldown on/off
     * Days field shows only when cooldown is ON
   - Mutual exclusivity is enforced in the UI

Teacher Workflow:
- Option A: Enable permanent block → Students NEVER repurchase
- Option B: Enable cooldown (30 days) → Students wait, then can repurchase
- Default: Both OFF → Students can immediately repurchase

Files modified:
- forms.py: Added enable_repurchase_cooldown field
- app.py: Added database column, updated save logic, updated purchase validation
- templates/admin_edit_insurance_policy.html: Redesigned UI with mutual exclusivity