### PR TITLE
Allow embedding of public hall pass display pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ and this project follows semantic versioning principles.
   - Created `_calculate_base_rent_amount()` helper to avoid code duplication
   - Used in both payroll warning calculation and unpaid students calculation
   - Follows DRY principle for better maintainability
-- **CSP Headers for Public Hall Pass Pages** - Modified Content Security Policy to allow embedding for public hall pass display pages
-  - `/hall-pass/terminal`, `/hall-pass/verification`, and `/hall-pass/queue` can now be embedded in external sites (e.g., Schoology, Canvas)
-  - These pages are already public, read-only, and contain no forms or authenticated actions
+- **CSP Headers for Public Hall Pass Pages** - Modified Content Security Policy to allow embedding for read-only hall pass display pages
+  - `/hall-pass/verification` and `/hall-pass/queue` can now be embedded in external sites (e.g., Schoology, Canvas)
+  - These pages are public, read-only displays with no state-changing actions
+  - `/hall-pass/terminal` remains protected (not embeddable) as it performs state-changing check-in/check-out actions
   - Removed `X-Frame-Options` header for embeddable pages and added `frame-ancestors *` to CSP
   - All other pages remain protected with `X-Frame-Options: SAMEORIGIN` and `frame-ancestors 'self'`
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -561,8 +561,8 @@ def create_app():
 
         # Public embeddable pages (hall pass displays for classroom use)
         # These pages are public, read-only, and safe to embed in LMS/other sites
+        # NOTE: /hall-pass/terminal is NOT embeddable as it performs state-changing actions
         embeddable_paths = [
-            '/hall-pass/terminal',
             '/hall-pass/verification',
             '/hall-pass/queue'
         ]


### PR DESCRIPTION
Modified CSP headers to enable embedding of the three public hall pass
pages in external sites like Schoology or Canvas:
- /hall-pass/verification (recent history)
- /hall-pass/queue (queue display)

Changes:
- Skip X-Frame-Options header for embeddable pages
- Add frame-ancestors * to CSP for embeddable pages
- Add frame-ancestors 'self' to CSP for all other pages
- All other security headers remain unchanged

These pages are already public, read-only, and contain no forms or
authenticated actions, making them safe to embed without introducing
clickjacking risk.