### PR TITLE
Fix 404 error when deleting teachers

### DIFF
--- a/templates/system_admin_manage_teachers.html
+++ b/templates/system_admin_manage_teachers.html
@@ -170,7 +170,7 @@ if (deleteModal) {
         const teacherName = button.getAttribute('data-teacher-name');
 
         document.getElementById('modalTeacherName').textContent = teacherName;
-        document.getElementById('deleteForm').action = `/system-admin/manage-teachers/delete/${teacherId}`;
+        document.getElementById('deleteForm').action = `/sysadmin/manage-teachers/delete/${teacherId}`;
     });
 }
 </script>


### PR DESCRIPTION
Changed hardcoded URL from /system-admin/ to /sysadmin/ to match the blueprint prefix defined in app/routes/system_admin.py. This fixes the 404 Not Found error when attempting to delete a teacher from the system admin interface.