### PR TITLE
Add missing timestamps to sysadmin pages

### DIFF
--- a/templates/layout_system_admin.html
+++ b/templates/layout_system_admin.html
@@ -278,6 +278,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/timezone-utils.js') }}"></script>
     <script>
         // Update time display
         function updateTime() {


### PR DESCRIPTION
Added timezone-utils.js script to layout_system_admin.html to enable timestamp conversion. This fixes the missing TIMESTAMP column data on all system admin pages including:
- Error Logs
- Dashboard
- Network Activity
- User Reports
- Manage Teachers/Admins
- Logs & Testing

The script converts UTC timestamps to the user's local timezone with proper formatting, consistent with other parts of the application.

