### PR TITLE
Fix multiple migration heads error

### DIFF
--- a/migrations/versions/d6e7f8g9h0i1_merge_insurance_feature_heads.py
+++ b/migrations/versions/d6e7f8g9h0i1_merge_insurance_feature_heads.py
@@ -1,0 +1,31 @@
+"""Merge insurance feature heads
+
+This merge migration consolidates two parallel insurance feature branches:
+- b3c4d5e6f7g8: Add marketing badge to insurance
+- c5d6e7f8g9h0: Add insurance tiers and settings mode
+
+Revision ID: d6e7f8g9h0i1
+Revises: b3c4d5e6f7g8, c5d6e7f8g9h0
+Create Date: 2025-11-23 14:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd6e7f8g9h0i1'
+down_revision = ('b3c4d5e6f7g8', 'c5d6e7f8g9h0')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # This is a merge migration - no schema changes needed
+    # Both parent migrations have already applied their respective changes
+    pass
+
+
+def downgrade():
+    # This is a merge migration - no schema changes needed
+    pass


### PR DESCRIPTION
Created merge migration to consolidate two parallel insurance feature branches:
- b3c4d5e6f7g8 (add marketing badge to insurance)
- c5d6e7f8g9h0 (add insurance tiers and settings mode)

This resolves the "Multiple head revisions are present" error that was preventing database migrations from running.