### PR TITLE
Add comprehensive documentation system and contextual help

### DIFF
--- a/templates/docs/view.html
+++ b/templates/docs/view.html
@@ -30,21 +30,12 @@
                     </div>
 
                     <!-- Docs Home (always show) -->
-                    {% if session.get('student_id') or session.get('admin_id') or session.get('sysadmin_id') %}
                     <div class="mb-3">
-                        <a href="{{ url_for('docs.index') }}" class="btn btn-sm btn-outline-secondary w-100">
+                        <a href="{{ url_for('docs.index') }}" class="btn btn-sm {% if session.get('student_id') or session.get('admin_id') or session.get('sysadmin_id') %}btn-outline-secondary{% else %}btn-primary{% endif %} w-100">
                             <span class="material-symbols-outlined icon-align">home</span>
                             Docs Home
                         </a>
                     </div>
-                    {% else %}
-                    <div class="mb-3">
-                        <a href="{{ url_for('docs.index') }}" class="btn btn-sm btn-primary w-100">
-                            <span class="material-symbols-outlined icon-align">home</span>
-                            Docs Home
-                        </a>
-                    </div>
-                    {% endif %}
 
                     <!-- Search -->
                     <form action="{{ url_for('docs.search') }}" method="get" class="mb-3">
@@ -170,7 +161,7 @@
                             {% endif %}
 
                             <!-- Markdown Content -->
-                            <div class="markdown-content">
+                            <div class="markdown-content{% if toc %} markdown-content-with-toc{% endif %}">
                                 {{ content | safe }}
                             </div>
 
@@ -279,7 +270,7 @@
 }
 
 /* Override max-width when TOC is present */
-.col-lg-9 .markdown-content {
+.markdown-content-with-toc {
     max-width: none;
 }
 


### PR DESCRIPTION
## Description

Implement a new documentation system that converts markdown to HTML, enhancing user access to feature-specific guides and contextual help links throughout the application. This update includes a responsive design, breadcrumb navigation, and a search functionality for improved user experience.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

If **Yes**, confirm:

- [ ] Synced with `main` branch immediately before running `flask db migrate`
- [ ] Migration file reviewed and verified correct `down_revision`
- [ ] Tested `flask db upgrade` successfully
- [ ] Tested `flask db downgrade` successfully
- [ ] Confirmed only ONE migration head exists (pre-push hook should verify this)
- [ ] Migration has a descriptive message/filename
- [ ] Breaking changes or data migrations documented in PR description

**Migration file location:**
<!-- e.g., migrations/versions/abc123_add_user_email.py -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

<!-- Link any related issues here -->

Closes #

## Additional Notes

<!-- Any additional information that reviewers should know -->

