### PR TITLE
Change Jekyll workflow to use github_pages branch

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["github_pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs/github_pages
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and deploying a Jekyll site to GitHub Pages. The workflow is triggered by pushes to the `github_pages` branch or manual dispatch, and it sets up the necessary permissions and jobs for continuous deployment.

**GitHub Pages deployment automation:**

* Added `.github/workflows/jekyll-gh-pages.yml` workflow to automatically build the Jekyll site from `./docs/github_pages` and deploy it to GitHub Pages on pushes to the `github_pages` branch or via manual trigger.
* Configured workflow permissions for secure deployment, including `pages: write` and `id-token: write`.
* Set up concurrency controls to ensure only one deployment runs at a time without canceling in-progress runs.
* Defined separate build and deploy jobs using official GitHub Actions for checkout, Jekyll build, artifact upload, and deployment.