### PR TITLE
Fix Alembic migration version tracking error

### DIFF
--- a/migrations/versions/m2n3o4p5q6r7_merge_hall_pass_demo_students_heads.py
+++ b/migrations/versions/m2n3o4p5q6r7_merge_hall_pass_demo_students_heads.py
@@ -1,12 +1,14 @@
-"""Merge demo_students, hall_pass_models, and production merge heads
+"""Merge demo_students and production merge heads
 
 This merge migration resolves multiple heads created by parallel work on:
 - e7f8g9h0i1j2: merge of production and insurance branches
 - c4d5e6f7g8h9: demo_students table introduction
-- f5a1e3e4d7c8: hall pass models
+
+Note: f5a1e3e4d7c8 (hall pass models) was already merged via merge_001 and is an
+ancestor of both branches, so it should not be included here.
 
 Revision ID: m2n3o4p5q6r7
-Revises: e7f8g9h0i1j2, c4d5e6f7g8h9, f5a1e3e4d7c8
+Revises: e7f8g9h0i1j2, c4d5e6f7g8h9
 Create Date: 2025-11-24 00:00:00.000000
 
 """
@@ -15,7 +17,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'm2n3o4p5q6r7'
-down_revision = ('e7f8g9h0i1j2', 'c4d5e6f7g8h9', 'f5a1e3e4d7c8')
+down_revision = ('e7f8g9h0i1j2', 'c4d5e6f7g8h9')
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The migration m2n3o4p5q6r7 was incorrectly trying to merge revision f5a1e3e4d7c8 (hall pass models) as a parent. However, f5a1e3e4d7c8 was already merged into the migration tree via merge_001, making it an ancestor of both e7f8g9h0i1j2 and c4d5e6f7g8h9.

When Alembic tried to apply this migration, it expected f5a1e3e4d7c8 to be in the current heads list, but it wasn't there because it had already been merged. This caused a KeyError when trying to remove it from the heads list.

The fix removes f5a1e3e4d7c8 from the down_revision tuple, leaving only the two actual heads: e7f8g9h0i1j2 and c4d5e6f7g8h9.

Fixes: KeyError: 'f5a1e3e4d7c8' in alembic/runtime/migration.py