### PR TITLE
Fix insurance claim filtering for scoped students

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2624,18 +2624,18 @@ def insurance_management():
             .all()
         )
 
-        # Get claims for selected block, filtered by join_code for proper multi-tenancy isolation
+        # Get claims for selected block, filtered by student IDs for proper multi-tenancy isolation
         claims = (
             InsuranceClaim.query
             .join(StudentInsurance, InsuranceClaim.student_insurance_id == StudentInsurance.id)
-            .filter(StudentInsurance.join_code == join_code)
+            .filter(StudentInsurance.student_id.in_(student_ids_in_block))
             .order_by(InsuranceClaim.filed_date.desc())
             .all()
         )
         pending_claims_count = (
             InsuranceClaim.query
             .join(StudentInsurance, InsuranceClaim.student_insurance_id == StudentInsurance.id)
-            .filter(StudentInsurance.join_code == join_code)
+            .filter(StudentInsurance.student_id.in_(student_ids_in_block))
             .filter(InsuranceClaim.status == 'pending')
             .count()
         )


### PR DESCRIPTION
<!-- Start of Document -->
## Description

Fixed the admin insurance dashboard claim queries to scope by the currently visible students rather than an undefined `join_code`, preventing the view from crashing and keeping results tenant-scoped.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

Pytest currently fails in this environment due to pre-existing test breakages (e.g., foreign key constraints and legacy routes returning 404s).

<!-- End of Document -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372a2d4a3083339ba83741ad3d65e7)