### PR TITLE
Fix 502 error after refactoring

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -660,7 +660,7 @@ python create_admin.py             # Create admin account
 python manage_invites.py           # Manage invite codes
 
 # Deployment
-gunicorn --bind=0.0.0.0 --timeout 600 app:app
+gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app
 
 # Dependencies
 ./scripts/update_packages.sh       # Update and test packages

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -23,7 +23,7 @@ The application is a standard Flask application that can be deployed to any plat
 4.  **Start the Application Server:**
     Use Gunicorn to run the application in a production environment:
     ```bash
-    gunicorn --bind=0.0.0.0 --timeout 600 app:app
+    gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app
     ```
 
 ## Environment Variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENV FLASK_APP=app.py
+ENV FLASK_APP=wsgi.py
 ENV FLASK_ENV=production
 
 # Use gunicorn to run the app in production, using Fly.io's release_command for migrations separately
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "app:app"]
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "wsgi:app"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bash -c 'flask db upgrade && gunicorn --bind=0.0.0.0 --timeout 600 app:app'
+web: bash -c 'flask db upgrade && gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app'

--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ The application also recognizes these optional variables for logging:
 Deploy using Gunicorn:
 
 ```bash
-gunicorn --bind=0.0.0.0 --timeout 600 app:app
+gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app
 ```
 
 For DigitalOcean deployments, run migrations, then launch Gunicorn:
 
 ```bash
-FLASK_APP=app flask db upgrade
-gunicorn --bind=0.0.0.0 --timeout 600 app:app
+FLASK_APP=wsgi flask db upgrade
+gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app
 ```
 
 ## Monitoring

--- a/wsgi.py
+++ b/wsgi.py
@@ -4,7 +4,7 @@ Root application module for Classroom Token Hub.
 This module serves as the WSGI entry point and provides backward compatibility
 imports. All routes have been modularized into blueprints (Stages 4-5).
 
-For gunicorn: app:app
+For gunicorn: wsgi:app
 """
 
 from flask import render_template, request, session


### PR DESCRIPTION
The application was failing to start with "Failed to find attribute 'app' in 'app'" because gunicorn was trying to import app:app, which created a naming conflict between the app.py file and the app/ package directory.

Changes:
- Renamed app.py to wsgi.py to eliminate naming conflict
- Updated Procfile to use wsgi:app instead of app:app
- Updated Dockerfile FLASK_APP and CMD to reference wsgi:app
- Updated all documentation (README.md, DEPLOYMENT.md, AGENT.md) with new entry point

This resolves the circular import issue where app.py was trying to 'from app import create_app' but Python was importing the file instead of the package, preventing the app instance from being created.