### PR TITLE
Exempt auth-check route from rate limiting

### DIFF
--- a/app/routes/system_admin.py
+++ b/app/routes/system_admin.py
@@ -141,7 +141,7 @@ def _tail_log_lines(file_path: str, max_lines: int = 200, chunk_size: int = 8192
 # -------------------- AUTHENTICATION --------------------
 
 @sysadmin_bp.route('/auth-check', methods=['GET'])
-@limiter.limit("100 per minute")
+@limiter.exempt
 def auth_check():
     """Internal auth probe for Nginx `auth_request`.
 


### PR DESCRIPTION
Remove rate limiting from the internal authentication check route to allow unrestricted access for Nginx authentication purposes. This change ensures that the route can be accessed without hitting rate limits.

Rationale
Current server secruity postures:
	•	Cloudflare in front: Already filters bots, L7 DDoS, rate-based attacks, etc.
	•	DigitalOcean firewall rules: Only allowing inbound traffic from Cloudflare IP ranges + SSH
	•	Nginx auth_request: Only triggers on legitimate authenticated subrequests, not externally exposed endpoints
	•	Session-based validation: Flask session must already be valid, or the /auth-check returns 401
the /auth-check endpoint isn’t exploitable externally. No one can spam it without already having a session, and no unauthenticated user can brute force their way through this gate — Cloudflare and your NGINX will block them far earlier.