### PR TITLE
Fix payroll template script closure

### DIFF
--- a/templates/admin_payroll.html
+++ b/templates/admin_payroll.html
@@ -1444,11 +1444,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Settings Form Validation
     const payrollSettingsForm = document.getElementById('payrollSettingsForm');
-    if (payrollSettingsForm) {
-        payrollSettingsForm.addEventListener('submit', function(e) {
-            const validationErrors = [];
-            const errorList = document.getElementById('validationErrorList');
-            const errorDiv = document.getElementById('validationErrors');
+      if (payrollSettingsForm) {
+          payrollSettingsForm.addEventListener('submit', function(e) {
+              const validationErrors = [];
+              const errorList = document.getElementById('validationErrorList');
+              const errorDiv = document.getElementById('validationErrors');
 
             // Clear previous errors
             errorList.innerHTML = '';
@@ -1487,17 +1487,14 @@ document.addEventListener("DOMContentLoaded", () => {
                     errorList.appendChild(li);
                 });
                 errorDiv.style.display = 'block';
-                errorDiv.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-            }
-        });
-    }
+                  errorDiv.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+              }
+          });
+      }
+  });
 
-        });
-    }
-});
-
-// Run Payroll
-document.getElementById('runPayrollBtn')?.addEventListener('click', async function() {
+  // Run Payroll
+  document.getElementById('runPayrollBtn')?.addEventListener('click', async function() {
   const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
   try {
     const resp = await fetch('{{ url_for("admin.run_payroll") }}', {


### PR DESCRIPTION
<!-- Start of Document -->
## Description
Fixes a stray closure in the admin payroll page script so the DOMContentLoaded handler ends correctly and the rest of the payroll JavaScript executes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

Unable to pull latest from `main` because no git remotes are configured in this environment.

<!-- End of Document -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fbb2e96888333bc09579a3d937a10)