### PR TITLE
Fix missing pytz import in tap endpoint

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1042,7 +1042,6 @@ def handle_tap():
 
         # Check daily limit when tapping IN
         if action == "tap_in":
-            import pytz
             from payroll import get_daily_limit_seconds
             from attendance import calculate_period_attendance_utc_range
 


### PR DESCRIPTION
…tap endpoint

The local import of pytz at line 1045 caused Python to treat pytz as a local variable throughout the handle_tap function, resulting in UnboundLocalError when pytz was referenced earlier in the function (line 954). Removed the redundant local import since pytz is already imported at the module level.

Fixes issue where students get UnboundLocalError when trying to tap out.