### PR TITLE
Remove card hover animations from all templates

### DIFF
--- a/templates/admin_feature_settings.html
+++ b/templates/admin_feature_settings.html
@@ -6,7 +6,6 @@
 {% block extra_head %}
 <style>
     .feature-card {
-        transition: all 0.2s ease;
         border-left: 4px solid transparent;
     }
     .feature-card.enabled {
@@ -22,7 +21,6 @@
         margin: 0.25rem;
         border-radius: 8px;
         cursor: pointer;
-        transition: all 0.2s ease;
     }
     .period-badge.active {
         background: linear-gradient(135deg, var(--brand-cyan) 0%, var(--brand-blue) 100%);

--- a/templates/admin_onboarding.html
+++ b/templates/admin_onboarding.html
@@ -94,7 +94,6 @@
         border-radius: 12px;
         padding: 1.5rem;
         cursor: pointer;
-        transition: all 0.2s ease;
     }
     
     

--- a/templates/admin_students.html
+++ b/templates/admin_students.html
@@ -10,9 +10,6 @@
 
 {% block extra_styles %}
 <style>
-    .student-card {
-        transition: all 0.2s ease;
-    }
     .block-tab-content {
         min-height: 400px;
     }

--- a/templates/hall_pass_queue.html
+++ b/templates/hall_pass_queue.html
@@ -65,7 +65,6 @@
             padding: 2rem;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
             text-align: center;
-            transition: all 0.3s ease;
         }
 
 
@@ -127,7 +126,6 @@
             background: #f7fafc;
             border-radius: 12px;
             border-left: 4px solid #667eea;
-            transition: all 0.3s ease;
         }
 
 

--- a/templates/hall_pass_verification.html
+++ b/templates/hall_pass_verification.html
@@ -83,7 +83,6 @@
             padding: 2rem;
             margin-bottom: 1.5rem;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
-            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
             position: relative;
             border: 3px solid transparent;
         }

--- a/templates/layout_admin.html
+++ b/templates/layout_admin.html
@@ -174,7 +174,6 @@
         border: none;
         border-radius: 16px;
         box-shadow: var(--shadow-sm);
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         overflow: hidden;
         position: relative;
     }

--- a/templates/layout_system_admin.html
+++ b/templates/layout_system_admin.html
@@ -90,7 +90,6 @@
         border: none;
         border-radius: 16px;
         box-shadow: var(--shadow-sm);
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         position: relative;
         overflow: hidden;
     }
@@ -163,7 +162,6 @@
     .stat-card {
         background: var(--white);
         border: none;
-        transition: all 0.3s;
         box-shadow: var(--shadow-sm);
         border-radius: 12px;
     }

--- a/templates/student_detail.html
+++ b/templates/student_detail.html
@@ -5,9 +5,6 @@
 
 {% block extra_styles %}
 <style>
-    .stat-card {
-        transition: transform 0.2s;
-    }
     .stat-value {
         font-size: 2rem;
         font-weight: bold;


### PR DESCRIPTION
Removed hover effects from cards across all templates (student, admin/teacher, sysadmin) to provide a consistent experience without hover animations. This includes:
- layout_admin.html: Removed .card:hover transform and shadow
- admin_feature_settings.html: Removed .feature-card:hover and .period-badge:hover effects
- admin_onboarding.html: Removed .feature-card:hover border and shadow
- admin_students.html: Removed .student-card:hover shadow
- student_detail.html: Removed .stat-card:hover transform
- layout_system_admin.html: Removed .card:hover and .stat-card:hover transforms
- hall_pass_queue.html: Removed .stat-card:hover and .queue-item:hover effects
- hall_pass_verification.html: Removed .pass-card:hover transform

