### PR TITLE
Ensure static_url helper fallback in render_template_with_fallback

### DIFF
--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -11,6 +11,8 @@ from datetime import timezone
 from urllib.parse import urlparse, urljoin
 import hashlib
 import hmac
+import os
+
 from flask import request, current_app, session, render_template, url_for
 from jinja2 import TemplateNotFound
 from markupsafe import Markup
@@ -27,9 +29,19 @@ def render_template_with_fallback(template_name, **context):
     # Ensure static_url helper is always available even if Jinja globals/context processors are missing
     static_helper = current_app.jinja_env.globals.get('static_url')
     if not static_helper:
-        current_app.logger.warning("static_url missing from Jinja globals; using url_for fallback")
-        def static_helper(filename):
-            return url_for('static', filename=filename)
+        current_app.logger.warning("static_url missing from Jinja globals; using fallback with cache-busting")
+
+        def static_helper(filename: str):
+            if not filename:
+                return url_for('static', filename=filename)
+
+            file_path = os.path.join(current_app.static_folder, filename)
+            try:
+                version = int(os.stat(file_path).st_mtime)
+                return url_for('static', filename=filename, v=version)
+            except (OSError, TypeError) as exc:
+                current_app.logger.debug(f"Could not add cache buster for {filename}: {exc}")
+                return url_for('static', filename=filename)
     context.setdefault('static_url', static_helper)
 
     if session.get('force_desktop'):


### PR DESCRIPTION
## Description

Ensure the `static_url` helper is always available in the `render_template_with_fallback` function, providing a fallback using `url_for` if it is missing from Jinja globals.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Other (please describe): Ensures availability of static_url helper

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Tested locally
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings or errors
- [ ] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

<!-- Any additional information that reviewers should know -->

