### PR TITLE
fix(migration): Correct payroll migration parent to h1i2j3k4l5m6

### DIFF
--- a/migrations/versions/i6j7k8l9m0n1_add_payroll_settings_rewards_fines.py
+++ b/migrations/versions/i6j7k8l9m0n1_add_payroll_settings_rewards_fines.py
@@ -1,7 +1,7 @@
 """Add payroll settings, rewards, and fines tables
 
 Revision ID: i6j7k8l9m0n1
-Revises: merge_001
+Revises: h1i2j3k4l5m6
 Create Date: 2025-11-17 12:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'i6j7k8l9m0n1'
-down_revision = 'merge_001'
+down_revision = 'h1i2j3k4l5m6'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The payroll migration was pointing to merge_001, but the migration chain has continued with: merge_001 → a1b2c3d4e5f6 (rent) → a2b3c4d5e6f7 (insurance) → ... → h1i2j3k4l5m6 (hall pass).

Setting down_revision to h1i2j3k4l5m6 ensures a linear migration chain and resolves the 'Multiple head revisions' error when running flask db upgrade.