### PR TITLE
Fix tap in/out toggle at period level

### DIFF
--- a/templates/admin_students.html
+++ b/templates/admin_students.html
@@ -1178,11 +1178,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // Handle toggle changes
     toggle.addEventListener('change', function() {
       const isEnabled = this.checked;
-      
+
       fetch('/api/admin/block-tap-settings', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-CSRFToken': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
         },
         body: JSON.stringify({
           block: block,


### PR DESCRIPTION
The period-level tap in/out toggle was failing with a 400 bad request error because the POST request to /api/admin/block-tap-settings was missing the CSRF token header.

This fix adds the X-CSRFToken header to the fetch request, matching the pattern used by other POST requests in the same file.

Fixes the 400 error when toggling tap in/out at the period level.

