### PR TITLE
Fix PWA mobile icons and navigation layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project follows semantic versioning principles.
 
 ### Fixed
 - **Payroll Button JSON Error** - Fixed "Run Payroll Now" button returning HTML instead of JSON, which caused "Unexpected token '<!DOCTYPE'" error. The `run_payroll()` endpoint now properly returns JSON response for AJAX requests.
+- **Mobile PWA Navigation** - Restored Material Symbols icons and tightened bottom navigation layout to remove horizontal scrolling on small screens.
 
 ### Changed
 - **Insurance Policy Edit Page** - Redesigned with collapsible accordion sections to eliminate overflow issues and reduce visual clutter

--- a/templates/mobile/layout_admin.html
+++ b/templates/mobile/layout_admin.html
@@ -10,9 +10,11 @@
     <link rel="manifest" href="{{ static_url('manifest.json') }}">
     <link rel="apple-touch-icon" href="{{ static_url('images/icon-192.png') }}">
     <title>{{ page_title or "Admin Portal" }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
     <style>
         :root {
             --brand-primary: #1a4d47;
@@ -21,6 +23,11 @@
             --gray-800: #2c2c2c;
             --white: #ffffff;
             --secondary: #d4a574;
+        }
+        html, body {
+            width: 100%;
+            max-width: 100%;
+            overflow-x: hidden;
         }
         body {
             font-family: 'Inter', sans-serif;
@@ -49,7 +56,8 @@
             background: var(--white);
             display: flex;
             justify-content: space-around;
-            padding: 0.5rem 0;
+            gap: 0.1rem;
+            padding: 0.5rem 0.35rem;
             box-shadow: 0 -2px 5px rgba(0,0,0,0.1);
             z-index: 1000;
         }
@@ -58,12 +66,14 @@
             text-align: center;
             font-size: 0.75rem;
             text-decoration: none;
-            flex-grow: 1;
-            padding: 0.25rem;
+            flex: 1 1 0;
+            min-width: 0;
+            padding: 0.35rem 0.25rem;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
+            gap: 0.2rem;
         }
         .bottom-nav a.active {
             color: var(--brand-primary);
@@ -72,7 +82,15 @@
         .bottom-nav .material-symbols-outlined {
             font-size: 1.5rem;
             display: block;
-            margin-bottom: 0.1rem;
+            line-height: 1;
+        }
+        .bottom-nav .nav-label {
+            display: block;
+            max-width: 100%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            line-height: 1.1;
         }
         .main-content {
             padding: 1rem;
@@ -119,20 +137,20 @@
 
     <nav class="bottom-nav">
         <a href="{{ url_for('admin.dashboard') }}" class="{{ 'active' if current_page == 'dashboard' else '' }}" aria-label="Dashboard">
-            <span class="material-symbols-outlined">dashboard</span>
-            Dashboard
+            <span class="material-symbols-outlined" aria-hidden="true">dashboard</span>
+            <span class="nav-label">Dashboard</span>
         </a>
         <a href="{{ url_for('admin.attendance_log') }}" class="{{ 'active' if current_page == 'attendance' else '' }}" aria-label="Approvals">
-            <span class="material-symbols-outlined">rule</span>
-            Approvals
+            <span class="material-symbols-outlined" aria-hidden="true">rule</span>
+            <span class="nav-label">Approvals</span>
         </a>
         <a href="{{ url_for('admin.students') }}" class="{{ 'active' if current_page == 'students' else '' }}" aria-label="Students">
-            <span class="material-symbols-outlined">group</span>
-            Students
+            <span class="material-symbols-outlined" aria-hidden="true">group</span>
+            <span class="nav-label">Students</span>
         </a>
         <a href="{{ url_for('admin.store_management') }}" class="{{ 'active' if current_page == 'store' else '' }}" aria-label="Store">
-            <span class="material-symbols-outlined">storefront</span>
-            Store
+            <span class="material-symbols-outlined" aria-hidden="true">storefront</span>
+            <span class="nav-label">Store</span>
         </a>
     </nav>
     <div style="text-align: center; margin-top: 10px; font-size: 0.8rem;">

--- a/templates/mobile/layout_student.html
+++ b/templates/mobile/layout_student.html
@@ -11,9 +11,11 @@
     <link rel="manifest" href="{{ static_url('manifest.json') }}">
     <link rel="apple-touch-icon" href="{{ static_url('images/icon-192.png') }}">
     <title>{{ page_title or "Student Portal" }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
     <style>
         :root {
             /* Student Theme - Dark Slate Blue */
@@ -27,6 +29,11 @@
             --success: #4A8B6C;
             --danger: #D97070;
             --warning: #E8A756;
+        }
+        html, body {
+            width: 100%;
+            max-width: 100%;
+            overflow-x: hidden;
         }
         body {
             font-family: 'Inter', sans-serif;
@@ -60,7 +67,8 @@
             background: var(--white);
             display: flex;
             justify-content: space-around;
-            padding: 0.5rem 0;
+            gap: 0.1rem;
+            padding: 0.5rem 0.35rem;
             box-shadow: 0 -2px 5px rgba(0,0,0,0.1);
             z-index: 1000;
         }
@@ -69,12 +77,14 @@
             text-align: center;
             font-size: 0.75rem;
             text-decoration: none;
-            flex-grow: 1;
-            padding: 0.25rem;
+            flex: 1 1 0;
+            min-width: 0;
+            padding: 0.35rem 0.25rem;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
+            gap: 0.2rem;
         }
         .bottom-nav a.active {
             color: var(--brand-primary);
@@ -83,7 +93,15 @@
         .bottom-nav .material-symbols-outlined {
             font-size: 1.5rem;
             display: block;
-            margin-bottom: 0.1rem;
+            line-height: 1;
+        }
+        .bottom-nav .nav-label {
+            display: block;
+            max-width: 100%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            line-height: 1.1;
         }
         .main-content {
             padding: 1rem;
@@ -171,26 +189,26 @@
 
     <nav class="bottom-nav">
         <a href="{{ url_for('student.dashboard') }}" class="{{ 'active' if current_page == 'dashboard' else '' }}" aria-label="Dashboard">
-            <span class="material-symbols-outlined">dashboard</span>
-            Dashboard
+            <span class="material-symbols-outlined" aria-hidden="true">dashboard</span>
+            <span class="nav-label">Dashboard</span>
         </a>
         <a href="{{ url_for('student.transfer') }}" class="{{ 'active' if current_page == 'transfer' else '' }}" aria-label="Banking">
-            <span class="material-symbols-outlined">account_balance</span>
-            Banking
+            <span class="material-symbols-outlined" aria-hidden="true">account_balance</span>
+            <span class="nav-label">Banking</span>
         </a>
         <a href="{{ url_for('student.shop') }}" class="{{ 'active' if current_page == 'store' else '' }}" aria-label="Store">
-            <span class="material-symbols-outlined">storefront</span>
-            Store
+            <span class="material-symbols-outlined" aria-hidden="true">storefront</span>
+            <span class="nav-label">Store</span>
         </a>
         {% if global_rent_enabled %}
         <a href="{{ url_for('student.rent') }}" class="{{ 'active' if current_page == 'rent' else '' }}" aria-label="Rent">
-            <span class="material-symbols-outlined">home</span>
-            Rent
+            <span class="material-symbols-outlined" aria-hidden="true">home</span>
+            <span class="nav-label">Rent</span>
         </a>
         {% endif %}
         <a href="{{ url_for('student.payroll') }}" class="{{ 'active' if current_page == 'payroll' else '' }}" aria-label="Payroll">
-            <span class="material-symbols-outlined">receipt_long</span>
-            Payroll
+            <span class="material-symbols-outlined" aria-hidden="true">receipt_long</span>
+            <span class="nav-label">Payroll</span>
         </a>
     </nav>
     <div style="text-align: center; margin-top: 10px; font-size: 0.8rem;">


### PR DESCRIPTION
## Description
- restore Material Symbols loading in mobile layouts with preconnects and display tweaks to fix missing navigation icons
- tighten bottom navigation styling to prevent horizontal scrolling on small screens while keeping labels readable
- document the PWA navigation fix in the changelog

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist
**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues
Closes #N/A

## Additional Notes
Attempted to pull latest main, but no remote named `origin` is configured in this environment.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b22b1c3c8333a7916839802facba)