### PR TITLE
Validate analytics snapshot window types and clean up analytics dashboard script

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1843,9 +1843,9 @@ class AnalyticsSnapshot(db.Model):
     avg_student_balance = db.Column(db.Float, nullable=True)  # Average balance (for CWI comparison only)
     
     # Drift & Anomaly Indicators (Trend-based)
-    balance_trend = db.Column(db.String(20), nullable=True)  # 'improving', 'stable', 'worsening'
+    balance_trend = db.Column(db.String(20), nullable=True)  # 'increasing', 'stable', 'decreasing'
     velocity_trend = db.Column(db.String(20), nullable=True)  # 'increasing', 'stable', 'decreasing'
-    participation_trend = db.Column(db.String(20), nullable=True)  # 'improving', 'stable', 'declining'
+    participation_trend = db.Column(db.String(20), nullable=True)  # 'increasing', 'stable', 'decreasing'
     
     # Additional context (non-student-identifying)
     total_students = db.Column(db.Integer, nullable=False)  # Total enrolled students
@@ -1916,5 +1916,4 @@ class AnalyticsEvent(db.Model):
     
     def __repr__(self):
         return f'<AnalyticsEvent {self.event_type} on {self.event_date.date()} for {self.join_code}>'
-
 

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -284,6 +284,9 @@ def api_snapshot(window_type):
     
     if not join_code:
         return jsonify({'error': 'No class period selected'}), 400
+
+    if window_type not in ALLOWED_WINDOW_TYPES:
+        return jsonify({'error': 'Invalid window type'}), 400
     
     # Calculate time window
     window_start, window_end = get_time_window(window_type, teacher_id, join_code)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project follows semantic versioning principles.
   - **After**: Same search returns only 15 user-facing results, filtering out 27 internal documents
 
 ### Fixed
+- **Analytics Snapshot API Validation** - Reject invalid analytics window types to keep snapshot endpoints aligned with supported time windows.
+- **Analytics Dashboard Script Cleanup** - Removed unused class-switcher script to match the dropdown-based selector.
 - **Documentation Table of Contents** - Added YAML front matter to all main documentation files to fix table of contents display showing directory paths instead of proper titles
   - Updated: Student Guide, Teacher Manual, Architecture Guide, API Reference, Database Schema, Changelog, Deployment Guide
 

--- a/templates/admin_analytics_dashboard.html
+++ b/templates/admin_analytics_dashboard.html
@@ -424,16 +424,6 @@
 </style>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    const classSelect = document.getElementById('analyticsClassSelect');
-    if (classSelect) {
-      classSelect.addEventListener('change', () => {
-        const baseUrl = classSelect.dataset.switchUrl || "{{ url_for('analytics.dashboard') }}";
-        const targetUrl = new URL(baseUrl, window.location.origin);
-        targetUrl.searchParams.set('join_code', classSelect.value);
-        window.location.assign(targetUrl.toString());
-      });
-    }
-
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
     [...tooltipTriggerList].map((tooltipTriggerEl) => new bootstrap.Tooltip(tooltipTriggerEl));
   });


### PR DESCRIPTION
### Motivation
- Align the analytics snapshot API with the technical analytics spec by ensuring only supported time windows are accepted via the endpoint.
- Remove dead UI script that previously attempted to switch class periods in the dashboard to match the template's dropdown-based selector.
- Standardize trend label wording to use consistent directionality (`increasing`/`stable`/`decreasing`) across analytics models and outputs.
- Keep release notes accurate by documenting the above fixes in the changelog.

### Description
- Add validation in `api_snapshot` to reject `window_type` values not in `ALLOWED_WINDOW_TYPES` and return a `400` error for invalid values.
- Remove the unused analytics class-switcher script from `templates/admin_analytics_dashboard.html` and retain tooltip initialization logic.
- Update `AnalyticsSnapshot` trend field comments in `app/models.py` to use consistent labels (`increasing`, `stable`, `decreasing`) for `balance_trend` and `participation_trend`.
- Add changelog entries in `docs/CHANGELOG.md` describing the snapshot API validation and dashboard script cleanup.

### Testing
- Ran `pytest -q` locally; test collection failed with an `ImportError` in `tests/test_comprehensive_legacy_migration.py` due to a missing `hash_password` export from `hash_utils`, so full test suite did not complete.
- Confirmed the analytics dashboard template renders without the removed class-switcher script in a local dev server smoke check (no automated test).
- No database migrations were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e0786e53083339e290590e8d0fb0f)