### PR TITLE
Update GitHub Pages for v1.3.0 release

### DIFF
--- a/docs/github_pages/index.html
+++ b/docs/github_pages/index.html
@@ -565,9 +565,10 @@
     <section class="hero">
         <div class="hero-container">
            <br>
+            <span class="badge">🔐 v1.3.0 Released - Passwordless Authentication Now Available</span>
             <h2>Classroom Economy System, <span style="font-weight:600; color:#f9d004">Reimagined.</span></strong></h2>
             <p>New approach to behavioral management that promotes student engagement, personal responsibility, and financial literacy.</p>
-            
+
         </div>
     </section>
 
@@ -590,8 +591,8 @@
                     </div>
                     <div class="stat">
                     <h4>Security<span style="font-weight:300;"> focused</span></h4>
-          
-                    <p>TOTP auth, CSRF protection, and encrypted PII across the stack.</p>
+
+                    <p>Passkey authentication, TOTP 2FA, CSRF protection, and encrypted PII across the stack.</p>
                     </div>
                 </div>
             </div>
@@ -645,7 +646,7 @@
                 <div class="feature-card">
                     <div class="feature-icon" aria-hidden="true">security</div>
                     <h3>Security First</h3>
-                    <p>PII encryption at rest, TOTP authentication, CSRF protection, and comprehensive security measures throughout.</p>
+                    <p>WebAuthn/FIDO2 passkey authentication, encrypted TOTP secrets, PII encryption at rest, CSRF protection, and comprehensive security measures throughout.</p>
                 </div>
 
                 <div class="feature-card">
@@ -731,7 +732,7 @@
                         <strong>Frontend:</strong> Jinja2, Bootstrap 5, Material Symbols, Service Workers
                     </p>
                     <p style="font-size: 1.1rem; margin-bottom: 2rem; color: var(--text-light);">
-                        <strong>Security:</strong> TOTP Authentication, PII Encryption, CSRF Protection, Join Code-Based Scoping
+                        <strong>Security:</strong> WebAuthn/FIDO2 Passkeys, TOTP Authentication, PII Encryption, CSRF Protection, Join Code-Based Scoping
                     </p>
                     <p style="font-size: 1.1rem; margin-bottom: 2rem; color: var(--text-light);">
                         <strong>Future Features: </strong>CSV Exporting, Classroom Announcements and Messaging, Job Board, CWI Auto Balancing Tool


### PR DESCRIPTION
Added passwordless authentication announcement and updated security features:
- Added v1.3.0 release badge in hero section
- Updated security stats to mention passkey authentication
- Updated Security First feature card with WebAuthn/FIDO2 details
- Updated tech stack security section with passkeys

This update highlights the major v1.3.0 release which introduces WebAuthn/FIDO2 passwordless authentication for teachers and system administrators.

