### PR TITLE
Fix available plans rendering and close tier loop

### DIFF
--- a/templates/student_insurance_marketplace.html
+++ b/templates/student_insurance_marketplace.html
@@ -163,6 +163,7 @@
         {% if available_policies or tier_groups %}
 
         <!-- Tier Groups (if any) -->
+        {% if tier_groups %}
         {% for tier_id, tier_data in tier_groups.items() %}
         <div class="card mb-4 border-{{ tier_data.color }} border-2">
             <div class="card-header bg-{{ tier_data.color }} bg-opacity-10">
@@ -320,8 +321,84 @@
                     <h5 class="mt-3">Select a Policy</h5>
                     <p>Click on a policy from the list to read about it</p>
                 </div>
-            </div>
         </div>
+        </div>
+        {% endfor %}
+        {% elif available_policies %}
+        <div class="row row-cols-1 row-cols-md-2 g-4">
+            {% for policy in available_policies %}
+            {% set badge_config = {
+                'best_value': {'color': 'warning', 'text': 'Best Value!', 'icon': 'grade', 'border': True},
+                'most_popular': {'color': 'primary', 'text': 'Most Popular', 'icon': 'trending_up', 'border': True},
+                'recommended': {'color': 'success', 'text': 'Recommended', 'icon': 'verified', 'border': False},
+                'premium': {'color': 'dark', 'text': 'Premium Coverage', 'icon': 'workspace_premium', 'border': True},
+                'limited_time': {'color': 'danger', 'text': 'Limited Time Offer', 'icon': 'schedule', 'border': True},
+                'new': {'color': 'info', 'text': 'New!', 'icon': 'new_releases', 'border': False},
+                'fan_favorite': {'color': 'primary', 'text': 'Fan Favorite', 'icon': 'favorite', 'border': False},
+                'yolo': {'color': 'danger', 'text': 'YOLO Protection', 'icon': 'casino', 'border': True},
+                'trust_me': {'color': 'warning', 'text': 'Trust Me Bro', 'icon': 'handshake', 'border': True},
+                'definitely_not_scam': {'color': 'success', 'text': 'Definitely Not a Scam', 'icon': 'verified_user', 'border': False},
+                'parents_approved': {'color': 'info', 'text': 'Your Parents Would Approve', 'icon': 'family_restroom', 'border': False},
+                'as_seen_on_tv': {'color': 'primary', 'text': 'As Seen on TV', 'icon': 'live_tv', 'border': True},
+                'industry_leading': {'color': 'dark', 'text': 'Industry Leading*', 'icon': 'emoji_events', 'border': True},
+                'chaos_insurance': {'color': 'danger', 'text': 'Chaos Insurance', 'icon': 'tornado', 'border': True},
+                'responsible_choice': {'color': 'success', 'text': 'The Responsible Choice™', 'icon': 'check_circle', 'border': False},
+                'your_friend_has_it': {'color': 'info', 'text': 'The One Your Friend Has', 'icon': 'groups', 'border': False}
+            } %}
+            {% set badge = badge_config.get(policy.marketing_badge, {'color': 'secondary', 'text': None, 'icon': None, 'border': False}) %}
+            <div class="col">
+                <div class="card h-100 {% if badge.border %}border-{{ badge.color }} border-3{% endif %}">
+                    <div class="card-header bg-{{ badge.color }} {% if badge.color in ['warning', 'info'] %}text-dark{% else %}text-white{% endif %}">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h4 class="mb-0">{{ policy.title }}</h4>
+                            {% if badge.text %}
+                            <span class="badge bg-white text-{{ badge.color }} d-inline-flex align-items-center gap-1">
+                                {% if badge.icon %}<span class="material-symbols-outlined" style="font-size: 1rem;">{{ badge.icon }}</span>{% endif %}
+                                {{ badge.text }}
+                            </span>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="card-body d-flex flex-column">
+                        <h2 class="text-{{ badge.color }} mb-3">
+                            ${{ "%.2f"|format(policy.premium) }}<small class="text-muted fs-5">/ {{ policy.charge_frequency }}</small>
+                        </h2>
+                        <div class="mb-3">{{ (policy.description or 'Comprehensive coverage for your needs.') | markdown }}</div>
+                        <ul class="small mb-4">
+                            <li>Waiting period: {{ policy.waiting_period_days }} days</li>
+                            {% if policy.max_claims_count %}
+                                <li>Max claims: {{ policy.max_claims_count }} per {{ policy.max_claims_period }}</li>
+                            {% else %}
+                                <li>Unlimited claims</li>
+                            {% endif %}
+                            {% if policy.is_monetary and policy.max_claim_amount %}
+                                <li>Max claim amount: ${{ "%.2f"|format(policy.max_claim_amount) }}</li>
+                            {% endif %}
+                        </ul>
+                        <div class="mt-auto">
+                            {% if can_purchase[policy.id] %}
+                                <form action="{{ url_for('student.purchase_insurance', policy_id=policy.id) }}" method="POST">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="btn btn-{{ badge.color }} w-100">
+                                        <span class="material-symbols-outlined">shopping_cart</span> Purchase Plan
+                                    </button>
+                                </form>
+                            {% else %}
+                                <button class="btn btn-secondary w-100" disabled>
+                                    {% if repurchase_blocks.get(policy.id) %}
+                                        <span class="material-symbols-outlined">block</span> Can't Repurchase ({{ repurchase_blocks[policy.id] }} days left)
+                                    {% else %}
+                                        <span class="material-symbols-outlined">check_circle</span> Already Enrolled
+                                    {% endif %}
+                                </button>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
         {% else %}
         <div class="alert alert-info">
             <h5>No Insurance Plans Available</h5>


### PR DESCRIPTION
## Summary
- close the tiered plan loop in the student insurance marketplace template to prevent template errors
- render ungrouped available policies when no tier groups exist so students can purchase plans

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692342787800833396e10a6fe54f23d5)