### PR TITLE
Clarify merge migration to avoid duplicate user_reports table

### DIFF
--- a/migrations/versions/r5s6t7u8v9w0_merge_user_reports_and_admin_fields.py
+++ b/migrations/versions/r5s6t7u8v9w0_merge_user_reports_and_admin_fields.py
@@ -1,4 +1,10 @@
-"""Merge user_reports and has_assigned_students migrations
+"""Merge user_reports and has_assigned_students migrations.
+
+This merge resolves the duplicate `user_reports` table creation that was
+introduced when `q4r5s6t7u8v9_add_user_reports_table` was created alongside
+`c4d5e6f7a8b9_add_user_reports_table`. The duplicate migration has been removed,
+and this merge keeps the Alembic history linear without generating multiple
+heads.
 
 Revision ID: r5s6t7u8v9w0
 Revises: c4d5e6f7a8b9, c5f3a8d9e1b4


### PR DESCRIPTION
## Summary
- document that the merge migration resolves the duplicate `user_reports` table creation
- ensure Alembic history stays linear after removing the redundant migration

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201a94c9808333b585ecabacc3470c)