### PR TITLE
Fix: Properly destructure passwordless.dev SDK response in signinWithDiscoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows semantic versioning principles.
 ### Fixed
 - **Content Security Policy** - Restored `'unsafe-eval'` directive to `script-src` CSP policy as it is required by passwordless.dev library's minified build (uses `new Function()` internally)
 - **Passkey Authentication** - Fixed environment variables not loading in production by ensuring gunicorn systemd service has `EnvironmentFile` directive to load `.env` file
+- **Passkey Authentication** - Fixed token destructuring in `signinWithDiscoverable()` to properly handle error responses from passwordless.dev SDK
 
 ## [1.5.0] - 2025-12-29
 

--- a/static/js/passkey_login.js
+++ b/static/js/passkey_login.js
@@ -190,7 +190,12 @@ function setupPasskeyAuthFlow({
             }
 
             const client = new Passwordless.Client({ apiUrl: 'https://v4.passwordless.dev' });
-            const token = await client.signinWithDiscoverable(options);
+            const { token, error } = await client.signinWithDiscoverable(options);
+
+            if (error) {
+                console.error('Passwordless.dev error:', error);
+                throw new Error(error.title || error.detail || 'Authentication failed');
+            }
 
             if (!token) {
                 throw new Error('Authentication was cancelled or failed');


### PR DESCRIPTION
## Description

Fixes passkey authentication token handling by properly destructuring the passwordless.dev SDK response.

## Problem

Backend error logs showed:
```
The token you sent was not correct. The token used for this endpoint should 
start with 'verify_'. The value you sent started with '{'error': '
```

**Root Cause**: 
- passwordless.dev JavaScript SDK returns `{ token, error }` from `signinWithDiscoverable()`
- Code was treating the entire response object as the token
- Error objects were being sent to the backend as verification tokens

## Solution

Changed the response handling to properly destructure the SDK response:

**Before:**
```javascript
const token = await client.signinWithDiscoverable(options);

if (!token) {
    throw new Error('Authentication was cancelled or failed');
}
```

**After:**
```javascript
const { token, error } = await client.signinWithDiscoverable(options);

if (error) {
    console.error('Passwordless.dev error:', error);
    throw new Error(error.title || error.detail || 'Authentication failed');
}

if (!token) {
    throw new Error('Authentication was cancelled or failed');
}
```

This pattern matches existing code in:
- `signinWithAlias()` in the same file (passkey_login.js:50)
- `p.register()` in admin_passkey_settings.html:160
- `p.register()` in system_admin_passkey_settings.html:160

**Changes**:
- `static/js/passkey_login.js` - Fix SDK response destructuring
- `CHANGELOG.md` - Document the fix

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Verify passkey authentication no longer sends error objects as tokens
- [x] Confirm proper error messages displayed when authentication fails
- [x] Test successful passkey authentication flow
- [x] Verify error handling matches existing patterns in codebase

## Impact

- **Fixes**: Invalid token errors during passkey authentication
- **Risk**: Very low - follows existing pattern used in other parts of the codebase
- **Rollback**: Simple revert if needed

## Dependencies

Requires PR #756 (gunicorn environment loading) to be merged first for complete passkey authentication functionality.

---

**Merge Priority**: HIGH - Part of passkey authentication fix series