### PR TITLE
Wire up economy balance checker fully to payroll settings

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -3583,6 +3583,10 @@ def payroll_settings():
         # Determine which mode we're in
         settings_mode = request.form.get('settings_mode', 'simple')
 
+        # Shared fields
+        expected_weekly_hours_raw = request.form.get('expected_weekly_hours')
+        expected_weekly_hours = float(expected_weekly_hours_raw) if expected_weekly_hours_raw else 5.0
+
         # Parse form data based on mode
         if settings_mode == 'simple':
             # Simple mode fields
@@ -3598,9 +3602,6 @@ def payroll_settings():
 
             daily_limit_hours = request.form.get('simple_daily_limit')
             daily_limit_hours = float(daily_limit_hours) if daily_limit_hours else None
-
-            expected_weekly_hours = request.form.get('expected_weekly_hours')
-            expected_weekly_hours = float(expected_weekly_hours) if expected_weekly_hours else 5.0
 
             apply_to = request.form.get('simple_apply_to', 'all')
             selected_blocks = request.form.getlist('simple_blocks[]') if apply_to == 'selected' else blocks
@@ -3674,9 +3675,6 @@ def payroll_settings():
             first_pay_date = datetime.strptime(first_pay_date_str, '%Y-%m-%d') if first_pay_date_str else None
 
             rounding = request.form.get('adv_rounding', 'down')
-
-            expected_weekly_hours = request.form.get('expected_weekly_hours')
-            expected_weekly_hours = float(expected_weekly_hours) if expected_weekly_hours else 5.0
 
             apply_to = request.form.get('adv_apply_to', 'all')
             selected_blocks = request.form.getlist('adv_blocks[]') if apply_to == 'selected' else blocks
@@ -5531,6 +5529,8 @@ def api_calculate_cwi():
         checker = EconomyBalanceChecker(admin_id, block)
         cwi_calc = checker.calculate_cwi(temp_settings, expected_weekly_hours)
 
+        recommendations = checker._generate_recommendations(cwi_calc.cwi, [])
+
         return jsonify({
             'status': 'success',
             'cwi': cwi_calc.cwi,
@@ -5540,7 +5540,8 @@ def api_calculate_cwi():
                 'expected_weekly_hours': expected_weekly_hours,
                 'expected_weekly_minutes': cwi_calc.expected_weekly_minutes,
                 'notes': cwi_calc.notes
-            }
+            },
+            'recommendations': recommendations
         })
 
     except Exception as e:

--- a/templates/admin_payroll.html
+++ b/templates/admin_payroll.html
@@ -382,6 +382,36 @@
                 <!-- CWI Display (calculated from pay rate + expected hours) -->
                 <div id="cwi-info-payroll" class="mb-3"></div>
 
+                <template id="cwiInfoTemplate">
+                  <div class="alert alert-success border-start border-5 border-success">
+                    <div class="d-flex align-items-center mb-2">
+                      <i class="bi bi-graph-up-arrow fs-3 me-2"></i>
+                      <div>
+                        <h6 class="mb-0 fw-bold">Classroom Wage Index (CWI)</h6>
+                        <div class="fs-4 text-success fw-bold" data-field="weekly-income"></div>
+                      </div>
+                    </div>
+                    <small class="text-muted" data-field="calculation-note"></small>
+
+                    <details class="mt-3" role="region" aria-label="Recommended Economy Settings" aria-expanded="false" data-field="recommendations-details">
+                      <summary class="fw-bold" style="cursor: pointer;" role="button">
+                        <i class="bi bi-lightbulb-fill text-warning"></i> View Recommended Economy Settings
+                      </summary>
+                      <div class="mt-2 p-2 bg-light rounded">
+                        <div class="row small">
+                          <div class="col-md-6 mb-2" data-field="rent"></div>
+                          <div class="col-md-6 mb-2" data-field="insurance"></div>
+                          <div class="col-md-6 mb-2" data-field="fines"></div>
+                          <div class="col-md-6" data-field="store"></div>
+                        </div>
+                        <div class="mt-2 alert alert-info mb-0 small">
+                          <i class="bi bi-info-circle"></i> These recommendations follow the AGENTS financial setup specification to ensure a balanced classroom economy.
+                        </div>
+                      </div>
+                    </details>
+                  </div>
+                </template>
+
                 <!-- Payroll Frequency -->
                 <div class="mb-3">
                   <label for="simpleFrequency" class="form-label fw-bold">Payroll Frequency:</label>
@@ -563,7 +593,7 @@
 
                 <!-- Expected Weekly Hours (shared field between modes) -->
                 <div class="mb-3" style="display:none;">
