### PR TITLE
Add pricing tier field to create new item form

### DIFF
--- a/static/js/item-form-economy.js
+++ b/static/js/item-form-economy.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const economyDataEl = document.getElementById('economy-data');
+  if (!economyDataEl || typeof EconomyBalanceChecker === 'undefined') {
+    return;
+  }
+
+  const expectedWeeklyHours = parseFloat(economyDataEl.dataset.expectedWeeklyHours);
+  const economyChecker = new EconomyBalanceChecker({
+    warningsContainer: '#economy-warnings',
+    expectedWeeklyHours: isNaN(expectedWeeklyHours) ? undefined : expectedWeeklyHours,
+  });
+
+  economyChecker
+    .analyzeEconomy()
+    .then((analysis) => {
+      economyChecker.displayCWIInfo(analysis, '#cwi-info');
+
+      const tierSelect = document.querySelector('[data-tier-select]');
+      const tierRecommendation = document.getElementById('tier-recommendation');
+      const tierRangeText = document.getElementById('tier-range-text');
+
+      const tierRanges = analysis?.recommendations?.store_tiers;
+
+      if (tierSelect && tierRecommendation && tierRangeText && tierRanges) {
+        function updateTierRecommendation() {
+          const selectedTier = tierSelect.value;
+          const range = tierRanges[selectedTier];
+
+          if (range && typeof range.min === 'number' && typeof range.max === 'number') {
+            tierRangeText.textContent = `$${range.min.toFixed(2)} - $${range.max.toFixed(2)}`;
+            tierRecommendation.style.display = 'block';
+          } else {
+            tierRecommendation.style.display = 'none';
+          }
+        }
+
+        tierSelect.addEventListener('change', updateTierRecommendation);
+        updateTierRecommendation();
+      }
+    })
+    .catch(() => {
+      console.log('Payroll not configured yet, skipping CWI display');
+    });
+});

