### PR TITLE
Claude/passwordless admin auth zk vh h

### DIFF
--- a/app/utils/passwordless_client.py
+++ b/app/utils/passwordless_client.py
@@ -67,7 +67,7 @@ class PasswordlessClient:
         options = PasswordlessOptions(self.api_key, api_url)
         self._client: _PasswordlessClient = PasswordlessClientBuilder(options).build()
 
-    def register_token(self, user_id: str, username: str, displayname: str) -> str:
+    def register_token(self, user_id: str, username: str, displayname: str, discoverable: bool = True) -> str:
         """
         Generate a registration token for creating a new passkey.
 
@@ -78,6 +78,8 @@ class PasswordlessClient:
             user_id: Unique identifier for the system admin (e.g., "sysadmin_123")
             username: System admin username
             displayname: Display name for the credential (used as username in SDK)
+            discoverable: Whether to create a discoverable credential (resident key).
+                         Defaults to True for cross-device syncing with password managers.
 
         Returns:
             Registration token to be used in the frontend
@@ -85,12 +87,14 @@ class PasswordlessClient:
         Raises:
             Exception: If the SDK request fails
         """
-        # Note: RegisterToken only accepts user_id, username, and aliases
-        # The username parameter is what shows in the browser UI
+        # Create discoverable credentials by default for better password manager support
+        # Discoverable credentials (resident keys) allow syncing across devices via
+        # password managers like Bitwarden
         register_token = RegisterToken(
             user_id=user_id,
             username=displayname,  # This is shown in browser UI
-            aliases=[username]      # Allow login by username
+            aliases=[username],     # Allow login by username
+            discoverable=discoverable  # Enable discoverable credentials for cross-device syncing
         )
 
         response: RegisteredToken = self._client.register_token(register_token)

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -231,11 +231,10 @@
                 button.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Authenticating...';
 
                 // Get CSRF token
-                const csrfMeta = document.querySelector('meta[name="csrf-token"]');
-                if (!csrfMeta) {
-                    throw new Error('CSRF token not found. Please refresh the page and try again.');
+                const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+                if (!csrfToken) {
+                    throw new Error('CSRF token not found or is empty. Please refresh the page and try again.');
                 }
-                const csrfToken = csrfMeta.getAttribute('content');
 
                 // Get username from form
                 const usernameInput = document.querySelector('input[name="username"]');

--- a/templates/system_admin_login.html
+++ b/templates/system_admin_login.html
@@ -226,11 +226,10 @@
                 button.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Authenticating...';
 
                 // Get CSRF token
-                const csrfMeta = document.querySelector('meta[name="csrf-token"]');
-                if (!csrfMeta) {
-                    throw new Error('CSRF token not found. Please refresh the page and try again.');
+                const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+                if (!csrfToken) {
+                    throw new Error('CSRF token not found or is empty. Please refresh the page and try again.');
                 }
-                const csrfToken = csrfMeta.getAttribute('content');
 
                 // Get username from form
                 const usernameInput = document.querySelector('input[name="username"]');


### PR DESCRIPTION
This pull request improves the robustness of the CSRF token retrieval logic in the login templates by adding error handling if the CSRF meta tag is missing. This prevents potential runtime errors and provides a clearer error message to users in case the CSRF token is not found.

Error handling improvements:

* Added a check to ensure the CSRF meta tag exists before accessing its `content` attribute in both `admin_login.html` and `system_admin_login.html`, throwing a descriptive error if not found. [[1]](diffhunk://#diff-450972337b202221ae4fdd396c52d02a3ed6abe399831ca26752fdbce26c2045L234-R238) [[2]](diffhunk://#diff-5f798be19d5b42ffcd6092176cf1921bf320b6dfd69bdd4eb1efdf5610d15e8cL229-R233)