-                  <input type="hidden" id="expectedWeeklyHoursAdv" value="{% if default_setting and default_setting.expected_weekly_hours %}{{ default_setting.expected_weekly_hours }}{% else %}5.0{% endif %}">
+                  <input type="hidden" id="expectedWeeklyHoursAdv" name="expected_weekly_hours" value="{% if default_setting and default_setting.expected_weekly_hours %}{{ default_setting.expected_weekly_hours }}{% else %}5.0{% endif %}">
                 </div>
 
                 <!-- Apply To -->
@@ -1200,8 +1230,17 @@ document.addEventListener("DOMContentLoaded", () => {
                 advancedModeFields.style.display = 'none';
                 settingsModeInput.value = 'simple';
             }
+
+            syncExpectedHoursToAdvanced();
+            updateCWI();
         });
     }
+
+    // Initialize Bootstrap tooltips
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+    tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl);
+    });
 
     // Simple Mode: Apply To - Show/hide block checkboxes
     const simpleApplySelected = document.getElementById('simpleApplySelected');
@@ -1486,112 +1525,175 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // ========== ECONOMY BALANCE CHECKER ==========
-    // Real-time CWI calculation and display
     const payRateInput = document.getElementById('simplePayRate');
     const expectedHoursInput = document.getElementById('expectedWeeklyHours');
+    const expectedHoursAdvInput = document.getElementById('expectedWeeklyHoursAdv');
     const cwiDisplay = document.getElementById('cwi-info-payroll');
+    const advPayAmountInput = document.getElementById('advPayAmount');
+    const advTimeUnitInput = document.getElementById('advTimeUnit');
+    const cwiTemplate = document.getElementById('cwiInfoTemplate');
 
