### PR TITLE
Fix join-code-scoped orphan cleanup and harden redemption-audit migration

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -335,7 +335,8 @@ def _hard_delete_join_code_scope(join_code, teacher_id):
 
     # Remove students that no longer belong to any class after this join-code deletion.
     remaining_student_ids_subq = db.session.query(TeacherBlock.student_id).filter(
-        TeacherBlock.student_id.isnot(None)
+        TeacherBlock.student_id.isnot(None),
+        TeacherBlock.join_code != join_code,
     ).subquery()
     orphan_student_ids = (
         db.session.query(Student.id)

--- a/migrations/versions/a9b8c7d6e5f4_add_redemption_audit_logs.py
+++ b/migrations/versions/a9b8c7d6e5f4_add_redemption_audit_logs.py
@@ -108,5 +108,9 @@ def upgrade():
 
 
 def downgrade():
-    # IRREVERSIBLE: redemption_audit_logs is append-only and must not be removed or contracted.
-    pass
+    raise RuntimeError(
+        "Downgrade is not supported for migration a9b8c7d6e5f4. "
+        "The redemption_audit_logs table is append-only and must not be removed or "
+        "contracted. If a downgrade is required, manually drop related indexes and "
+        "enum types before adjusting the Alembic revision."
+    )

--- a/migrations/versions/b0c1d2e3f4a5_merge_redemption_audit_with_current_head.py
+++ b/migrations/versions/b0c1d2e3f4a5_merge_redemption_audit_with_current_head.py
@@ -4,10 +4,6 @@ Revision ID: b0c1d2e3f4a5
 Revises: 2765a36d76ff, a9b8c7d6e5f4
 Create Date: 2026-02-11 12:20:00.000000
 """
-from alembic import op
-import sqlalchemy as sa
-
-
 # revision identifiers, used by Alembic.
 revision = 'b0c1d2e3f4a5'
 down_revision = ('2765a36d76ff', 'a9b8c7d6e5f4')

--- a/tests/test_collective_goal_progress.py
+++ b/tests/test_collective_goal_progress.py
@@ -143,7 +143,7 @@ def test_admin_store_shows_collective_progress(client):
     db.session.flush()
 
     student_a1 = _create_student(teacher, 'Ana', 'JOINADMINA', block='A')
-    student_a2 = _create_student(teacher, 'Bo', 'JOINADMINA', block='A')
+    _create_student(teacher, 'Bo', 'JOINADMINA', block='A')
     db.session.flush()
 
     item = StoreItem(


### PR DESCRIPTION
### Motivation

- Fix a join-code hard-delete bug where students unique to the deleted class were not being detected as orphans and therefore were not cleaned up.
- Make irreversible migration behavior explicit to avoid confusing or unsafe downgrade attempts for append-only audit data.
- Address review/lint feedback by removing minor unused symbols in a merge migration and a test helper.

### Description

- Adjusted the join-code hard-delete cleanup in `_hard_delete_join_code_scope` to exclude the `join_code` being deleted when computing `remaining_student_ids_subq`, ensuring students belonging only to the deleted class are identified for removal; file: `app/routes/admin.py`.
- Replaced the silent `pass` in the migration `downgrade()` with an explicit `RuntimeError` and message in `migrations/versions/a9b8c7d6e5f4_add_redemption_audit_logs.py` to prevent accidental/dangerous downgrades of an append-only audit table.
- Removed unused imports from the merge migration `migrations/versions/b0c1d2e3f4a5_merge_redemption_audit_with_current_head.py` and removed an unused test variable in `tests/test_collective_goal_progress.py` to satisfy reviewer lint comments.
- Applied small test and migration hygiene edits called out in the review to keep the codebase consistent with the deletion semantics and migration checklist.

### Testing

- Ran the full test suite with `pytest -v`; result: `402 passed, 1 skipped, 2 warnings`.
- Verified the join-code deletion semantics tests and the legacy bulk-deletion tests were passing as part of the run.
- No new test failures introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d4f4698188333b1d4463350448122)