### PR TITLE
Harden student_blocks join_code migration

### DIFF
--- a/docs/development/MIGRATION_BEST_PRACTICES.md
+++ b/docs/development/MIGRATION_BEST_PRACTICES.md
@@ -10,6 +10,10 @@ This document outlines best practices for creating database migrations in the Cl
 2. Previous migration runs may have partially completed before failing
 3. The same migration may exist in multiple branches that get merged
 
+### Real-World Example: Duplicate Column Protection
+
+We recently hit `psycopg2.errors.DuplicateColumn: column "join_code" of relation "student_blocks" already exists` while running `flask db upgrade` because a hotfix script had already added the column. Guarding migrations with `column_exists`/`index_exists` checks avoids this failure mode without requiring manual DB cleanup.
+
 ## Required Checks Before Schema Changes
 
 ### 1. Check if Columns Exist Before Adding

--- a/migrations/versions/a1b2c3d4e5f8_add_join_code_to_student_blocks.py
+++ b/migrations/versions/a1b2c3d4e5f8_add_join_code_to_student_blocks.py
@@ -16,13 +16,68 @@ branch_labels = None
 depends_on = None
 
 
+def column_exists(table_name, column_name):
+    """Check if a column exists on a table."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [col['name'] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def index_exists(table_name, index_name):
+    """Check if an index exists on a table."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    indexes = [idx['name'] for idx in inspector.get_indexes(table_name)]
+    return index_name in indexes
+
+
+def table_exists(table_name):
+    """Check if a table exists in the current database."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    return table_name in inspector.get_table_names()
+
+
 def upgrade():
-    # Add join_code column to student_blocks table
-    op.add_column('student_blocks', sa.Column('join_code', sa.String(length=20), nullable=True))
-    op.create_index(op.f('ix_student_blocks_join_code'), 'student_blocks', ['join_code'], unique=False)
+    table_name = 'student_blocks'
+    column_name = 'join_code'
+    index_name = op.f('ix_student_blocks_join_code')
+
+    if not table_exists(table_name):
+        print(f"⚠️  Table '{table_name}' does not exist; skipping join_code addition.")
+        return
+
+    if not column_exists(table_name, column_name):
+        op.add_column(table_name, sa.Column(column_name, sa.String(length=20), nullable=True))
+        print(f"✅ Added {column_name} column to {table_name} table")
+    else:
+        print(f"⚠️  Column '{column_name}' already exists on '{table_name}', skipping...")
+
+    if not index_exists(table_name, index_name):
+        op.create_index(index_name, table_name, [column_name], unique=False)
+        print(f"✅ Created index {index_name}")
+    else:
+        print(f"⚠️  Index '{index_name}' already exists on '{table_name}', skipping...")
 
 
 def downgrade():
-    # Remove the index and column
-    op.drop_index(op.f('ix_student_blocks_join_code'), table_name='student_blocks')
-    op.drop_column('student_blocks', 'join_code')
+    table_name = 'student_blocks'
+    column_name = 'join_code'
+    index_name = op.f('ix_student_blocks_join_code')
+
+    if not table_exists(table_name):
+        print(f"⚠️  Table '{table_name}' does not exist; skipping downgrade steps.")
+        return
+
+    if index_exists(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+        print(f"❌ Dropped index {index_name}")
+    else:
+        print(f"⚠️  Index '{index_name}' does not exist on '{table_name}', skipping...")
+
+    if column_exists(table_name, column_name):
+        op.drop_column(table_name, column_name)
+        print(f"❌ Removed {column_name} column from {table_name} table")
+    else:
+        print(f"⚠️  Column '{column_name}' does not exist on '{table_name}', skipping...")


### PR DESCRIPTION
## Description

- make the `a1b2c3d4e5f8_add_join_code_to_student_blocks` migration idempotent by checking table, column, and index existence before applying changes
- add documentation note highlighting the duplicate `join_code` column scenario and the need for defensive checks during migrations

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

**Does this PR include a database migration?** [x] Yes / [ ] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [x] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [x] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
`migrations/versions/a1b2c3d4e5f8_add_join_code_to_student_blocks.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [ ] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

- `pytest -q` currently fails during collection because `hash_utils.hash_password` is missing, preventing test imports (existing issue).
- Unable to pull latest `main` because no `origin` remote is configured in this environment; branch was already clean locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69485e78a9e48333b173d7605ebd4aa7)