### PR TITLE
Fix store item hard delete query filter

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2636,9 +2636,8 @@ def hard_delete_store_item(item_id):
     from app.models import StudentItem
     purchase_count = (
         StudentItem.query
-        .join(Student, StudentItem.student_id == Student.id)
-        .filter(Student.id.in_(_student_scope_subquery()))
-        .filter_by(store_item_id=item_id)
+        .filter(StudentItem.student_id.in_(_student_scope_subquery()))
+        .filter(StudentItem.store_item_id == item_id)
         .count()
     )
 


### PR DESCRIPTION
<!-- Start of Document -->
## Description

Ensure the store item hard delete purchase count query filters on `StudentItem` columns without relying on a join that caused invalid attribute errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] Tested locally
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

Command: `pytest -q` (fails due to pre-existing migration head mismatch and Student username field expectations).

## Database Migration Checklist

<!-- If this PR includes a database migration, complete the following checklist -->

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

- Unable to fetch `origin/main`; repository has no configured remote.
- Local `pytest -q` currently fails in existing tests due to migration head mismatch and Student model username field expectations.

<!-- End of Document -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dec7ee1548333b0636441f2123cf7)