### PR TITLE
Fix student-status route missing class context import

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1826,6 +1826,8 @@ def check_and_auto_tapout_if_limit_reached(student):
 @api_bp.route('/student-status', methods=['GET'])
 @login_required
 def student_status():
+    from app.routes.student import get_current_class_context
+
     student = get_logged_in_student()
 
     context = get_current_class_context()


### PR DESCRIPTION
<!-- Start of Document -->
## Description

- Fix NameError in `/student-status` by importing `get_current_class_context` so the endpoint can resolve the selected class context.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

<!-- If this PR includes a database migration, complete the following checklist -->

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

- `pytest -q` currently fails due to pre-existing test failures in the suite (multiple IntegrityError and 404 assertions).
- Unable to pull latest `main` because no git remotes are configured in this environment.

<!-- End of Document -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390f6578ec8333a35053e14f0e7114)