### PR TITLE
Harden insurance claim integrity

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -512,6 +512,9 @@ class StudentInsurance(db.Model):
 
 class InsuranceClaim(db.Model):
     __tablename__ = 'insurance_claims'
+    __table_args__ = (
+        db.UniqueConstraint('transaction_id', name='uq_insurance_claims_transaction_id'),
+    )
     id = db.Column(db.Integer, primary_key=True)
     student_insurance_id = db.Column(db.Integer, db.ForeignKey('student_insurance.id'), nullable=False)
     policy_id = db.Column(db.Integer, db.ForeignKey('insurance_policies.id'), nullable=False)

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1767,6 +1767,8 @@ def process_claim(claim_id):
 
     if claim.policy.claim_type == 'transaction_monetary' and not claim.transaction:
         validation_errors.append("Transaction-based claim is missing a linked transaction")
+    if claim.policy.claim_type == 'transaction_monetary' and claim.transaction and claim.transaction.is_void:
+        validation_errors.append("Linked transaction has been voided and cannot be reimbursed")
     if claim.policy.claim_type == 'transaction_monetary' and claim.transaction_id:
         duplicate_claim = InsuranceClaim.query.filter(
             InsuranceClaim.transaction_id == claim.transaction_id,

--- a/migrations/versions/a3b4c5d6e7f8_enforce_unique_claim_transaction.py
+++ b/migrations/versions/a3b4c5d6e7f8_enforce_unique_claim_transaction.py
@@ -1,0 +1,27 @@
+"""Enforce unique claim per transaction
+
+Revision ID: a3b4c5d6e7f8
+Revises: 2f3g4h5i6j7k
+Create Date: 2025-12-15 00:00:00.000000
+
+"""
+
+revision = 'a3b4c5d6e7f8'
+down_revision = '2f3g4h5i6j7k'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_unique_constraint(
+        'uq_insurance_claims_transaction_id',
+        'insurance_claims',
+        ['transaction_id'],
+    )
+
+
+def downgrade():
+    op.drop_constraint('uq_insurance_claims_transaction_id', 'insurance_claims', type_='unique')

--- a/tests/test_insurance_security.py
+++ b/tests/test_insurance_security.py
@@ -1,0 +1,126 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.exc import IntegrityError
+
+from app import db
+from app.models import Admin, InsurancePolicy, StudentInsurance, InsuranceClaim, Transaction
+
+
+@pytest.fixture
+def admin_user():
+    admin = Admin(username="teacher-insurance", totp_secret="totp-secret")
+    db.session.add(admin)
+    db.session.commit()
+    return admin
+
+
+def _create_policy(admin_id):
+    policy = InsurancePolicy(
+        policy_code="POLICY-001",
+        teacher_id=admin_id,
+        title="Test Coverage",
+        description="",
+        premium=10.0,
+        claim_type="transaction_monetary",
+        is_monetary=True,
+    )
+    db.session.add(policy)
+    db.session.commit()
+    return policy
+
+
+def _enroll_student(student_id, policy_id):
+    enrollment = StudentInsurance(
+        student_id=student_id,
+        policy_id=policy_id,
+        status="active",
+        coverage_start_date=datetime.utcnow() - timedelta(days=2),
+        payment_current=True,
+    )
+    db.session.add(enrollment)
+    db.session.commit()
+    return enrollment
+
+
+def _create_transaction(student_id, teacher_id, is_void=False):
+    tx = Transaction(
+        student_id=student_id,
+        teacher_id=teacher_id,
+        amount=-25.0,
+        account_type="checking",
+        description="Test purchase",
+        type="purchase",
+        is_void=is_void,
+    )
+    db.session.add(tx)
+    db.session.commit()
+    return tx
+
+
+def _build_claim(enrollment, policy, student_id, transaction):
+    return InsuranceClaim(
+        student_insurance_id=enrollment.id,
+        policy_id=policy.id,
+        student_id=student_id,
+        incident_date=transaction.timestamp,
+        description="Test claim",
+        claim_amount=abs(transaction.amount),
+        transaction_id=transaction.id,
+        status="pending",
+    )
+
+
+def test_duplicate_transaction_claim_blocked(client, test_student, admin_user):
+    test_student.teacher_id = admin_user.id
+    db.session.commit()
+
+    policy = _create_policy(admin_user.id)
+    enrollment = _enroll_student(test_student.id, policy.id)
+    tx = _create_transaction(test_student.id, admin_user.id)
+
+    first_claim = _build_claim(enrollment, policy, test_student.id, tx)
+    db.session.add(first_claim)
+    db.session.commit()
+
+    duplicate_claim = _build_claim(enrollment, policy, test_student.id, tx)
+    db.session.add(duplicate_claim)
+
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+
+    db.session.rollback()
+    assert InsuranceClaim.query.filter_by(transaction_id=tx.id).count() == 1
+
+
+def test_voided_transaction_cannot_be_approved(client, test_student, admin_user):
+    test_student.teacher_id = admin_user.id
+    db.session.commit()
+
+    policy = _create_policy(admin_user.id)
+    enrollment = _enroll_student(test_student.id, policy.id)
+    tx = _create_transaction(test_student.id, admin_user.id, is_void=True)
+
+    claim = _build_claim(enrollment, policy, test_student.id, tx)
+    db.session.add(claim)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["is_admin"] = True
+        sess["admin_id"] = admin_user.id
+        sess["last_activity"] = datetime.now(timezone.utc).isoformat()
+
+    response = client.post(
+        f"/admin/insurance/claim/{claim.id}",
+        data={
+            "status": "approved",
+            "approved_amount": "",
+            "rejection_reason": "",
+            "admin_notes": "",
+        },
+        follow_redirects=True,
+    )
+
+    db.session.refresh(claim)
+    assert claim.status == "pending"
+    assert b"voided" in response.data


### PR DESCRIPTION
## Summary
- add database-level uniqueness for insurance claim transaction links and guard application flow against duplicates
- block approvals for claims tied to voided transactions and surface safer validation to admins
- expand insurance security coverage with tests for duplicate claims and voided transaction approvals

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c3373298833395d1d8a7be78ec6c)