### PR TITLE
Fix payroll template block label rendering

### DIFF
--- a/templates/admin_payroll.html
+++ b/templates/admin_payroll.html
@@ -811,7 +811,12 @@
                           {% if student.block %}
                             {% set blocks = student.block.split(',') %}
                             {% if blocks|length > 1 %}
-                              {{ ', '.join([class_labels_by_block.get(b.strip(), b.strip()) for b in blocks]) }}
+                              {% set ns = namespace(labels=[]) %}
+                              {% for b in blocks %}
+                                {% set trimmed_block = b.strip() %}
+                                {% set ns.labels = ns.labels + [class_labels_by_block.get(trimmed_block, trimmed_block)] %}
+                              {% endfor %}
+                              {{ ns.labels | join(', ') }}
                             {% else %}
                               {{ class_labels_by_block.get(student.block, student.block) }}
                             {% endif %}


### PR DESCRIPTION
<!-- Start of Document -->
## Description

- Fix admin payroll template to render multiple class labels without Jinja syntax errors by accumulating labels via namespace loop.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

<!-- If this PR includes a database migration, complete the following checklist -->

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

- Pytest currently fails in the baseline environment due to pre-existing issues (see failure log).
<!-- End of Document -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372547a080833382f3b4004b2c36c6)