--- a/templates/admin_edit_item.html
+++ b/templates/admin_edit_item.html
@@ -6,6 +6,7 @@
 {% block extra_head %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
 <script src="{{ url_for('static', filename='js/economy-balance.js') }}"></script>
+<script src="{{ url_for('static', filename='js/item-form-economy.js') }}"></script>
 <style>
     .EasyMDEContainer .CodeMirror {
         min-height: 150px;
@@ -36,6 +37,7 @@
                 </div>
                 <div class="card-body">
                     <!-- Economy Balance Check -->
+                    <div id="economy-data" data-expected-weekly-hours="{{ (payroll_settings.expected_weekly_hours if payroll_settings and payroll_settings.expected_weekly_hours is not none else 5.0) | float }}" class="visually-hidden"></div>
                     <div id="cwi-info" class="mb-3"></div>
 
                     <div class="row">
@@ -219,54 +221,8 @@
 
 <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
-  // Initialize markdown editors for description and redemption_prompt fields
-  document.addEventListener('DOMContentLoaded', function() {
-    // Initialize Economy Balance Checker
-    if (typeof EconomyBalanceChecker !== 'undefined') {
-      const economyChecker = new EconomyBalanceChecker({
-        warningsContainer: '#economy-warnings',
-        expectedWeeklyHours: {{ (payroll_settings.expected_weekly_hours if payroll_settings and payroll_settings.expected_weekly_hours is not none else 5.0) | float }}
-      });
-
-      // Display CWI info if payroll is configured
-      economyChecker.analyzeEconomy().then(analysis => {
-        economyChecker.displayCWIInfo(analysis, '#cwi-info');
-
-        // Setup tier recommendation display
-        const tierSelect = document.querySelector('[data-tier-select]');
-        const tierRecommendation = document.getElementById('tier-recommendation');
-        const tierRangeText = document.getElementById('tier-range-text');
-
-        if (tierSelect && tierRecommendation && tierRangeText) {
-          const cwi = analysis.cwi;
-
-          const tierRanges = {
-            'basic': { min: cwi * 0.02, max: cwi * 0.05 },
-            'standard': { min: cwi * 0.05, max: cwi * 0.10 },
-            'premium': { min: cwi * 0.10, max: cwi * 0.25 },
-            'luxury': { min: cwi * 0.25, max: cwi * 0.50 }
-          };
-
-          function updateTierRecommendation() {
-            const selectedTier = tierSelect.value;
-            if (selectedTier && tierRanges[selectedTier]) {
-              const range = tierRanges[selectedTier];
-              tierRangeText.textContent = `$${range.min.toFixed(2)} - $${range.max.toFixed(2)}`;
-              tierRecommendation.style.display = 'block';
-            } else {
-              tierRecommendation.style.display = 'none';
-            }
-          }
-
-          tierSelect.addEventListener('change', updateTierRecommendation);
-          // Initialize on page load
-          updateTierRecommendation();
-        }
-      }).catch(err => {
-        console.log('Payroll not configured yet, skipping CWI display');
-      });
-    }
-
+// Initialize markdown editors for description and redemption_prompt fields
+document.addEventListener('DOMContentLoaded', function() {
     const descriptionField = document.getElementById('description');
     const redemptionPromptField = document.getElementById('redemption_prompt');
 

--- a/templates/admin_store.html
+++ b/templates/admin_store.html
@@ -6,6 +6,7 @@
 {% block extra_head %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
 <script src="{{ url_for('static', filename='js/economy-balance.js') }}"></script>
+<script src="{{ url_for('static', filename='js/item-form-economy.js') }}"></script>
 <style>
     .EasyMDEContainer .CodeMirror {
         min-height: 120px;
@@ -159,6 +160,7 @@
                 </div>
                 <div class="card-body">
                   <!-- Economy Balance Check -->
+                  <div id="economy-data" data-expected-weekly-hours="{{ (payroll_settings.expected_weekly_hours if payroll_settings and payroll_settings.expected_weekly_hours is not none else 5.0) | float }}" class="visually-hidden"></div>
                   <div id="cwi-info" class="mb-3"></div>
 
                   <div class="row">
@@ -646,52 +648,6 @@
 <script>
   // Initialize markdown editors for description and redemption_prompt fields
   document.addEventListener('DOMContentLoaded', function() {
-    // Initialize Economy Balance Checker
-    if (typeof EconomyBalanceChecker !== 'undefined') {
-      const economyChecker = new EconomyBalanceChecker({
-        warningsContainer: '#economy-warnings',
-        expectedWeeklyHours: {{ (payroll_settings.expected_weekly_hours if payroll_settings and payroll_settings.expected_weekly_hours is not none else 5.0) | float }}
-      });
-
-      // Display CWI info if payroll is configured
-      economyChecker.analyzeEconomy().then(analysis => {
-        economyChecker.displayCWIInfo(analysis, '#cwi-info');
-
-        // Setup tier recommendation display
-        const tierSelect = document.querySelector('[data-tier-select]');
-        const tierRecommendation = document.getElementById('tier-recommendation');
-        const tierRangeText = document.getElementById('tier-range-text');
-
-        if (tierSelect && tierRecommendation && tierRangeText) {
-          const cwi = analysis.cwi;
-
-          const tierRanges = {
-            'basic': { min: cwi * 0.02, max: cwi * 0.05 },
-            'standard': { min: cwi * 0.05, max: cwi * 0.10 },
-            'premium': { min: cwi * 0.10, max: cwi * 0.25 },
-            'luxury': { min: cwi * 0.25, max: cwi * 0.50 }
-          };
-
-          function updateTierRecommendation() {
-            const selectedTier = tierSelect.value;
-            if (selectedTier && tierRanges[selectedTier]) {
-              const range = tierRanges[selectedTier];
-              tierRangeText.textContent = `$${range.min.toFixed(2)} - $${range.max.toFixed(2)}`;
-              tierRecommendation.style.display = 'block';
-            } else {
-              tierRecommendation.style.display = 'none';
-            }
-          }
-
-          tierSelect.addEventListener('change', updateTierRecommendation);
-          // Initialize on page load
-          updateTierRecommendation();
-        }
-      }).catch(err => {
-        console.log('Payroll not configured yet, skipping CWI display');
-      });
-    }
-
     const descriptionField = document.getElementById('description');
     const redemptionPromptField = document.getElementById('redemption_prompt');
 


### PR DESCRIPTION
The pricing tier dropdown was previously only available when editing existing store items but missing from the create new item form. This caused inconsistency in the UI.

Changes:
- Added pricing tier select field to Basic Information section
- Integrated economy-balance.js for CWI calculations
- Added tier recommendation display (shows recommended price ranges)
- Added economy validation attribute to price field
- Added CWI info and economy warnings containers

The create form now matches the edit form functionality.

