### PR TITLE
Fix student insurance marketplace template error

### DIFF
--- a/templates/student_insurance_marketplace.html
+++ b/templates/student_insurance_marketplace.html
@@ -322,6 +322,9 @@
                 </div>
             </div>
         </div>
+            </div>
+        </div>
+        {% endfor %}
         {% else %}
         <div class="alert alert-info">
             <h5>No Insurance Plans Available</h5>


### PR DESCRIPTION
- Added missing {% endfor %} tag to close tier_groups loop
- Closes unclosed for loop that was causing TemplateSyntaxError
- Fixed proper nesting of HTML div closing tags