### PR TITLE
Support two-digit year format in teacher uploads

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2246,7 +2246,18 @@ def upload_students():
             name_code = ''.join(vowels + consonants).lower()
 
             # Generate dob_sum
-            mm, dd, yyyy = map(int, dob_str.split('/'))
+            # Handle both mm/dd/yy and mm/dd/yyyy formats
+            date_parts = dob_str.split('/')
+            mm = int(date_parts[0])
+            dd = int(date_parts[1])
+            year = int(date_parts[2])
+
+            # If year is 2 digits, convert to 4 digits by adding 2000
+            if year < 100:
+                yyyy = year + 2000
+            else:
+                yyyy = year
+
             dob_sum = mm + dd + yyyy
 
             # Generate salt


### PR DESCRIPTION
Updated the upload_students route to accept date of birth in both mm/dd/yy and mm/dd/yyyy formats. When a 2-digit year is provided, it is automatically converted to 4-digit format by adding 2000.