### PR TITLE
Address PR #1125 review comments

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -8202,6 +8202,7 @@ def apply_scheduled_economy_rebalance_now():
         change_plan,
         REBALANCE_ACTIVATION_IMMEDIATE,
     )
+    settings_row.economy_pending_rebalance_json = None
     db.session.commit()
     flash(f"Applied scheduled economy update now for {len(applied_labels)} setting(s).", "success")
     return redirect(url_for('admin.economy_health', block=selected_block))

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5180,7 +5180,7 @@ body.maintenance-active .sidebar {
     line-height: 1;
 }
 
-.economy-heath-page .info-icon {
+.economy-health-page .info-icon {
     font-size:0.5rem;
 }
 

--- a/templates/admin_economy_health.html
+++ b/templates/admin_economy_health.html
@@ -103,9 +103,8 @@
 <div class="container-fluid py-1 economy-health-page">
   <div class="d-flex flex-wrap  align-items-center mb-3 gap-3">
     <div class="d-flex align-items-center gap-2">
-      <p class="text-muted mb-0">Review your current CWI and see how payroll, rent, banking, insurance, and the store fit together.
-     
-      </p>
+      <p class="text-muted mb-0">Review your current CWI and see how payroll, rent, banking, insurance, and the store fit together.</p>
+      {{ help.help_icon("user-guides/diagnostics/teacher/attendance-payroll", "Economy health help") }}
     </div>
     {% if blocks|length >= 1 %}
     <div class="d-flex align-items-center gap-2">
@@ -131,22 +130,6 @@
 
   {% set balance_warning_count = warnings_by_level['critical']|length + warnings_by_level['warning']|length %}
   {% set non_banking_summary = health_warning_summary | rejectattr('label', 'equalto', 'Banking') | list %}
-  {% set quick_action = namespace(payroll=not payroll_settings, rent=false, insurance=false, store=false) %}
-  {% for level in ['critical', 'warning'] %}
-    {% for warning in warnings_by_level[level] %}
-      {% set feature_lower = warning.feature.lower() %}
-      {% if feature_lower.startswith('rent') %}
-        {% set quick_action.rent = true %}
-      {% elif feature_lower.startswith('insurance') %}
-        {% set quick_action.insurance = true %}
-      {% elif feature_lower.startswith('store') %}
-        {% set quick_action.store = true %}
-      {% elif feature_lower.startswith('fine') or feature_lower.startswith('budget survival test') %}
-        {% set quick_action.payroll = true %}
-      {% endif %}
-    {% endfor %}
-  {% endfor %}
-  {% set has_quick_actions = quick_action.payroll or quick_action.rent or quick_action.insurance or quick_action.store %}
 
   <div class="row g-3 mb-3">
     <div class="col-12 col-xl-6">
@@ -238,7 +221,7 @@
           <h5 class="mb-1"><span class="material-symbols-outlined me-2">tune</span>Economy Policy</h5>
           <p class="text-muted mb-0">Pick the classroom pressure profile, then optionally realign current settings.
              {% if policy_summary.updated_at %}
-          Last updated: {{ policy_summary.updated_at.strftime('%B %-d, %Y') if policy_summary.updated_at else '' }}
+          Last updated: {% if policy_summary.updated_at %}{{ policy_summary.updated_at.strftime('%B') }} {{ policy_summary.updated_at.day }}, {{ policy_summary.updated_at.year }}{% endif %}
           {% endif %}
           {% if selected_class_label %}
             <span class="fw-semibold">Currently viewing class: {{ selected_class_label }}</span>
@@ -298,7 +281,7 @@
 
         <div class="d-flex flex-wrap gap-2 align-items-center">
           <button class="btn btn-primary" type="submit">Save Policy Mode</button>
-          {% if policy_summary.pending_rebalance_json %}
+          {% if scheduled_rebalance %}
           <button class="btn btn-info" type="button" data-bs-toggle="modal" data-bs-target="#rebalanceReviewModal">Economy Update Scheduled</button>
           {% elif rebalance_preview %}
           <button class="btn btn-secondary" type="button" data-bs-toggle="modal" data-bs-target="#rebalanceReviewModal">Review Recommended Rebalance</button>
@@ -347,29 +330,30 @@
               <div class="row text-center g-2 mb-2">
             <div class="col-6">
               <div class="p-3 border rounded">
-                <div class="text-muted small">Pricing(s) that Requires Update</div>
+                <div class="text-muted small">Prices Requiring Update</div>
                 <div class="h4 mb-0 text-danger">{{ warnings_by_level['critical']|length }}</div>
               </div>
             </div>
             <div class="col-6">
               <div class="p-3 border rounded">
-                <div class="text-muted small">Pricing(s) that Needs Review</div>
+                <div class="text-muted small">Prices Needing Review</div>
                 <div class="h4 mb-0 text-warning">{{ warnings_by_level['warning']|length }}</div>
               </div>
             </div>
           </div>
               {% for row in non_banking_summary %}
               <div class="d-flex align-items-center mb-2 ">
-                <p class="mt-2 economy-health-page economy-health-item"><span class=" bg-light text-primary me-2 ">{{ row.label }}</span>
+                <p class="mt-2 economy-health-item"><span class=" bg-light text-primary me-2 ">{{ row.label }}</span>
                 {{ row.count }} pricing(s) might need adjustments.
                 {% if row.link_href %}
-                • <a href="{{ row.link_href }}" class="ms-1">{{ row.link_label }} <span class="material-symbols-outlined economy-health-inline-icon">arrow_circle_right</span></a></p>
+                • <a href="{{ row.link_href }}" class="ms-1">{{ row.link_label }} <span class="material-symbols-outlined economy-health-inline-icon">arrow_circle_right</span></a>
                 {% endif %}
+                </p>
               </div>
               {% endfor %}
-            {% else %}
+            {% elif balance_warning_count == 0 %}
             <div class="economy-health-empty-state economy-health-empty-state-centered">
-              <p class="text-muted mb-0">All princings are balanced within this economy</p>
+              <p class="text-muted mb-0">All pricings are balanced within this economy</p>
             </div>
 
             {% endif %}

--- a/tests/test_economy_policy_mode.py
+++ b/tests/test_economy_policy_mode.py
@@ -311,7 +311,7 @@ def test_update_economy_policy_creates_block_scoped_settings(client):
     })
 
     assert response.status_code == 302
