### PR TITLE
Fix workflow heredoc expansion and maintenance message quoting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,11 @@ jobs:
         MAINT_END: ${{ vars.MAINTENANCE_EXPECTED_END || '' }}
         MAINT_CONTACT: ${{ vars.MAINTENANCE_CONTACT || '' }}
       run: |
+        # Prepare escaped environment variables to avoid local shell expansion
+        SSH_ENV_VARS="MAINT_MODE=$(printf %q "${MAINT_MODE}") MAINT_MESSAGE=$(printf %q "${MAINT_MESSAGE}") MAINT_END=$(printf %q "${MAINT_END}") MAINT_CONTACT=$(printf %q "${MAINT_CONTACT}") DATABASE_URL=$(printf %q '${{ secrets.PRODUCTION_DATABASE_URL }}')"
+
         # Connect to the production server and deploy
-        ssh -o StrictHostKeyChecking=no root@24.199.127.184 << EOF
+        ssh -o StrictHostKeyChecking=no root@24.199.127.184 "export ${SSH_ENV_VARS}; bash -s" << 'EOF'
 
           set -e  # Exit immediately if a command exits with a non-zero status
 
@@ -62,7 +65,6 @@ jobs:
 
           # Ensure DATABASE_URL is set for migrations
           echo 'Exporting DATABASE_URL for production migrations...'
-          export DATABASE_URL='${{ secrets.PRODUCTION_DATABASE_URL }}'
 
           echo 'Running database migrations...'
           flask db upgrade

--- a/.github/workflows/toggle-maintenance.yml
+++ b/.github/workflows/toggle-maintenance.yml
@@ -43,7 +43,9 @@ jobs:
         EXPECTED_END="${{ inputs.expected_end }}"
         CONTACT="${{ inputs.contact }}"
 
-        ssh -o StrictHostKeyChecking=no root@24.199.127.184 << EOF
+        SSH_ENV_VARS="MODE_VALUE=$(printf %q "${MODE_VALUE}") MESSAGE=$(printf %q "${MESSAGE}") EXPECTED_END=$(printf %q "${EXPECTED_END}") CONTACT=$(printf %q "${CONTACT}")"
+
+        ssh -o StrictHostKeyChecking=no root@24.199.127.184 "export ${SSH_ENV_VARS}; bash -s" << 'EOF'
           set -e
 
           echo 'Navigating to project directory...'
@@ -57,10 +59,10 @@ jobs:
           sed -i '/^MAINTENANCE_CONTACT=/d' .env 2>/dev/null || true
 
           # Add new maintenance mode variables
-          echo "MAINTENANCE_MODE=$MODE_VALUE" >> .env
-          echo 'MAINTENANCE_MESSAGE="$MESSAGE"' >> .env
-          echo 'MAINTENANCE_EXPECTED_END="$EXPECTED_END"' >> .env
-          echo 'MAINTENANCE_CONTACT="$CONTACT"' >> .env
+          echo "MAINTENANCE_MODE=${MODE_VALUE}" >> .env
+          echo "MAINTENANCE_MESSAGE=\"${MESSAGE}\"" >> .env
+          echo "MAINTENANCE_EXPECTED_END=\"${EXPECTED_END}\"" >> .env
+          echo "MAINTENANCE_CONTACT=\"${CONTACT}\"" >> .env
 
           echo 'Restarting Gunicorn to apply changes...'
           sudo systemctl restart gunicorn


### PR DESCRIPTION
## Summary
- prevent local shell from expanding secrets by exporting escaped env vars and using quoted heredoc in deploy workflow
- safely pass maintenance variables to remote host while handling apostrophes in messages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220a069b848333a1f787edf7978d6e)