### PR TITLE
Fix multiple Alembic migration head revisions

### DIFF
--- a/migrations/versions/a3b4c5d6e7f8_merge_insurance_and_tenancy_heads.py
+++ b/migrations/versions/a3b4c5d6e7f8_merge_insurance_and_tenancy_heads.py
@@ -1,0 +1,31 @@
+"""Merge insurance policy updates and multi-tenancy branches
+
+This merge migration consolidates two parallel development branches:
+- h2i3j4k5l6m7: Insurance policy code and teacher_id updates
+- z1a2b3c4d5e6: Multi-tenancy and other feature merges
+
+Revision ID: a3b4c5d6e7f8
+Revises: h2i3j4k5l6m7, z1a2b3c4d5e6
+Create Date: 2025-11-23 05:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a3b4c5d6e7f8'
+down_revision = ('h2i3j4k5l6m7', 'z1a2b3c4d5e6')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # This is a merge migration - no schema changes needed
+    # Both parent migrations have already applied their respective changes
+    pass
+
+
+def downgrade():
+    # This is a merge migration - no schema changes needed
+    pass


### PR DESCRIPTION
This migration consolidates two parallel development branches that resulted in multiple head revisions:
- h2i3j4k5l6m7: Insurance policy code and teacher_id updates
- z1a2b3c4d5e6: Multi-tenancy and other feature merges

The merge migration creates a single head (a3b4c5d6e7f8) to resolve the "Multiple head revisions are present" error when running migrations.