### PR TITLE
Remove 'All classes' view from Economy Health - always show per-class CWI

### DIFF
--- a/templates/admin_economy_health.html
+++ b/templates/admin_economy_health.html
@@ -109,7 +109,7 @@
     {% if blocks|length > 1 %}
     <div class="d-flex align-items-center gap-2">
       <label for="classSelector" class="text-muted mb-0">Class:</label>
-      <select id="classSelector" class="form-select form-select-sm" style="width: auto;" onchange="window.location.href='{{ url_for('admin.economy_health') }}?block=' + this.value">
+      <select id="classSelector" class="form-select form-select-sm" style="width: auto;" onchange="window.location.href='{{ url_for('admin.economy_health') }}?block=' + encodeURIComponent(this.value)">
         {% for block in blocks %}
         <option value="{{ block }}" {% if selected_block == block %}selected{% endif %}>{{ block }}</option>
         {% endfor %}


### PR DESCRIPTION
The 'All classes' view was attempting to use global payroll settings
(block=None) which never exist by design in the multi-tenancy
architecture. CWI is inherently per-class since each class period has
its own join_code and payroll settings.

Changes:
Backend (app/routes/admin.py):
- Removed scope parameter and global_payroll_settings logic
- Always default to per-class view with first available class
- Simplified fallback logic to use first class when no specific block selected
- Removed has_global_payroll_settings variable

Frontend (templates/admin_economy_health.html):
- Removed "All classes" vs "Individual class" toggle buttons
- Added simple class dropdown selector (only shown when multiple classes exist)
- Removed misleading "needs global payroll settings" warning
- Removed "Switch Between Scopes" help section
- Updated help text to reflect per-class nature of CWI
- Removed redundant class selector from CWI card
- Simplified URLs to remove scope parameter

This fixes the issue where Economy Health showed confusing warnings
about needing global settings even when valid class-specific payroll
settings existed. Now the page always shows CWI for a specific class
and users can switch between classes using the dropdown.

Resolves issue with Economy Health not recognizing payroll settings

