### PR TITLE
Add merge migration to resolve multiple Alembic heads

### DIFF
--- a/migrations/versions/m2n3o4p5q6r7_merge_hall_pass_demo_students_heads.py
+++ b/migrations/versions/m2n3o4p5q6r7_merge_hall_pass_demo_students_heads.py
@@ -1,0 +1,30 @@
+"""Merge demo_students, hall_pass_models, and production merge heads
+
+This merge migration resolves multiple heads created by parallel work on:
+- e7f8g9h0i1j2: merge of production and insurance branches
+- c4d5e6f7g8h9: demo_students table introduction
+- f5a1e3e4d7c8: hall pass models
+
+Revision ID: m2n3o4p5q6r7
+Revises: e7f8g9h0i1j2, c4d5e6f7g8h9, f5a1e3e4d7c8
+Create Date: 2025-11-24 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'm2n3o4p5q6r7'
+down_revision = ('e7f8g9h0i1j2', 'c4d5e6f7g8h9', 'f5a1e3e4d7c8')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Merge migration; no schema changes required.
+    pass
+
+
+def downgrade():
+    # Merge migration; no schema changes required.
+    pass


### PR DESCRIPTION
## Summary
- add a merge migration that consolidates the e7f8g9h0i1j2, c4d5e6f7g8h9, and f5a1e3e4d7c8 heads
- keep upgrade/downgrade empty since the merge only resolves the head split

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237028026c8333893d167d80f3871a)