### PR TITLE
Fix PWA icons and horizontal scroll issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project follows semantic versioning principles.
 ### Fixed
 - **Payroll Button JSON Error** - Fixed "Run Payroll Now" button returning HTML instead of JSON, which caused "Unexpected token '<!DOCTYPE'" error. The `run_payroll()` endpoint now properly returns JSON response for AJAX requests.
 - **Mobile PWA Navigation** - Restored Material Symbols icons and tightened bottom navigation layout to remove horizontal scrolling on small screens.
+- **Desktop PWA Icon Rendering** - Fixed Material Symbols icons not displaying properly when desktop templates are served on mobile devices (PWA mode or "View Full Site")
+  - Root cause: Previous PWA fixes only targeted mobile templates; desktop templates lacked `&display=swap` parameter and PWA support
+  - Added `&display=swap` to Material Symbols font URL in desktop templates (`layout_admin.html`, `layout_student.html`) to prevent font blocking
+  - Added PWA meta tags (theme-color, apple-mobile-web-app-capable, manifest link) to desktop templates
+  - Added font preconnect hints for faster Google Fonts loading
+  - Added service worker registration to desktop templates
+- **Desktop PWA Horizontal Scroll** - Fixed horizontal scrolling issue when viewing desktop templates on mobile devices
+  - Added responsive CSS media queries to hide sidebar and reset content layout on narrow viewports
+  - Added overflow-x protection to prevent horizontal scroll on mobile
+- **Service Worker Cache** - Bumped cache version to v3 to ensure updated styles and templates are loaded
 
 ### Changed
 - **Insurance Policy Edit Page** - Redesigned with collapsible accordion sections to eliminate overflow issues and reduce visual clutter

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -725,3 +725,45 @@ body.maintenance-active .main-content {
         padding: 3rem 2rem;
     }
 }
+
+/* PWA Mobile Viewport Fix - prevents horizontal scroll when desktop template is served on mobile */
+@media (max-width: 767.98px) {
+    html, body {
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
+    }
+
+    /* Hide desktop sidebar on mobile to prevent horizontal overflow */
+    .sidebar,
+    .student-sidebar {
+        display: none !important;
+    }
+
+    /* Reset main content to fill screen without sidebar margin */
+    .main-content,
+    .student-main {
+        margin-left: 0 !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        padding: 1rem !important;
+    }
+
+    /* Ensure page header doesn't overflow */
+    .page-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .page-header-actions {
+        width: 100%;
+        justify-content: flex-start;
+        margin-top: 0.5rem;
+    }
+
+    /* Ensure tables scroll horizontally within their container */
+    .table-responsive {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,10 +1,11 @@
-const CACHE_NAME = 'classroom-token-hub-v2';
+const CACHE_NAME = 'classroom-token-hub-v3';
 const STATIC_ASSETS = [
   '/static/manifest.json',
   '/static/images/brand-logo.svg',
   '/static/images/icon-192.png',
   '/static/images/icon-512.png',
   '/static/js/timezone-utils.js',
+  '/static/css/style.css',
   '/offline'
 ];
 

--- a/templates/layout_admin.html
+++ b/templates/layout_admin.html
@@ -6,9 +6,19 @@
     <title>{% block page_title %}{{ page_title or "Admin Portal" }}{% endblock %}</title>
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    <!-- Fonts -->
+    <!-- PWA Meta Tags -->
+    <meta name="theme-color" content="#1a4d47">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="{{ static_url('manifest.json') }}">
+    <link rel="apple-touch-icon" href="{{ static_url('images/icon-192.png') }}">
+
+    <!-- Fonts - preconnect for faster loading -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
 
     <!-- CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -181,6 +191,20 @@
             });
         }
     });
+    </script>
+    <!-- Service Worker Registration for PWA -->
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register("/sw.js")
+                    .then(registration => {
+                        console.log('ServiceWorker registration successful with scope: ', registration.scope);
+                    })
+                    .catch(err => {
+                        console.log('ServiceWorker registration failed: ', err);
+                    });
+            });
+        }
     </script>
     <!-- TODO: Re-enable View as Student once demo sessions are stable -->
     {% block extra_scripts %}{% endblock %}

--- a/templates/layout_student.html
+++ b/templates/layout_student.html
@@ -8,9 +8,19 @@
     <title>{{ resolved_page_title }} - Classroom Token Hub</title>
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    <!-- Fonts -->
+    <!-- PWA Meta Tags -->
+    <meta name="theme-color" content="#2F4F7F">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="{{ static_url('manifest.json') }}">
+    <link rel="apple-touch-icon" href="{{ static_url('images/icon-192.png') }}">
+
+    <!-- Fonts - preconnect for faster loading -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
 
     <!-- CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -253,6 +263,20 @@
                 });
             }
         });
+    </script>
+    <!-- Service Worker Registration for PWA -->
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register("/sw.js")
+                    .then(registration => {
+                        console.log('ServiceWorker registration successful with scope: ', registration.scope);
+                    })
+                    .catch(err => {
+                        console.log('ServiceWorker registration failed: ', err);
+                    });
+            });
+        }
     </script>
     {% block extra_scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
Root cause analysis:
- Previous PWA fixes (#672, #674) only targeted mobile templates
- When users viewed desktop templates on mobile (via "View Full Site" or PWA installed from desktop URL), icons displayed as text and horizontal scroll occurred because desktop templates lacked PWA support

Changes to desktop templates (layout_admin.html, layout_student.html):
- Added &display=swap to Material Symbols font URL to prevent font blocking
- Added PWA meta tags (theme-color, manifest, apple-touch-icon, web-app-capable)
- Added font preconnect hints for faster Google Fonts loading
- Added service worker registration script

Changes to static/css/style.css:
- Added responsive media query (max-width: 767.98px) to:
  - Hide desktop sidebar on narrow mobile viewports
  - Reset main content layout to fill screen without sidebar margin
  - Prevent horizontal overflow with overflow-x: hidden
  - Make page header stack vertically on mobile

Changes to static/sw.js:
- Bumped cache version to v3 to force cache refresh
- Added style.css to cached static assets

This fixes the issue where Material Symbols icons showed as text (e.g., "dashboard", "group", "fact_check") instead of actual icons when viewing desktop templates on mobile devices in PWA mode.