-    function calculateAndDisplayCWI() {
-        if (!payRateInput || !expectedHoursInput || !cwiDisplay) return;
+    const cwiChecker = new EconomyBalanceChecker({ autoValidate: false, debounceDelay: 400 });
 
-        const payRate = parseFloat(payRateInput.value) || 0;
-        const expectedHours = parseFloat(expectedHoursInput.value) || 5.0;
+    function debounce(fn, delay = 400) {
+        let timer;
+        return (...args) => {
+            clearTimeout(timer);
+            timer = setTimeout(() => fn(...args), delay);
+        };
+    }
 
-        if (payRate <= 0) {
-            cwiDisplay.innerHTML = '';
-            cwiDisplay.style.display = 'none';
-            return;
+    function getExpectedWeeklyHours() {
+        return parseFloat(expectedHoursInput?.value) || 5.0;
+    }
+
+    function syncExpectedHoursToAdvanced() {
+        const hours = getExpectedWeeklyHours();
+        if (expectedHoursAdvInput) {
+            expectedHoursAdvInput.value = hours;
+        }
+        cwiChecker.expectedWeeklyHours = hours;
+    }
+
+    function getHourlyRate() {
+        const mode = settingsModeInput ? settingsModeInput.value : 'simple';
+        let hourlyRate = 0;
+
+        if (mode === 'advanced' && advPayAmountInput && advTimeUnitInput) {
+            const advAmount = parseFloat(advPayAmountInput.value) || 0;
+            const unit = advTimeUnitInput.value;
+
+            switch (unit) {
+                case 'seconds':
+                    hourlyRate = advAmount * 3600;
+                    break;
+                case 'minutes':
+                    hourlyRate = advAmount * 60;
+                    break;
+                case 'hours':
+                    hourlyRate = advAmount;
+                    break;
+                case 'days':
+                    hourlyRate = advAmount / 24;
+                    break;
+                default:
+                    hourlyRate = 0;
+            }
+        } else if (payRateInput) {
+            hourlyRate = parseFloat(payRateInput.value) || 0;
         }
 
-        const cwi = payRate * expectedHours;
+        return hourlyRate;
+    }
 
-        // Calculate recommended economy settings
-        const recommendations = {
-            rent: {
-                min: (cwi * 2.0).toFixed(2),
-                max: (cwi * 2.5).toFixed(2),
-                recommended: (cwi * 2.25).toFixed(2)
-            },
-            insurance: {
-                min: (cwi * 0.05).toFixed(2),
-                max: (cwi * 0.12).toFixed(2),
-                recommended: (cwi * 0.08).toFixed(2)
-            },
-            fine: {
-                min: (cwi * 0.05).toFixed(2),
-                max: (cwi * 0.15).toFixed(2),
-                recommended: (cwi * 0.10).toFixed(2)
-            },
-            store: {
-                basic: { min: (cwi * 0.02).toFixed(2), max: (cwi * 0.05).toFixed(2) },
-                standard: { min: (cwi * 0.05).toFixed(2), max: (cwi * 0.10).toFixed(2) },
-                premium: { min: (cwi * 0.10).toFixed(2), max: (cwi * 0.25).toFixed(2) },
-                luxury: { min: (cwi * 0.25).toFixed(2), max: (cwi * 0.50).toFixed(2) }
-            }
-        };
+    function clearCWI() {
+        if (!cwiDisplay) return;
+        cwiDisplay.innerHTML = '';
+        cwiDisplay.style.display = 'none';
+    }
 
-        cwiDisplay.innerHTML = `
-            <div class="alert alert-success border-start border-5 border-success">
-                <div class="d-flex align-items-center mb-2">
-                    <i class="bi bi-graph-up-arrow fs-3 me-2"></i>
-                    <div>
-                        <h6 class="mb-0 fw-bold">Classroom Wage Index (CWI)</h6>
-                        <div class="fs-4 text-success fw-bold">$${cwi.toFixed(2)}/week</div>
-                    </div>
-                </div>
-                <small class="text-muted">Based on $${payRate}/hour × ${expectedHours} hours/week</small>
+    function renderRecommendationRow(prefix, recommendation, label, icon) {
+        if (!recommendation) return '';
+        return `
+            <strong><i class="bi ${icon}"></i> ${label}:</strong>
+            $${recommendation.min?.toFixed(2)} - $${recommendation.max?.toFixed(2)}
+            ${recommendation.recommended !== undefined ? `<span class="badge bg-info">Ideal: $${recommendation.recommended?.toFixed(2)}</span>` : ''}
+        `;
+    }
 
-                <details class="mt-3">
-                    <summary class="fw-bold" style="cursor: pointer;">
-                        <i class="bi bi-lightbulb-fill text-warning"></i> View Recommended Economy Settings
-                    </summary>
-                    <div class="mt-2 p-2 bg-light rounded">
-                        <div class="row small">
-                            <div class="col-md-6 mb-2">
-                                <strong><i class="bi bi-house-door"></i> Rent:</strong>
-                                $${recommendations.rent.min} - $${recommendations.rent.max}
-                                <span class="badge bg-info">Ideal: $${recommendations.rent.recommended}</span>
-                            </div>
-                            <div class="col-md-6 mb-2">
-                                <strong><i class="bi bi-shield-check"></i> Insurance (weekly):</strong>
-                                $${recommendations.insurance.min} - $${recommendations.insurance.max}
-                                <span class="badge bg-info">Ideal: $${recommendations.insurance.recommended}</span>
-                            </div>
-                            <div class="col-md-6 mb-2">
-                                <strong><i class="bi bi-exclamation-triangle"></i> Fines:</strong>
-                                $${recommendations.fine.min} - $${recommendations.fine.max}
-                                <span class="badge bg-info">Ideal: $${recommendations.fine.recommended}</span>
-                            </div>
-                            <div class="col-md-6">
-                                <strong><i class="bi bi-shop"></i> Store Items:</strong>
-                                <div class="ms-3">
-                                    <div>BASIC: $${recommendations.store.basic.min} - $${recommendations.store.basic.max}</div>
-                                    <div>STANDARD: $${recommendations.store.standard.min} - $${recommendations.store.standard.max}</div>
-                                    <div>PREMIUM: $${recommendations.store.premium.min} - $${recommendations.store.premium.max}</div>
-                                    <div>LUXURY: $${recommendations.store.luxury.min} - $${recommendations.store.luxury.max}</div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="mt-2 alert alert-info mb-0 small">
-                            <i class="bi bi-info-circle"></i> These recommendations follow the AGENTS financial setup specification to ensure a balanced classroom economy.
-                        </div>
-                    </div>
-                </details>
+    function renderStoreTiers(tiers) {
+        if (!tiers) return '';
+        return `
+            <strong><i class="bi bi-shop"></i> Store Items:</strong>
+            <div class="ms-3">
+                <div>BASIC: $${tiers.basic?.min?.toFixed(2)} - $${tiers.basic?.max?.toFixed(2)}</div>
+                <div>STANDARD: $${tiers.standard?.min?.toFixed(2)} - $${tiers.standard?.max?.toFixed(2)}</div>
+                <div>PREMIUM: $${tiers.premium?.min?.toFixed(2)} - $${tiers.premium?.max?.toFixed(2)}</div>
+                <div>LUXURY: $${tiers.luxury?.min?.toFixed(2)} - $${tiers.luxury?.max?.toFixed(2)}</div>
             </div>
         `;
+    }
+
+    function renderCWIInfo(cwiData) {
+        if (!cwiDisplay || !cwiTemplate) return;
+
+        const recommendations = cwiData.recommendations || {};
+        const clone = cwiTemplate.content.cloneNode(true);
+
+        const weeklyIncomeEl = clone.querySelector('[data-field="weekly-income"]');
+        const calcNoteEl = clone.querySelector('[data-field="calculation-note"]');
+        const rentEl = clone.querySelector('[data-field="rent"]');
+        const insuranceEl = clone.querySelector('[data-field="insurance"]');
+        const finesEl = clone.querySelector('[data-field="fines"]');
+        const storeEl = clone.querySelector('[data-field="store"]');
+        const detailsEl = clone.querySelector('[data-field="recommendations-details"]');
+
+        if (weeklyIncomeEl) {
+            weeklyIncomeEl.textContent = `$${cwiData.cwi.toFixed(2)}/week`;
+        }
+
+        if (calcNoteEl) {
+            const breakdown = cwiData.breakdown || {};
+            const payRateHour = breakdown.pay_rate_per_hour !== undefined ? breakdown.pay_rate_per_hour : getHourlyRate();
+            calcNoteEl.textContent = `Based on $${(payRateHour || 0).toFixed(2)}/hour × ${breakdown.expected_weekly_hours || getExpectedWeeklyHours()} hours/week`;
+        }
+
+        if (rentEl) {
+            rentEl.innerHTML = renderRecommendationRow('rent', recommendations.rent, 'Rent', 'bi-house-door');
+        }
+
+        if (insuranceEl) {
+            insuranceEl.innerHTML = renderRecommendationRow('insurance', recommendations.insurance_premium_weekly, 'Insurance (weekly)', 'bi-shield-check');
+        }
+
+        if (finesEl) {
+            finesEl.innerHTML = renderRecommendationRow('fines', recommendations.fine, 'Fines', 'bi-exclamation-triangle');
+        }
+
+        if (storeEl) {
+            storeEl.innerHTML = renderStoreTiers(recommendations.store_tiers);
+        }
+
+        if (detailsEl) {
+            detailsEl.addEventListener('toggle', () => {
+                detailsEl.setAttribute('aria-expanded', detailsEl.open.toString());
+            });
+        }
+
+        cwiDisplay.innerHTML = '';
+        cwiDisplay.appendChild(clone);
         cwiDisplay.style.display = 'block';
     }
 
-    // Attach event listeners for real-time updates
-    if (payRateInput) {
-        payRateInput.addEventListener('input', calculateAndDisplayCWI);
-    }
-    if (expectedHoursInput) {
-        expectedHoursInput.addEventListener('input', calculateAndDisplayCWI);
-    }
+    const updateCWI = debounce(async () => {
+        if (!cwiDisplay) return;
+
+        const hourlyRate = getHourlyRate();
+        const expectedHours = getExpectedWeeklyHours();
+        syncExpectedHoursToAdvanced();
+
+        if (!hourlyRate || hourlyRate <= 0) {
+            clearCWI();
+            return;
+        }
+
+        try {
+            const cwiData = await cwiChecker.calculateCWI(hourlyRate, expectedHours);
+            renderCWIInfo(cwiData);
+        } catch (error) {
+            console.error('CWI calculation error:', error);
+            clearCWI();
+        }
+    }, 400);
+
+    [payRateInput, expectedHoursInput, advPayAmountInput, advTimeUnitInput].forEach(input => {
+        if (!input) return;
+        const eventName = input === advTimeUnitInput ? 'change' : 'input';
+        input.addEventListener(eventName, updateCWI);
+    });
 
     // Calculate on page load
-    calculateAndDisplayCWI();
+    updateCWI();
 });
 
 // Run Payroll


### PR DESCRIPTION
Complete integration of economy balance checker across the application:

Payroll Settings Integration:
- Add expected_weekly_hours input field to simple mode payroll form
- Add hidden field for advanced mode (shared value)
- Add real-time CWI calculator that updates as teacher types
- Display prominent CWI badge with weekly income calculation
- Show expandable recommendations for all economy settings (rent, insurance, fines, store item tiers)
- Update backend routes to save expected_weekly_hours for both modes

Backend Route Updates:
- Save expected_weekly_hours in simple mode (/payroll/settings)
- Save expected_weekly_hours in advanced mode (/payroll/settings)
- Field defaults to 5.0 hours if not provided

Frontend Enhancements:
- Load economy-balance.js script on payroll page
- Real-time calculation on input changes (debounced)
- Visual display of CWI with green success badge
- Collapsible recommendations section showing:
  * Rent: $X - $Y (Ideal: $Z)
  * Insurance: $X - $Y (weekly)
  * Fines: $X - $Y
  * Store pricing tiers (BASIC, STANDARD, PREMIUM, LUXURY)
- All calculations follow AGENTS specification ratios

This completes the full economy balance checker implementation: ✅ Backend utility and API endpoints
✅ JavaScript real-time validation module
✅ Integration into rent settings
✅ Integration into insurance editor
✅ Integration into store item editor
✅ Integration into payroll settings
✅ Database migration for expected_weekly_hours field

Teachers can now:
1. Set their pay rate and expected weekly hours in payroll
2. See immediate CWI calculation
3. View recommended economy settings based on CWI
4. Get real-time validation when configuring rent/insurance/store/fines
5. Ensure balanced classroom economy per AGENTS specification
