### PR TITLE
Fix deploy workflow env vars for SSH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,10 @@ jobs:
         MAINT_END="${{ vars.MAINTENANCE_EXPECTED_END || '' }}"
         MAINT_CONTACT="${{ vars.MAINTENANCE_CONTACT || '' }}"
 
+        SSH_ENV_VARS="MAINT_MODE=$(printf %q "$MAINT_MODE") MAINT_MESSAGE=$(printf %q "$MAINT_MESSAGE") MAINT_END=$(printf %q "$MAINT_END") MAINT_CONTACT=$(printf %q "$MAINT_CONTACT")"
+
         # Connect to the production server and deploy
-        ssh -o StrictHostKeyChecking=no \
-          MAINT_MODE="$(printf '%s' "$MAINT_MODE")" \
-          MAINT_MESSAGE="$(printf '%s' "$MAINT_MESSAGE")" \
-          MAINT_END="$(printf '%s' "$MAINT_END")" \
-          MAINT_CONTACT="$(printf '%s' "$MAINT_CONTACT")" \
-          root@24.199.127.184 << 'EOF'
+        ssh -o StrictHostKeyChecking=no root@24.199.127.184 "export ${SSH_ENV_VARS}; bash -s" << 'EOF'
 
           set -e  # Exit immediately if a command exits with a non-zero status
 


### PR DESCRIPTION
## Summary
- fix production deploy SSH command to export maintenance variables in remote session

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222f28c9f4833395ebd61aa0cbd150)