-    assert 'review_rebalance=1' in response.location
+    assert 'economy-health' in response.location
 
     settings_row = FeatureSettings.query.filter_by(teacher_id=admin.id, block='A').first()
     assert settings_row is not None
@@ -842,3 +842,54 @@ def test_filter_economy_health_warnings_hides_balanced_and_bypassed_items(client
     assert 'Insurance' in summary_labels
     assert 'Rent' not in summary_labels
     assert 'Store' not in summary_labels
+
+
+def test_apply_scheduled_economy_rebalance_now_applies_and_clears_json(client):
+    """Test that applying a scheduled rebalance immediately clears economy_pending_rebalance_json."""
+    admin, payroll_settings, rent_settings = _create_admin_with_block()
+    _login_admin(client, admin.id)
+
+    scheduled_payload = json.dumps({
+        'activation_mode': 'next_renewal',
+        'changes': [{'type': 'rent', 'field': 'rent_amount', 'new_value': '400.00'}],
+        'scheduled_at': '2026-01-01T00:00:00',
+    })
+    settings_row = FeatureSettings(
+        teacher_id=admin.id,
+        block='A',
+        economy_policy_mode='tight',
+        economy_pending_rebalance_json=scheduled_payload,
+    )
+    db.session.add(settings_row)
+    db.session.commit()
+
+    response = client.post('/admin/economy-policy/rebalance/apply-scheduled-now', data={
+        'block': 'A',
+    })
+
+    assert response.status_code == 302
+    db.session.refresh(settings_row)
+    assert settings_row.economy_pending_rebalance_json is None
+
+
+def test_apply_scheduled_economy_rebalance_now_clears_invalid_json(client):
+    """Test that invalid pending JSON is cleared and a warning is shown."""
+    admin, _, _ = _create_admin_with_block()
+    _login_admin(client, admin.id)
+
+    settings_row = FeatureSettings(
+        teacher_id=admin.id,
+        block='A',
+        economy_policy_mode='tight',
+        economy_pending_rebalance_json='not valid json {{{',
+    )
+    db.session.add(settings_row)
+    db.session.commit()
+
+    response = client.post('/admin/economy-policy/rebalance/apply-scheduled-now', data={
+        'block': 'A',
+    })
+
+    assert response.status_code == 302
+    db.session.refresh(settings_row)
+    assert settings_row.economy_pending_rebalance_json is None


### PR DESCRIPTION
- Fix CSS typo: .economy-heath-page -> .economy-health-page so info-icon
  styles apply correctly on economy health page
- Clear economy_pending_rebalance_json after applying scheduled rebalance
  immediately so the scheduled banner is dismissed and changes can't be
  re-applied
- Gate "Economy Update Scheduled" button on parsed scheduled_rebalance
  instead of raw pending_rebalance_json to prevent targeting a missing modal
  when JSON is invalid or unparseable
- Restore help icon on economy health page intro paragraph
- Remove unused quick_action/has_quick_actions Jinja2 block
- Fix unclosed <p> tag when row.link_href is falsy (HTML structure bug)
- Remove redundant economy-health-page class on inner <p> element
- Fix grammar: "Pricing(s) that Requires Update" -> "Prices Requiring Update",
  "Pricing(s) that Needs Review" -> "Prices Needing Review"
- Fix typo: "princings" -> "pricings" in empty-state message
- Gate "all balanced" empty-state on balance_warning_count == 0 so it isn't
  shown when warnings exist outside non_banking_summary
- Replace non-portable %-d strftime format with .day/.year attributes for
  cross-platform date rendering
- Update test_update_economy_policy_creates_block_scoped_settings to match
  new redirect URL (no longer includes review_rebalance=1)
- Add regression tests for apply_scheduled_economy_rebalance_now: successful
  apply clears pending JSON; invalid JSON is cleared with a warning redirect

https://claude.ai/code/session_01C2DSSnHTLUg1MhmB6YJGsL