### PR TITLE
Enhance unclaimed seats tracking to exclude seats linked to a student

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1967,7 +1967,11 @@ def students():
                 unclaimed_seats_by_block[block_name] = 0
 
             # Track unclaimed seats (excluding legacy placeholders and seats already linked to a student)
-            if not tb.is_claimed and tb.first_name != LEGACY_PLACEHOLDER_FIRST_NAME and tb.student_id is None:
+            if (
+                not tb.is_claimed
+                and tb.first_name != LEGACY_PLACEHOLDER_FIRST_NAME
+                and tb.student_id is None
+            ):
                 unclaimed_seats_list_by_block[block_name].append(tb)
                 unclaimed_seats_by_block[block_name] += 1
 


### PR DESCRIPTION
This pull request makes a small but important change to the logic for tracking unclaimed seats in the `students` route. The update ensures that seats already linked to a student are not incorrectly counted as unclaimed.

- Improved seat tracking: Updated the condition to exclude seats already linked to a student (`tb.student_id is None`) when determining unclaimed seats, in addition to previous checks for claim status and legacy placeholders.