### PR TITLE
Fix incorrect route references in mobile admin dashboard

### DIFF
--- a/templates/mobile/admin_dashboard.html
+++ b/templates/mobile/admin_dashboard.html
@@ -158,7 +158,7 @@
         </a>
 
         <!-- Payroll -->
-        <a href="{{ url_for('admin.payroll_settings') }}" class="feature-card">
+        <a href="{{ url_for('admin.payroll') }}" class="feature-card">
             <div class="feature-icon">
                 <span class="material-symbols-outlined">payments</span>
             </div>
@@ -169,7 +169,7 @@
         </a>
 
         <!-- Banking -->
-        <a href="{{ url_for('admin.banking_settings') }}" class="feature-card">
+        <a href="{{ url_for('admin.banking') }}" class="feature-card">
             <div class="feature-icon">
                 <span class="material-symbols-outlined">account_balance</span>
             </div>


### PR DESCRIPTION
Fixed two routing issues in the mobile admin dashboard template:

1. Changed url_for('admin.banking_settings') to url_for('admin.banking')
   - The endpoint 'admin.banking_settings' doesn't exist (only POST-only update endpoint exists)
   - The correct endpoint is 'admin.banking' which displays the banking management page

2. Changed url_for('admin.payroll_settings') to url_for('admin.payroll')
   - The endpoint 'admin.payroll_settings' is POST-only for updating settings
   - The correct endpoint is 'admin.payroll' which displays the payroll page

These changes ensure the feature cards on the mobile dashboard correctly navigate
to their respective pages, preventing BuildError exceptions.