### PR TITLE
fix: add student name to setup greeting and properly handle hall pass…

### DIFF
--- a/app/routes/student.py
+++ b/app/routes/student.py
@@ -1341,7 +1341,7 @@ def setup_complete():
     student = get_logged_in_student()
     student.has_completed_setup = True
     db.session.commit()
-    return render_template('student_setup_complete.html')
+    return render_template('student_setup_complete.html', student_name=student.first_name)
 
 
 # -------------------- HELP AND SUPPORT --------------------


### PR DESCRIPTION
… refunds

- Add missing student name to "All set" greeting on setup complete page
- Fix hall pass voiding to properly decrement student's pass count when refunding Previously, voiding a hall pass purchase would refund the money but student would keep the pass