### PR TITLE
feat: Add join_code migration for P0 multi-period isolation fix

### DIFF
--- a/migrations/versions/b1c2d3e4f5g6_add_join_code_to_related_tables.py
+++ b/migrations/versions/b1c2d3e4f5g6_add_join_code_to_related_tables.py
@@ -108,7 +108,50 @@ def upgrade():
     print("")
     print("⚠️  WARNING: Existing records will have NULL join_code")
     print("⚠️  Action required: Backfill join_code for historical data")
-    print("⚠️  See docs/security/CRITICAL_SAME_TEACHER_LEAK.md for backfill strategy")
+    print("⚠️  See below for table-specific SQL examples to backfill join_code:")
+    print("")
+    print("----")
+    print("student_items: If you have a student_items.period column, you can backfill join_code like:")
+    print(\"\"\"UPDATE student_items
+    SET join_code = (
+        SELECT join_code FROM enrollments
+        WHERE enrollments.student_id = student_items.student_id
+          AND enrollments.period = student_items.period
+        LIMIT 1
+    )
+    WHERE join_code IS NULL;\"\"\")
+    print("")
+    print("student_insurance: If you have a period or enrollment reference, use:")
+    print(\"\"\"UPDATE student_insurance
+    SET join_code = (
+        SELECT join_code FROM enrollments
+        WHERE enrollments.student_id = student_insurance.student_id
+          AND enrollments.period = student_insurance.period
+        LIMIT 1
+    )
+    WHERE join_code IS NULL;\"\"\")
+    print("")
+    print("hall_pass_logs: If hall_pass_logs.period exists, use:")
+    print(\"\"\"UPDATE hall_pass_logs
+    SET join_code = (
+        SELECT join_code FROM enrollments
+        WHERE enrollments.student_id = hall_pass_logs.student_id
+          AND enrollments.period = hall_pass_logs.period
+        LIMIT 1
+    )
+    WHERE join_code IS NULL;\"\"\")
+    print("")
+    print("rent_payments: If rent_payments.period exists, use:")
+    print(\"\"\"UPDATE rent_payments
+    SET join_code = (
+        SELECT join_code FROM enrollments
+        WHERE enrollments.student_id = rent_payments.student_id
+          AND enrollments.period = rent_payments.period
+        LIMIT 1
+    )
+    WHERE join_code IS NULL;\"\"\")
+    print("----")
+    print("If your schema differs, see docs/security/CRITICAL_SAME_TEACHER_LEAK.md#backfill-join_code for more details.")
     print("")
     print("----")
     print("Table-specific SQL examples to backfill join_code using enrollments.period mapping:")


### PR DESCRIPTION
CRITICAL P0 FIX: Complete database schema for same-teacher multi-period isolation

## Problem
Students enrolled in multiple periods with the same teacher were seeing aggregated data across all periods. The Transaction table had join_code added (migration 00212c18b0ac), but 4 other tables still needed it.

## This Migration (b1c2d3e4f5g6)

Adds join_code column to:
- student_items (store purchases)
- student_insurance (insurance enrollments)
- hall_pass_logs (hall pass requests)
- rent_payments (rent payments)

### Technical Details
- down_revision: a1b2c3d4e5f7 (current production head)
- All columns nullable for backward compatibility
- Indexes created for query performance
- Existence checks for safe re-runs
- Complete upgrade/downgrade paths

## Production Deployment

After deploying this migration:
1. Run: flask db upgrade
2. Verify columns exist in all 4 tables
3. Backfill join_code for existing records (see docs)
4. Update application code to populate join_code on insert
5. Eventually enforce NOT NULL after backfill complete

## Documentation
- Issue: docs/security/CRITICAL_SAME_TEACHER_LEAK.md
- Roadmap: ROADMAP_TO_1.0.md (P0 Blocker)

This completes the database schema portion of the P0 fix. Application code updates and backfill script still required.

