### PR TITLE
Clarify tier grouping unavailable warning

### DIFF
--- a/templates/admin_edit_insurance_policy.html
+++ b/templates/admin_edit_insurance_policy.html
@@ -375,7 +375,7 @@
                     </div>
                     {% else %}
                     <div class="alert alert-warning mb-0">
-                      Tier grouping controls are temporarily unavailable. Reload the page after updating the site to enable grouping.
+                      Tier grouping controls are temporarily unavailable. To enable them, please update the site and then reload this page.
                     </div>
                     {% endif %}
                   </div>

--- a/templates/admin_insurance.html
+++ b/templates/admin_insurance.html
@@ -559,7 +559,7 @@
               </div>
               {% else %}
               <div class="alert alert-warning mb-0">
-                Tier grouping controls are temporarily unavailable. Reload the page after updating the site to enable grouping.
+                Tier grouping controls are temporarily unavailable. To enable them, please update the site and then reload this page.
               </div>
               {% endif %}
             </div>


### PR DESCRIPTION
## Summary
- Clarify the tier grouping unavailable warning copy on the insurance admin pages per review feedback

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408ee94c488333903a537253be312b)