### PR TITLE
Standardize page layout width across templates

### DIFF
--- a/templates/layout_student.html
+++ b/templates/layout_student.html
@@ -370,7 +370,7 @@
 
     {% block session_timer %}{% endblock %}
 
-    <div class="container content-container">
+    <div class="container-fluid content-container">
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
           {% for category, message in messages %}


### PR DESCRIPTION
Changed student layout from 'container' to 'container-fluid' to match admin and system admin layouts. This ensures all pages span the full width uniformly instead of some appearing as a narrow strip.

- Student portal now uses container-fluid for full-width layout
- Consistent with admin and system admin portal layouts
- Resolves layout inconsistency issue