### PR TITLE
Keep recovery seat claimed, show reset code on student detail, and improve recovery mobile UX

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,6 +21,14 @@
 
 ---
 
+## In Progress (Unreleased)
+
+- Fixed student recovery identity updates to preserve claimed class seats, preventing post-claim "No class selected" errors on next login.
+- Updated teacher reset flow to redirect to Student Detail after generating a reset code, where the active code remains visible until expiration.
+- Improved mobile responsiveness for student recovery pages by tightening spacing and collapsing the right panel on small screens.
+
+---
+
 ## Recent Releases
 
 ### ✅ Version 1.8.0 - February 9, 2026

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2456,8 +2456,16 @@ def student_detail(student_id):
                 if teacher_block.join_code:
                     join_codes[teacher_block.block] = teacher_block.join_code
 
+    reset_code_is_active = bool(
+        student.reset_code
+        and student.reset_code_expires_at
+        and ensure_utc(student.reset_code_expires_at) >= utc_now()
+        and student.recovery_status == 'to_be_claimed'
+    )
+
     return render_template('student_detail.html',
                          student=student,
+                         reset_code_is_active=reset_code_is_active,
                          join_codes=join_codes,
                          transactions=transactions,
                          student_items=student_items,
@@ -2734,6 +2742,9 @@ def edit_student():
         db.session.rollback()
         current_app.logger.error(f"Error updating student {student_id}", exc_info=True)
         flash("Error updating student due to internal error", "error")
+
+    if reset_login:
+        return redirect(url_for('admin.student_detail', student_id=student.id))
 
     return redirect(url_for('admin.students'))
 

--- a/app/routes/recovery.py
+++ b/app/routes/recovery.py
@@ -226,8 +226,10 @@ def verify_identity():
             teacher_block.dob_sum = student.dob_sum or 0
             teacher_block.salt = new_salt
             teacher_block.first_half_hash = student.first_half_hash
-            teacher_block.is_claimed = False
-            teacher_block.claimed_at = None
+            # Keep the seat claimed for this student so they can log in immediately
+            # after completing credential setup without losing class context.
+            teacher_block.is_claimed = True
+            teacher_block.claimed_at = teacher_block.claimed_at or utc_now()
 
         db.session.commit()
 

--- a/templates/student/recovery/layout.html
+++ b/templates/student/recovery/layout.html
@@ -84,6 +84,29 @@
         .back-link:hover {
             color: var(--primary);
         }
+
+        @media (max-width: 768px) {
+            body {
+                align-items: flex-start;
+                padding: 0.75rem;
+            }
+            .login-container {
+                flex-direction: column;
+                min-height: auto;
+                border-radius: 0.75rem;
+                margin: 0;
+            }
+            .login-left {
+                padding: 1.25rem;
+            }
+            .login-right {
+                display: none;
+            }
+            .btn-lg {
+                padding: 0.85rem 1rem;
+                font-size: 1rem;
+            }
+        }
     </style>
 </head>
 <body class="student-theme">

--- a/templates/student_detail.html
+++ b/templates/student_detail.html
@@ -239,7 +239,7 @@
                         </table>
 
                         <!-- Active Recovery Code Display -->
-                        {% if student.recovery_status == 'to_be_claimed' and student.reset_code %}
+                        {% if reset_code_is_active %}
                         <div class="alert alert-danger mt-3 border-danger shadow-sm">
                             <h6 class="alert-heading fw-bold">
                                 <i class="bi bi-shield-exclamation me-2"></i>Account Recovery In Progress

--- a/tests/test_student_recovery.py
+++ b/tests/test_student_recovery.py
@@ -259,6 +259,34 @@ def test_verify_identity_updates_pii_and_clears_credentials(client, recovery_dat
     assert student.recovery_status == 'to_be_claimed'
 
 
+def test_verify_identity_keeps_teacher_block_claimed(client, recovery_data):
+    """Recovery identity update must preserve claimed seat status for login class context."""
+    student = recovery_data["student"]
+    teacher = recovery_data["teacher"]
+
+    student.reset_code = "KEEPCLM1"
+    student.reset_code_expires_at = utc_now() + timedelta(minutes=10)
+    student.recovery_status = 'to_be_claimed'
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["recovery_student_id"] = student.id
+        sess["recovery_teacher_id"] = teacher.id
+
+    resp = client.post("/recovery/verify-identity", data={
+        "first_name": "Claimed",
+        "last_name": "Seat",
+        "dob": "2012-01-05",
+    }, follow_redirects=False)
+
+    assert resp.status_code == 302
+
+    seat = TeacherBlock.query.filter_by(student_id=student.id, teacher_id=teacher.id, block='A').first()
+    assert seat is not None
+    assert seat.is_claimed is True
+    assert seat.claimed_at is not None
+
+
 def test_verify_identity_no_new_student_row(client, recovery_data):
     """Recovering an account must not create a new student row."""
     student = recovery_data["student"]


### PR DESCRIPTION
### Motivation

- Teachers reported the reset code toast disappeared too quickly, so the reset code should be visible on the student detail page for the full 10-minute lifetime so teachers can repeat it for students.
- Students who completed the recovery/claim flow were seeing a post-claim "No class selected" error because seats were being unclaimed during identity re-registration, breaking class context.
- Recovery pages were not mobile friendly and needed layout adjustments for small screens.

### Description

- Preserve claimed seat state during recovery by leaving `TeacherBlock.is_claimed = True` and ensuring `claimed_at` is set in `app/routes/recovery.py` so class context is retained after identity re-registration.
- Surface the active reset code on the teacher-facing student detail page by computing `reset_code_is_active` in `app/routes/admin.py` and passing it to the template, and redirect to `admin.student_detail` after generating a reset so the active code is visible instead of relying on a transient toast.
- Change the student detail template to render the recovery panel only while the reset code is still active (unexpired) using the new `reset_code_is_active` flag in `templates/student_detail.html`.
- Improve mobile responsiveness of the recovery flow by adding a small-screen media query to `templates/student/recovery/layout.html` that tightens spacing and hides the right panel for narrow viewports.
- Add a regression test `test_verify_identity_keeps_teacher_block_claimed` in `tests/test_student_recovery.py` to ensure claimed seats remain claimed after identity re-registration.
- Update `DEVELOPMENT.md` with an entry describing the in-progress fixes.

### Testing

- Ran the full test suite with `pytest -q` and all tests passed: `425 passed, 1 skipped` (the new regression test was included and passed).
- Local sanity checks were performed by rendering the student detail view with an active reset code to verify the code is shown for the expected duration and mobile layout adjustments were validated in a narrow viewport.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f7012ab848333a761c5b8afbb2b80)