### PR TITLE
Fix student login safe redirect helper usage

### DIFF
--- a/app/routes/student.py
+++ b/app/routes/student.py
@@ -13,7 +13,6 @@ from calendar import monthrange
 from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, redirect, url_for, flash, request, session, jsonify, current_app
-from urllib.parse import urlparse
 from sqlalchemy import or_, func, select, and_
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -32,18 +31,7 @@ from forms import (
 )
 
 # Import utility functions
-from app.utils.helpers import generate_anonymous_code, render_template_with_fallback as render_template
-
-def _is_safe_url(target):
-    """Return True if the URL is a relative path without scheme or netloc (prevents open redirects)."""
-    from urllib.parse import urlparse
-    if not target:
-        return False
-    # Remove backslashes (which browsers may tolerate as slashes)
-    target = target.replace('\\', '')
-    parsed = urlparse(target)
-    # Check that both netloc and scheme are empty (relative URL/path only)
-    return not parsed.netloc and not parsed.scheme
+from app.utils.helpers import generate_anonymous_code, is_safe_url, render_template_with_fallback as render_template
 from app.utils.constants import THEME_PROMPTS
 from app.utils.turnstile import verify_turnstile_token
 from app.utils.demo_sessions import cleanup_demo_student_data
@@ -2696,7 +2684,7 @@ def login():
             return jsonify(status="success", message="Login successful")
 
         next_url = request.args.get('next')
-        if not _is_safe_url(next_url):
+        if not is_safe_url(next_url):
             return redirect(url_for('student.dashboard'))
         return redirect(next_url or url_for('student.dashboard'))
 


### PR DESCRIPTION
<!-- Start of Document -->
## Description
- Use the shared `is_safe_url` helper for student login redirects to prevent NameError and ensure redirect safety.
- Remove redundant local safe URL helper definition from student routes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

- Attempted to pull from `origin/main` but no remote named `origin` is configured in this environment.

<!-- End of Document -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408bd84d3c8333930f00c30abbfe48)