### PR TITLE
Refactor multi-tenancy to fix Phase A.0 blockers

### DIFF
--- a/app/routes/student.py
+++ b/app/routes/student.py
@@ -196,17 +196,30 @@ def get_feature_settings_for_student():
         return FeatureSettings.get_defaults()
 
     current_block = (context.get('block') or '').strip().upper() or None
+    join_code = context.get('join_code')
 
-    # Try block-specific settings first
-    if current_block:
+    # Try block-specific settings first (scoped by join_code)
+    if current_block and join_code:
         block_settings = FeatureSettings.query.filter_by(
-            teacher_id=teacher_id,
+            join_code=join_code,
             block=current_block
         ).first()
         if block_settings:
             return block_settings.to_dict()
 
     # Fall back to global settings for this teacher
+    # Note: Global settings (block=None) might not have a join_code if they apply to all of a teacher's classes
+    # But we should prefer one linked to this join_code if it exists (e.g. class-wide default)
+    if join_code:
+        class_settings = FeatureSettings.query.filter_by(
+            join_code=join_code,
+            block=None
+        ).first()
+        if class_settings:
+            return class_settings.to_dict()
+
+    # Final fallback: Teacher global (no block, no join_code or just teacher_id)
+    # This maintains backward compatibility for settings created before join_code association
     global_settings = FeatureSettings.query.filter_by(
         teacher_id=teacher_id,
         block=None

--- a/tests/test_feature_settings.py
+++ b/tests/test_feature_settings.py
@@ -315,6 +315,8 @@ class TestTeacherDeletionCascade:
 
     def test_teacher_blocks_cascade_on_teacher_delete(self, client_with_fk):
         """Test that TeacherBlocks are CASCADE deleted when teacher is deleted."""
+        from app.models import ClassEconomy
+
         # Create a teacher
         admin = Admin(
             username='blocks_cascade_test',
@@ -323,6 +325,13 @@ class TestTeacherDeletionCascade:
         db.session.add(admin)
         db.session.commit()
         teacher_id = admin.id
+
+        # Ensure ClassEconomy exists for FK constraints
+        if not ClassEconomy.query.get('TEST123'):
+            db.session.add(ClassEconomy(join_code='TEST123', display_name='Class TEST123'))
+        if not ClassEconomy.query.get('TEST456'):
+            db.session.add(ClassEconomy(join_code='TEST456', display_name='Class TEST456'))
+        db.session.commit()
 
         # Create teacher blocks
         # PIIEncryptedType will handle encryption automatically

--- a/tests/test_tap_flow.py
+++ b/tests/test_tap_flow.py
@@ -13,9 +13,14 @@ def parse_server_state(html):
     return json.loads(script.string)
 
 def create_claimed_seat(teacher_id, student_id, block, join_code, salt=None):
-    from app.models import TeacherBlock
+    from app.models import TeacherBlock, ClassEconomy
     if salt is None:
         salt = get_random_salt()
+
+    # Ensure ClassEconomy exists for FK constraint
+    if not ClassEconomy.query.get(join_code):
+        db.session.add(ClassEconomy(join_code=join_code, display_name=f"Class {join_code}"))
+        db.session.flush()
 
     tb = TeacherBlock(
         teacher_id=teacher_id,


### PR DESCRIPTION
## Schema Change Gate Classification (required for schema changes)

<!--
Required if this PR modifies app/models.py, app/models/**, or migrations/versions/**.
Select exactly one classification for schema-affecting changes.
-->

- [x] **EXPAND** – Additive, backward-compatible (no removals)
- [ ] **CONTRACT (CODE ONLY)** – Model attribute removal, DB schema unchanged
- [ ] **CONTRACT (DATABASE)** – Destructive migration only
- [ ] 
This pull request primarily improves how feature settings are retrieved for students by enhancing the logic to prefer settings associated with a `join_code`, and updates tests to ensure that foreign key constraints are satisfied by creating necessary `ClassEconomy` records. The changes help ensure more accurate settings retrieval and more robust test setup.

**Feature settings retrieval improvements:**

* Updated `get_feature_settings_for_student` in `student.py` to first check for block-specific settings scoped by `join_code`, then fall back to class-wide settings for the `join_code`, and finally to global teacher settings, maintaining backward compatibility.

**Test robustness and FK constraint handling:**

* Modified test utility `create_claimed_seat` in `test_tap_flow.py` to ensure a `ClassEconomy` record exists for the given `join_code` before creating a `TeacherBlock`, preventing FK errors.
* Updated `test_teacher_blocks_cascade_on_teacher_delete` in `test_feature_settings.py` to create necessary `ClassEconomy` records for the tested `join_code`s, ensuring foreign key constraints are satisfied. [[1]](diffhunk://#diff-768ec7e25a33f082ba3a0393961749ba5775b876d8c13df7f398b0e73912492dR318-R319) [[2]](diffhunk://#diff-768ec7e25a33f082ba3a0393961749ba5775b876d8c13df7f398b0e73912492dR329-R335)
