### PR TITLE
Optimize orphaned StoreItemBlock cleanup and add regression test

### DIFF
--- a/app/scheduled_tasks.py
+++ b/app/scheduled_tasks.py
@@ -135,6 +135,7 @@ def database_maintenance_job():
     Runs at 2 AM UTC to clean up orphaned entries and maintain data integrity.
     """
     # Import here to avoid circular imports
+    from sqlalchemy import and_, or_, tuple_
     from app.models import StoreItemBlock, TeacherBlock, StoreItem
     from app.extensions import db
 
@@ -148,47 +149,46 @@ def database_maintenance_job():
         # These are blocks that reference classes that no longer exist
         logger.info("Checking for orphaned StoreItemBlock entries...")
         
-        # Get all unique store item blocks
-        all_store_blocks = db.session.query(
-            StoreItemBlock.store_item_id,
-            StoreItemBlock.block
-        ).distinct().all()
-        
-        orphaned_store_blocks = []
-        
-        for store_item_id, block in all_store_blocks:
-            # Get the teacher_id for this store item
-            store_item = db.session.get(StoreItem, store_item_id)
-            if not store_item:
-                # Store item doesn't exist, this is orphaned
-                orphaned_store_blocks.append((store_item_id, block))
-                continue
-            
-            # Check if a TeacherBlock exists for this teacher and block
-            teacher_block_exists = TeacherBlock.query.filter_by(
-                teacher_id=store_item.teacher_id,
-                block=block
-            ).first() is not None
-            
-            if not teacher_block_exists:
-                orphaned_store_blocks.append((store_item_id, block))
-        
-        if orphaned_store_blocks:
-            logger.info(f"Found {len(orphaned_store_blocks)} orphaned StoreItemBlock entries")
-            for store_item_id, block in orphaned_store_blocks:
-                try:
-                    deleted = StoreItemBlock.query.filter_by(
-                        store_item_id=store_item_id,
-                        block=block
-                    ).delete()
-                    total_cleaned += deleted
-                except Exception as e:
-                    logger.error(f"Error deleting StoreItemBlock({store_item_id}, {block}): {e}")
-                    db.session.rollback()
-                    continue
-            
+        orphaned_entries_subq = (
+            db.session.query(
+                StoreItemBlock.store_item_id.label("store_item_id"),
+                StoreItemBlock.block.label("block"),
+            )
+            .outerjoin(StoreItem, StoreItem.id == StoreItemBlock.store_item_id)
+            .outerjoin(
+                TeacherBlock,
+                and_(
+                    TeacherBlock.teacher_id == StoreItem.teacher_id,
+                    TeacherBlock.block == StoreItemBlock.block,
+                ),
+            )
+            .filter(
+                or_(
+                    StoreItem.id.is_(None),
+                    TeacherBlock.id.is_(None),
+                )
+            )
+            .distinct()
+            .subquery()
+        )
+
+        orphaned_count = db.session.query(orphaned_entries_subq).count()
+        if orphaned_count:
+            logger.info("Found %s orphaned StoreItemBlock entries", orphaned_count)
+            total_cleaned = (
+                StoreItemBlock.query
+                .filter(
+                    tuple_(StoreItemBlock.store_item_id, StoreItemBlock.block).in_(
+                        db.session.query(
+                            orphaned_entries_subq.c.store_item_id,
+                            orphaned_entries_subq.c.block,
+                        )
+                    )
+                )
+                .delete(synchronize_session=False)
+            )
             db.session.commit()
-            logger.info(f"Cleaned up {len(orphaned_store_blocks)} orphaned StoreItemBlock entries")
+            logger.info("Cleaned up %s orphaned StoreItemBlock entries", total_cleaned)
         else:
             logger.info("No orphaned StoreItemBlock entries found")
 

--- a/scripts/cleanup_orphaned_store_blocks.py
+++ b/scripts/cleanup_orphaned_store_blocks.py
@@ -11,55 +11,67 @@ Usage:
 
 from app.extensions import db
 from app.models import StoreItemBlock, TeacherBlock, StoreItem
+from sqlalchemy import and_, or_, tuple_
 
 def cleanup_orphaned_store_blocks():
     """Remove StoreItemBlock entries for non-existent classes."""
-    
-    # Get all unique blocks from StoreItemBlock
-    all_store_blocks = db.session.query(
-        StoreItemBlock.store_item_id,
-        StoreItemBlock.block
-    ).distinct().all()
-    
-    orphaned_entries = []
-    
-    for store_item_id, block in all_store_blocks:
-        # Get the teacher_id for this store item
-        store_item = db.session.get(StoreItem, store_item_id)
-        if not store_item:
-            # Store item doesn't exist, this is orphaned
-            orphaned_entries.append((store_item_id, block))
-            continue
-        
-        # Check if a TeacherBlock exists for this teacher and block
-        teacher_block_exists = TeacherBlock.query.filter_by(
-            teacher_id=store_item.teacher_id,
-            block=block
-        ).first() is not None
-        
-        if not teacher_block_exists:
-            orphaned_entries.append((store_item_id, block))
-    
+
+    orphaned_entries_subq = (
+        db.session.query(
+            StoreItemBlock.store_item_id.label("store_item_id"),
+            StoreItemBlock.block.label("block"),
+        )
+        .outerjoin(StoreItem, StoreItem.id == StoreItemBlock.store_item_id)
+        .outerjoin(
+            TeacherBlock,
+            and_(
+                TeacherBlock.teacher_id == StoreItem.teacher_id,
+                TeacherBlock.block == StoreItemBlock.block,
+            ),
+        )
+        .filter(
+            or_(
+                StoreItem.id.is_(None),
+                TeacherBlock.id.is_(None),
+            )
+        )
+        .distinct()
+        .subquery()
+    )
+
+    orphaned_entries = db.session.query(
+        orphaned_entries_subq.c.store_item_id,
+        orphaned_entries_subq.c.block,
+    ).all()
+
     if not orphaned_entries:
         print("No orphaned StoreItemBlock entries found.")
         return 0
-    
+
     print(f"Found {len(orphaned_entries)} orphaned StoreItemBlock entries:")
     for store_item_id, block in orphaned_entries:
         print(f"  - StoreItem ID {store_item_id}, Block '{block}'")
-    
-    # Delete orphaned entries
-    deleted_count = 0
-    for store_item_id, block in orphaned_entries:
-        result = StoreItemBlock.query.filter_by(
-            store_item_id=store_item_id,
-            block=block
-        ).delete()
-        deleted_count += result
-    
-    db.session.commit()
-    print(f"\nSuccessfully deleted {deleted_count} orphaned StoreItemBlock entries.")
-    return deleted_count
+
+    try:
+        deleted_count = (
+            StoreItemBlock.query
+            .filter(
+                tuple_(StoreItemBlock.store_item_id, StoreItemBlock.block).in_(
+                    db.session.query(
+                        orphaned_entries_subq.c.store_item_id,
+                        orphaned_entries_subq.c.block,
+                    )
+                )
+            )
+            .delete(synchronize_session=False)
+        )
+        db.session.commit()
+        print(f"\nSuccessfully deleted {deleted_count} orphaned StoreItemBlock entries.")
+        return deleted_count
+    except Exception as exc:
+        db.session.rollback()
+        print(f"Cleanup failed: {exc}")
+        raise
 
 if __name__ == "__main__":
     cleanup_orphaned_store_blocks()

--- a/tests/test_scheduled_tasks_store_item_cleanup.py
+++ b/tests/test_scheduled_tasks_store_item_cleanup.py
@@ -1,0 +1,56 @@
+from app.extensions import db
+from app.models import Admin, StoreItem, StoreItemBlock, TeacherBlock
+from app.scheduled_tasks import database_maintenance_job
+
+
+def _admin(username="teacher"):
+    admin = Admin(username=username, totp_secret="test-secret")
+    db.session.add(admin)
+    db.session.flush()
+    return admin
+
+
+def _teacher_block(teacher_id, block="A", join_code="JOINA"):
+    tb = TeacherBlock(
+        teacher_id=teacher_id,
+        block=block,
+        class_label=block,
+        first_name="Seat",
+        last_initial="S",
+        last_name_hash_by_part=["hash"],
+        dob_sum=1234,
+        salt=b"0123456789abcdef",
+        first_half_hash=f"hash-{teacher_id}-{block}",
+        join_code=join_code,
+        is_claimed=False,
+    )
+    db.session.add(tb)
+    return tb
+
+
+def test_database_maintenance_bulk_cleans_only_orphaned_store_item_blocks(app):
+    with app.app_context():
+        admin = _admin()
+        db.session.flush()
+
+        valid_item = StoreItem(teacher_id=admin.id, name="Valid", price=1, item_type="delayed")
+        orphan_item = StoreItem(teacher_id=admin.id, name="Orphan", price=2, item_type="delayed")
+        db.session.add_all([valid_item, orphan_item])
+        db.session.flush()
+
+        _teacher_block(admin.id, block="A", join_code="JOINA")
+        db.session.add_all([
+            StoreItemBlock(store_item_id=valid_item.id, block="A"),
+            StoreItemBlock(store_item_id=orphan_item.id, block="B"),
+        ])
+        db.session.commit()
+
+        database_maintenance_job()
+
+        remaining_blocks = {
+            (row.store_item_id, row.block)
+            for row in StoreItemBlock.query.order_by(StoreItemBlock.store_item_id).all()
+        }
+
+        assert (valid_item.id, "A") in remaining_blocks
+        assert (orphan_item.id, "B") not in remaining_blocks


### PR DESCRIPTION
### Motivation
- Address remaining review feedback from PR #956 that flagged N+1 queries and per-row delete loops when cleaning up orphaned `StoreItemBlock` entries.
- Improve reliability and observability of the nightly maintenance job so deletions are set-based and the logged counts reflect actual rows removed.
- Provide a small one-off script parity and regression coverage to prevent regressions in orphan-cleanup behavior.

### Description
- Refactored `database_maintenance_job()` in `app/scheduled_tasks.py` to detect orphaned `(store_item_id, block)` pairs via a set-based `outerjoin`/`subquery` and perform a single bulk delete using `tuple_` to avoid N+1 queries and per-row deletes, and adjusted logging to report actual deleted counts.
- Applied the same set-based detection and bulk-delete approach to the one-off cleanup script in `scripts/cleanup_orphaned_store_blocks.py`, added explicit error handling with rollback on failure, and imported `and_`, `or_`, and `tuple_` where needed.
- Added a focused regression test `tests/test_scheduled_tasks_store_item_cleanup.py` that asserts orphaned `StoreItemBlock` rows are removed while valid ones are preserved.

### Testing
- Ran the full test suite with `pytest -q` and observed `432 passed, 1 skipped` indicating no regressions after changes.
- Executed the new regression test (`tests/test_scheduled_tasks_store_item_cleanup.py`) as part of the suite and verified it passes and protects the orphan-cleanup behavior.
- Verified local linting/behavior by running the maintenance job in test context and confirming remaining `StoreItemBlock` entries are correct via assertions in the added test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991305d80988333a1349302772a23cc)