### PR TITLE
Fix student tap-in issues later in day

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, request, jsonify, session, current_app
 from sqlalchemy import func, or_
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from werkzeug.security import check_password_hash
 
 from app.extensions import db


### PR DESCRIPTION
This fixes a critical bug where students could not tap in, especially during periods later in the day when concurrency is higher.

Root cause:
- The code at api.py:1274 catches IntegrityError to handle race conditions when creating StudentBlock records
- However, IntegrityError was never imported from sqlalchemy.exc
- This caused a NameError when race conditions occurred, resulting in unhandled exceptions and failed tap-in attempts

The bug particularly affected later periods because:
- Higher student concurrency leads to more race conditions
- Multiple students trying to create StudentBlock simultaneously
- The unique constraint on (student_id, period) triggers IntegrityError
- Without proper handling, the tap endpoint crashes

Fix:
- Added IntegrityError to the sqlalchemy.exc imports
- Now race conditions are properly caught and handled
- Students can successfully tap in even under high concurrency

Related symptoms this fixes:
- Students unable to tap in despite tap enabled on admin end
- Some students able to tap out but not tap in (leading to lockout)
- Status showing "enabled" but not accumulating money
- Status showing "inactive" on admin side

