### PR TITLE
Fix admin help support template defaults

### DIFF
--- a/templates/admin_help_support.html
+++ b/templates/admin_help_support.html
@@ -1,5 +1,7 @@
 {% extends "layout_admin.html" %}
 
+{% set help_content = help_content|default({'how_to': [], 'troubleshooting': []}, true) %}
+
 {% block content %}
 <div class="container-fluid">
     <h2 class="mb-4"><i class="bi bi-life-preserver me-2"></i>Help & Support</h2>
@@ -35,7 +37,7 @@
                         </div>
                         <div class="card-body">
                             <div class="accordion" id="howToAccordion">
-                                {% for article in help_content.how_to %}
+                                {% for article in help_content.how_to|default([]) %}
                                 <div class="accordion-item">
                                     <h2 class="accordion-header" id="heading{{ article.id }}">
                                         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ article.id }}" aria-expanded="false" aria-controls="collapse{{ article.id }}">
@@ -62,7 +64,7 @@
                         </div>
                         <div class="card-body">
                             <div class="accordion" id="troubleshootAccordion">
-                                {% for article in help_content.troubleshooting %}
+                                {% for article in help_content.troubleshooting|default([]) %}
                                 <div class="accordion-item">
                                     <h2 class="accordion-header" id="heading{{ article.id }}">
                                         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ article.id }}" aria-expanded="false" aria-controls="collapse{{ article.id }}">

--- a/tests/test_admin_help_support.py
+++ b/tests/test_admin_help_support.py
@@ -1,0 +1,28 @@
+import pyotp
+
+from app import db
+from app.models import Admin
+
+
+def _login_admin(client):
+    secret = pyotp.random_base32()
+    admin = Admin(username="teacher_help", totp_secret=secret)
+    db.session.add(admin)
+    db.session.commit()
+
+    response = client.post(
+        "/admin/login",
+        data={"username": admin.username, "totp_code": pyotp.TOTP(secret).now()},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+
+def test_help_support_page_renders(client):
+    _login_admin(client)
+
+    response = client.get("/admin/help-support")
+
+    assert response.status_code == 200
+    assert b"Help & Support" in response.data
+    assert b"Knowledge Base" in response.data


### PR DESCRIPTION
<!-- Start of Document -->
## Description
- Add safe defaults to the admin help/support template so missing context does not break rendering.
- Introduce a regression test to ensure the help/support page loads for logged-in admins.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
- [x] Tested locally
- [ ] All existing tests pass
- [x] Added new tests for new functionality

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [ ] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes
- `pytest -q` currently reports 22 failing tests in the existing suite (e.g., foreign key constraint setup and missing endpoints); see run output for details.
- Unable to pull from `origin/main` because no git remote is configured in this environment.
<!-- End of Document -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693986df25ac8333959bc5325de0c61c)