### PR TITLE
[codex] Fix rent full-payment mode

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1875,6 +1875,7 @@ class Issue(db.Model):
     STATUS_OPEN = 'OPEN'
     STATUS_TEACHER_REVIEW = 'TEACHER_REVIEW'
     STATUS_ESCALATED_TO_DEV = 'ESCALATED_TO_DEV'
+    STATUS_DEV_IN_REVIEW = 'DEV_IN_REVIEW'
     STATUS_DEV_RESOLVED = 'DEV_RESOLVED'
     STATUS_TEACHER_FINAL_REVIEW = 'TEACHER_FINAL_REVIEW'
     STATUS_CLOSED = 'CLOSED'
@@ -1885,7 +1886,7 @@ class Issue(db.Model):
         'teacher_review': STATUS_TEACHER_REVIEW,
         'teacher_resolved': STATUS_TEACHER_FINAL_REVIEW,
         'elevated': STATUS_ESCALATED_TO_DEV,
-        'developer_review': STATUS_ESCALATED_TO_DEV,
+        'developer_review': STATUS_DEV_IN_REVIEW,
         'developer_resolved': STATUS_DEV_RESOLVED,
     }
 
@@ -1896,6 +1897,7 @@ class Issue(db.Model):
             self.STATUS_OPEN: 'Submitted',
             self.STATUS_TEACHER_REVIEW: 'Teacher Review',
             self.STATUS_ESCALATED_TO_DEV: 'Escalated to Developer',
+            self.STATUS_DEV_IN_REVIEW: 'Developer Review In Progress',
             self.STATUS_DEV_RESOLVED: 'Developer Fix Applied - Teacher Review Required',
             self.STATUS_TEACHER_FINAL_REVIEW: 'Teacher Final Review',
             self.STATUS_CLOSED: 'Closed',
@@ -1910,6 +1912,7 @@ class Issue(db.Model):
             self.STATUS_TEACHER_REVIEW: 'bg-info',
             self.STATUS_TEACHER_FINAL_REVIEW: 'bg-primary',
             self.STATUS_ESCALATED_TO_DEV: 'bg-warning text-dark',
+            self.STATUS_DEV_IN_REVIEW: 'bg-warning text-dark',
             self.STATUS_DEV_RESOLVED: 'bg-info',
             self.STATUS_CLOSED: 'bg-success',
         }

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -12130,6 +12130,7 @@ def issues_queue():
     escalated_issues = issues_query.filter(
         Issue.status.in_([
             Issue.STATUS_ESCALATED_TO_DEV,
+            Issue.STATUS_DEV_IN_REVIEW,
             'elevated',
             'developer_review',
         ])

--- a/app/routes/student.py
+++ b/app/routes/student.py
@@ -3878,14 +3878,19 @@ def rent_pay(period):
         flash(f"You have already paid rent for Period {period} this month!", "info")
         return redirect(url_for('student.rent'))
 
-    # Get payment amount from form (supports incremental payments)
+    payment_mode = (request.form.get('payment_mode') or 'full').strip().lower()
     payment_amount_input = request.form.get('amount', '').strip()
 
-    # Determine payment amount based on incremental setting
-    if settings.allow_incremental_payment and payment_amount_input:
+    # Full payment is the safe default. Only treat a request as partial when the
+    # client explicitly opts into partial mode. This prevents browser autofill or
+    # stale form state from silently converting a "Pay Rent" click into a
+    # one-cent-short partial payment.
+    if settings.allow_incremental_payment and payment_mode == 'partial':
+        if not payment_amount_input:
+            flash("Enter an amount to make a partial payment.", "error")
+            return redirect(url_for('student.rent'))
         try:
             payment_amount = _quantize_currency(payment_amount_input)
-            # Validate payment amount
             if payment_amount <= Decimal('0'):
                 flash("Payment amount must be greater than 0.", "error")
                 return redirect(url_for('student.rent'))
@@ -3896,7 +3901,6 @@ def rent_pay(period):
             flash("Invalid payment amount.", "error")
             return redirect(url_for('student.rent'))
     else:
-        # Full payment required (or no amount specified with incremental disabled)
         payment_amount = remaining_amount
 
     # Get banking settings for overdraft handling (reuse teacher_id from above)
@@ -3940,7 +3944,7 @@ def rent_pay(period):
 
     # FIX: Process payment with teacher_id
     # Deduct from checking account
-    is_partial = payment_amount < remaining_amount
+    is_partial = settings.allow_incremental_payment and payment_mode == 'partial' and payment_amount < remaining_amount
     billed_period_date = payment_due_date or now
     payment_description = f'Rent for Period {period} - {billed_period_date.strftime("%B %Y")}'
     if is_partial and settings.allow_incremental_payment:

--- a/app/routes/system_admin.py
+++ b/app/routes/system_admin.py
@@ -1924,6 +1924,64 @@ def view_escalated_issue(issue_ref):
         format_utc_iso=format_utc_iso)
 
 
+@sysadmin_bp.route('/issues/<issue_ref>/status', methods=['POST'])
+@system_admin_required
+def update_escalated_issue_status(issue_ref):
+    """Update developer-side workflow status for an escalated issue."""
+    issue_id = _resolve_issue_id_from_ref(issue_ref)
+    if issue_id is None:
+        raise NotFound("Issue not found")
+
+    issue = Issue.query.filter(
+        Issue.id == issue_id,
+        Issue.status.in_([
+            Issue.STATUS_ESCALATED_TO_DEV,
+            Issue.STATUS_DEV_RESOLVED,
+            'elevated',
+            'developer_review',
+            'developer_resolved',
+        ])
+    ).first_or_404()
+
+    requested_status = (request.form.get('status') or '').strip()
+    allowed_statuses = {
+        Issue.STATUS_ESCALATED_TO_DEV: "Escalated to Developer",
+        'developer_review': "In Review",
+    }
+
+    if requested_status not in allowed_statuses:
+        flash("Invalid escalated issue status.", "error")
+        return redirect(url_for('sysadmin.view_escalated_issue', issue_ref=make_opaque_ref('issue', issue.id)))
+
+    old_status = issue.status
+    if old_status == requested_status:
+        flash(f"Status remains {allowed_statuses[requested_status]}.", "info")
+        return redirect(url_for('sysadmin.view_escalated_issue', issue_ref=make_opaque_ref('issue', issue.id)))
+
+    sysadmin_id = session.get('sysadmin_id')
+    if not sysadmin_id:
+        flash("System admin session is invalid. Please log in again.", "error")
+        return redirect(url_for('sysadmin.login', next=request.path))
+
+    from app.utils.issue_helpers import update_issue_status
+
+    issue.sysadmin_id = sysadmin_id
+    if issue.sysadmin_reviewed_at is None:
+        issue.sysadmin_reviewed_at = utc_now()
+
+    update_issue_status(
+        issue,
+        requested_status,
+        'sysadmin',
+        sysadmin_id,
+        notes=f"Sysadmin status updated to {allowed_statuses[requested_status]}",
+    )
+    db.session.commit()
+
+    flash(f"Issue status updated to {allowed_statuses[requested_status]}.", "success")
+    return redirect(url_for('sysadmin.view_escalated_issue', issue_ref=make_opaque_ref('issue', issue.id)))
+
+
 @sysadmin_bp.route('/issues/<issue_ref>/start-review', methods=['POST'])
 @system_admin_required
 def start_review_escalated_issue(issue_ref):

--- a/app/routes/system_admin.py
+++ b/app/routes/system_admin.py
@@ -537,6 +537,7 @@ def dashboard():
     open_issues_count = Issue.query.filter(
         Issue.status.in_([
             Issue.STATUS_ESCALATED_TO_DEV,
+            Issue.STATUS_DEV_IN_REVIEW,
             'elevated',
             'developer_review',
         ])
@@ -1273,6 +1274,7 @@ def support_tickets():
     all_issues = Issue.query.filter(
         Issue.status.in_([
             Issue.STATUS_ESCALATED_TO_DEV,
+            Issue.STATUS_DEV_IN_REVIEW,
             Issue.STATUS_DEV_RESOLVED,
             'elevated',
             'developer_review',
@@ -1283,7 +1285,7 @@ def support_tickets():
         i for i in all_issues
         if i.status in [Issue.STATUS_ESCALATED_TO_DEV, 'elevated']
     ]
-    issues_in_review = [i for i in all_issues if i.status == 'developer_review']
+    issues_in_review = [i for i in all_issues if i.status in [Issue.STATUS_DEV_IN_REVIEW, 'developer_review']]
     issues_resolved = [i for i in all_issues if i.status in [Issue.STATUS_DEV_RESOLVED, 'developer_resolved']]
 
     return render_template(
@@ -1867,6 +1869,7 @@ def escalated_issues():
     issues = Issue.query.filter(
         Issue.status.in_([
             Issue.STATUS_ESCALATED_TO_DEV,
+            Issue.STATUS_DEV_IN_REVIEW,
             Issue.STATUS_DEV_RESOLVED,
             'elevated',
             'developer_review',
@@ -1876,7 +1879,7 @@ def escalated_issues():
 
     # Separate by status
     pending_issues = [i for i in issues if i.status in [Issue.STATUS_ESCALATED_TO_DEV, 'elevated']]
-    in_review_issues = [i for i in issues if i.status == 'developer_review']
+    in_review_issues = [i for i in issues if i.status in [Issue.STATUS_DEV_IN_REVIEW, 'developer_review']]
     resolved_issues = [i for i in issues if i.status in [Issue.STATUS_DEV_RESOLVED, 'developer_resolved']]
 
     return render_template('sysadmin_escalated_issues.html',
@@ -1932,21 +1935,21 @@ def update_escalated_issue_status(issue_ref):
     if issue_id is None:
         raise NotFound("Issue not found")
 
+    open_escalated_statuses = [
+        Issue.STATUS_ESCALATED_TO_DEV,
+        Issue.STATUS_DEV_IN_REVIEW,
+        'elevated',
+        'developer_review',
+    ]
     issue = Issue.query.filter(
         Issue.id == issue_id,
-        Issue.status.in_([
-            Issue.STATUS_ESCALATED_TO_DEV,
-            Issue.STATUS_DEV_RESOLVED,
-            'elevated',
-            'developer_review',
-            'developer_resolved',
-        ])
+        Issue.status.in_(open_escalated_statuses)
     ).first_or_404()
 
     requested_status = (request.form.get('status') or '').strip()
     allowed_statuses = {
         Issue.STATUS_ESCALATED_TO_DEV: "Escalated to Developer",
-        'developer_review': "In Review",
+        Issue.STATUS_DEV_IN_REVIEW: "In Review",
     }
 
     if requested_status not in allowed_statuses:
@@ -1991,10 +1994,21 @@ def start_review_escalated_issue(issue_ref):
         raise NotFound("Issue not found")
     issue = Issue.query.filter(
         Issue.id == issue_id,
-        Issue.status.in_([Issue.STATUS_ESCALATED_TO_DEV, 'elevated', 'developer_review'])
+        Issue.status.in_([Issue.STATUS_ESCALATED_TO_DEV, Issue.STATUS_DEV_IN_REVIEW, 'elevated', 'developer_review'])
     ).first_or_404()
-
-    flash("Status remains Escalated to Developer until technical resolution is recorded.", "info")
+    from app.utils.issue_helpers import update_issue_status
+    sysadmin_id = session.get('sysadmin_id')
+    if not sysadmin_id:
+        flash("System admin session is invalid. Please log in again.", "error")
+        return redirect(url_for('sysadmin.login', next=request.path))
+    if issue.status != Issue.STATUS_DEV_IN_REVIEW:
+        issue.sysadmin_id = sysadmin_id
+        issue.sysadmin_reviewed_at = utc_now()
+        update_issue_status(issue, Issue.STATUS_DEV_IN_REVIEW, 'sysadmin', sysadmin_id, notes="Sysadmin started review")
+        db.session.commit()
+        flash("Issue moved to In Review.", "success")
+    else:
+        flash("Issue is already in review.", "info")
     return redirect(url_for('sysadmin.view_escalated_issue', issue_ref=make_opaque_ref('issue', issue.id)))
 
 
@@ -2007,7 +2021,7 @@ def resolve_escalated_issue(issue_ref):
         raise NotFound("Issue not found")
     issue = Issue.query.filter(
         Issue.id == issue_id,
-        Issue.status.in_([Issue.STATUS_ESCALATED_TO_DEV, 'elevated', 'developer_review'])
+        Issue.status.in_([Issue.STATUS_ESCALATED_TO_DEV, Issue.STATUS_DEV_IN_REVIEW, 'elevated', 'developer_review'])
     ).first_or_404()
 
     resolution_note = request.form.get('resolution_note', '').strip()

--- a/app/utils/banking.py
+++ b/app/utils/banking.py
@@ -191,6 +191,12 @@ def settle_balances(student_id: int, join_code: str) -> None:
             
             if tx.amount_cents is None:
                 # Fallback if validation missed this (should be prevented by strict creation)
+                if tx.amount is None:
+                    logger.error(
+                        "Refusing to derive amount_cents for transaction %s with null amount",
+                        tx.id,
+                    )
+                    raise ValueError(f"Transaction {tx.id} has null amount during settlement")
                 tx.amount_cents = int(_quantize_currency(tx.amount) * 100)
 
             # Handle Void Logic for Pending
@@ -212,6 +218,12 @@ def settle_balances(student_id: int, join_code: str) -> None:
             if not tx.posted_at:
                 tx.posted_at = now
             if tx.amount_cents is None:
+                if tx.amount is None:
+                    logger.error(
+                        "Refusing to derive amount_cents for posted transaction %s with null amount",
+                        tx.id,
+                    )
+                    raise ValueError(f"Transaction {tx.id} has null amount during settlement")
                 tx.amount_cents = int(_quantize_currency(tx.amount) * 100)
             cnt_posted += 1
 

--- a/app/utils/banking.py
+++ b/app/utils/banking.py
@@ -2,7 +2,7 @@ import logging
 from flask import g
 from sqlalchemy.exc import IntegrityError
 from app import db
-from app.models import Transaction, TransactionStatus, BalanceCache, AccountType
+from app.models import Transaction, TransactionStatus, BalanceCache, AccountType, _quantize_currency
 from app.utils.time import utc_now
 
 logger = logging.getLogger(__name__)
@@ -191,7 +191,7 @@ def settle_balances(student_id: int, join_code: str) -> None:
             
             if tx.amount_cents is None:
                 # Fallback if validation missed this (should be prevented by strict creation)
-                tx.amount_cents = int(tx.amount * 100)
+                tx.amount_cents = int(_quantize_currency(tx.amount) * 100)
 
             # Handle Void Logic for Pending
             if tx.is_void:
@@ -212,7 +212,7 @@ def settle_balances(student_id: int, join_code: str) -> None:
             if not tx.posted_at:
                 tx.posted_at = now
             if tx.amount_cents is None:
-                tx.amount_cents = int(tx.amount * 100)
+                tx.amount_cents = int(_quantize_currency(tx.amount) * 100)
             cnt_posted += 1
 
         authoritative_checking_cents, authoritative_savings_cents = _authoritative_posted_totals(

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ zope.event==5.0
 # breaking changes (transitive dep for gevent) before upgrading from 7.2 to 8.2
 zope.interface==7.2
 python-dateutil==2.9.0.post0
-cryptography==46.0.6
+cryptography==46.0.7
 Flask-WTF==1.2.2
 python-dotenv==1.2.2
 

--- a/templates/admin_view_issue.html
+++ b/templates/admin_view_issue.html
@@ -23,7 +23,7 @@
                         <span class="badge
                             {% if issue.status in ['OPEN', 'TEACHER_REVIEW', 'submitted', 'teacher_review'] %}bg-warning text-dark
                             {% elif issue.status in ['TEACHER_FINAL_REVIEW', 'teacher_resolved'] %}bg-primary
-                            {% elif issue.status in ['ESCALATED_TO_DEV', 'elevated', 'developer_review'] %}bg-warning
+                            {% elif issue.status in ['ESCALATED_TO_DEV', 'DEV_IN_REVIEW', 'elevated', 'developer_review'] %}bg-warning
                             {% elif issue.status in ['DEV_RESOLVED', 'developer_resolved'] %}bg-info
                             {% elif issue.status == 'CLOSED' %}bg-success
                             {% else %}bg-dark{% endif %}">
@@ -353,7 +353,7 @@
                     </p>
                 </div>
             </div>
-            {% elif issue.status in ['ESCALATED_TO_DEV', 'elevated', 'developer_review'] %}
+            {% elif issue.status in ['ESCALATED_TO_DEV', 'DEV_IN_REVIEW', 'elevated', 'developer_review'] %}
             <div class="card shadow-sm mb-4 border-warning">
                 <div class="card-header bg-warning">
                     <h5 class="mb-0 text-black">

--- a/templates/student_rent.html
+++ b/templates/student_rent.html
@@ -201,26 +201,30 @@
 
         {% if not status.is_paid %}
             {% if settings.allow_incremental_payment or checking_balance >= status.remaining_amount %}
-            <form action="{{ url_for('student.rent_pay', period=current_block) }}" method="POST">
+            <form action="{{ url_for('student.rent_pay', period=current_block) }}" method="POST" class="mb-3">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                {% if settings.allow_incremental_payment %}
-                <div class="mb-2">
-                    <label for="amount_{{ current_block }}" class="form-label"><small>Payment Amount (optional - leave
-                            blank for full payment)</small></label>
-                    <input type="number" step="0.01" min="0.01" max="{{ status.remaining_amount }}" class="form-control"
-                        id="amount_{{ current_block }}" name="amount"
-                        placeholder="Max: ${{ '%.2f'|format(status.remaining_amount) }}">
-                </div>
-                {% endif %}
+                <input type="hidden" name="payment_mode" value="full" />
                 <button type="submit" class="btn btn-primary w-100"
                     onclick="return confirm('Pay rent for Period {{ current_block|upper }}?');">
-                    {% if settings.allow_incremental_payment %}
-                    Pay Rent (Remaining: ${{ "%.2f"|format(status.remaining_amount) }})
-                    {% else %}
-                    Pay Rent (${{ "%.2f"|format(status.remaining_amount) }})
-                    {% endif %}
+                    Pay Full Remaining Balance (${{ "%.2f"|format(status.remaining_amount) }})
                 </button>
             </form>
+            {% if settings.allow_incremental_payment %}
+            <form action="{{ url_for('student.rent_pay', period=current_block) }}" method="POST">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                <input type="hidden" name="payment_mode" value="partial" />
+                <div class="mb-2">
+                    <label for="amount_{{ current_block }}" class="form-label"><small>Custom Partial Payment</small></label>
+                    <input type="number" step="0.01" min="0.01" max="{{ status.remaining_amount }}" class="form-control"
+                        id="amount_{{ current_block }}" name="amount"
+                        placeholder="Up to ${{ '%.2f'|format(status.remaining_amount) }}">
+                </div>
+                <button type="submit" class="btn btn-outline-primary w-100"
+                    onclick="return confirm('Make a partial rent payment for Period {{ current_block|upper }}?');">
+                    Pay Custom Amount
+                </button>
+            </form>
+            {% endif %}
             {% else %}
             <button class="btn btn-secondary w-100" disabled>
                 Insufficient Funds

--- a/templates/sysadmin_view_escalated_issue.html
+++ b/templates/sysadmin_view_escalated_issue.html
@@ -19,7 +19,7 @@
                             <span class="material-symbols-outlined icon-inline me-2">flag</span>Issue {{ issue_ref[:12] }}...
                         </h4>
                         <span class="badge
-                            {% if issue.status in ['ESCALATED_TO_DEV', 'elevated', 'developer_review'] %}bg-warning text-dark
+                            {% if issue.status in ['ESCALATED_TO_DEV', 'DEV_IN_REVIEW', 'elevated', 'developer_review'] %}bg-warning text-dark
                             {% elif issue.status in ['DEV_RESOLVED', 'developer_resolved'] %}bg-success
                             {% else %}bg-secondary{% endif %}">
                             {{ issue.status|replace('_', ' ')|title }}
@@ -287,7 +287,7 @@
 
         <!-- Sidebar -->
         <div class="col-lg-4">
-            {% if issue.status in ['ESCALATED_TO_DEV', 'elevated', 'developer_review'] %}
+            {% if issue.status in ['ESCALATED_TO_DEV', 'DEV_IN_REVIEW', 'elevated', 'developer_review'] %}
             <div class="card shadow-sm mb-4">
                 <div class="card-header bg-primary text-white">
                     <h5 class="mb-0">
@@ -302,7 +302,7 @@
                             <label for="status" class="form-label">Status</label>
                             <select class="form-select" id="status" name="status" required>
                                 <option value="ESCALATED_TO_DEV" {% if issue.status in ['ESCALATED_TO_DEV', 'elevated'] %}selected{% endif %}>Escalated to Developer</option>
-                                <option value="developer_review" {% if issue.status == 'developer_review' %}selected{% endif %}>In Review</option>
+                                <option value="DEV_IN_REVIEW" {% if issue.status in ['DEV_IN_REVIEW', 'developer_review'] %}selected{% endif %}>In Review</option>
                             </select>
                         </div>
 
@@ -315,7 +315,7 @@
             {% endif %}
 
             <!-- Actions Card -->
-            {% if issue.status in ['ESCALATED_TO_DEV', 'elevated', 'developer_review'] %}
+            {% if issue.status in ['ESCALATED_TO_DEV', 'DEV_IN_REVIEW', 'elevated', 'developer_review'] %}
             <div class="card shadow-sm mb-4">
                 <div class="card-header bg-success text-white">
                     <h5 class="mb-0">

--- a/templates/sysadmin_view_escalated_issue.html
+++ b/templates/sysadmin_view_escalated_issue.html
@@ -287,6 +287,33 @@
 
         <!-- Sidebar -->
         <div class="col-lg-4">
+            {% if issue.status in ['ESCALATED_TO_DEV', 'elevated', 'developer_review'] %}
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="mb-0">
+                        <span class="material-symbols-outlined icon-inline me-2">edit_square</span>Update Status
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST" action="{{ url_for('sysadmin.update_escalated_issue_status', issue_ref=issue_ref) }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+                        <div class="mb-3">
+                            <label for="status" class="form-label">Status</label>
+                            <select class="form-select" id="status" name="status" required>
+                                <option value="ESCALATED_TO_DEV" {% if issue.status in ['ESCALATED_TO_DEV', 'elevated'] %}selected{% endif %}>Escalated to Developer</option>
+                                <option value="developer_review" {% if issue.status == 'developer_review' %}selected{% endif %}>In Review</option>
+                            </select>
+                        </div>
+
+                        <button type="submit" class="btn btn-primary w-100">
+                            <span class="material-symbols-outlined icon-inline me-2">save</span>Update Status
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {% endif %}
+
             <!-- Actions Card -->
             {% if issue.status in ['ESCALATED_TO_DEV', 'elevated', 'developer_review'] %}
             <div class="card shadow-sm mb-4">

--- a/tests/test_decimal_precision.py
+++ b/tests/test_decimal_precision.py
@@ -593,7 +593,7 @@ class TestDecimalPrecision:
 
         response = client.post(
             '/student/rent/pay/A',
-            data={'amount': '285.00'},
+            data={'payment_mode': 'partial', 'amount': '285.00'},
             follow_redirects=False,
         )
 
@@ -605,3 +605,96 @@ class TestDecimalPrecision:
         ).order_by(RentPayment.id.desc()).first()
         assert rent_payment is not None
         assert rent_payment.late_fee_charged == Decimal('0.00')
+
+    def test_full_rent_payment_mode_ignores_stale_partial_amount(self, client):
+        teacher = Admin(
+            username='teacher_full_payment_mode',
+            totp_secret='test_secret'
+        )
+        db.session.add(teacher)
+        db.session.flush()
+
+        join_code = 'FULL_PAY_Q'
+        student = Student(
+            first_name='Full',
+            last_initial='P',
+            block='A',
+            salt=b'test_salt',
+            passphrase_hash='test_hash'
+        )
+        db.session.add(student)
+        db.session.flush()
+
+        db.session.add(TeacherBlock(
+            teacher_id=teacher.id,
+            join_code=join_code,
+            block='A',
+            student_id=student.id,
+            is_claimed=True,
+            first_name='Full',
+            last_initial='P',
+            last_name_hash_by_part=['hash1'],
+            dob_sum=1234,
+            salt=b'test_salt_123456',
+            first_half_hash='test_hash'
+        ))
+
+        db.session.add(RentSettings(
+            teacher_id=teacher.id,
+            block='A',
+            is_enabled=True,
+            rent_amount=Decimal('570.00'),
+            allow_incremental_payment=True,
+            frequency_type='monthly',
+            first_rent_due_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            grace_period_days=5,
+            late_penalty_amount=Decimal('0.00'),
+            late_penalty_type='once',
+        ))
+
+        db.session.add(StudentBlock(
+            student_id=student.id,
+            period='A',
+            join_code=join_code
+        ))
+        db.session.add(StudentTeacher(student_id=student.id, admin_id=teacher.id))
+        db.session.add(Transaction(
+            student_id=student.id,
+            teacher_id=teacher.id,
+            join_code=join_code,
+            amount=Decimal('600.00'),
+            account_type='checking',
+            type='Initial Deposit',
+            description='Starting balance'
+        ))
+        db.session.commit()
+
+        with client.session_transaction() as sess:
+            sess['student_id'] = student.id
+            sess['current_join_code'] = join_code
+            sess['login_time'] = datetime.now(timezone.utc).isoformat()
+            sess['last_activity'] = datetime.now(timezone.utc).isoformat()
+
+        response = client.post(
+            '/student/rent/pay/A',
+            data={'payment_mode': 'full', 'amount': '569.99'},
+            follow_redirects=False,
+        )
+
+        assert response.status_code in (302, 303)
+
+        rent_payment = RentPayment.query.filter_by(
+            student_id=student.id,
+            join_code=join_code,
+        ).order_by(RentPayment.id.desc()).first()
+        assert rent_payment is not None
+        assert rent_payment.amount_paid == Decimal('570.00')
+
+        rent_tx = Transaction.query.filter_by(
+            student_id=student.id,
+            join_code=join_code,
+            type='Rent Payment',
+        ).order_by(Transaction.id.desc()).first()
+        assert rent_tx is not None
+        assert rent_tx.amount == Decimal('-570.00')
+        assert 'Partial' not in (rent_tx.description or '')

--- a/tests/test_rent_display_dynamic.py
+++ b/tests/test_rent_display_dynamic.py
@@ -444,5 +444,6 @@ def test_incremental_rent_form_shows_even_when_full_balance_is_short(client, set
 
     response = client.get('/student/rent')
     assert response.status_code == 200
-    assert b'Payment Amount' in response.data
+    assert b'Pay Full Remaining Balance' in response.data
+    assert b'Custom Partial Payment' in response.data
     assert b'Insufficient Funds' not in response.data

--- a/tests/test_sysadmin_issue_rewards.py
+++ b/tests/test_sysadmin_issue_rewards.py
@@ -6,6 +6,7 @@ from app.models import (
     Issue,
     IssueCategory,
     IssueResolutionAction,
+    IssueStatusHistory,
     Student,
     SystemAdmin,
     Transaction,
@@ -85,3 +86,63 @@ def test_sysadmin_resolve_issue_issues_bug_reward_transaction(client):
     ).first()
     assert reward_action is not None
     assert reward_action.related_transaction_id == reward_tx.id
+
+
+def test_sysadmin_can_update_escalated_issue_status_to_in_review(client):
+    teacher = Admin(username="teacher_issue_status", totp_secret="secret")
+    sysadmin = SystemAdmin(username="sysadmin_issue_status", totp_secret="secret")
+    student = Student(first_name="Review", last_initial="Q", block="A", salt=b"salt")
+    category = IssueCategory(
+        name="Status Category",
+        category_type="general",
+        is_active=True,
+    )
+    db.session.add_all([teacher, sysadmin, student, category])
+    db.session.flush()
+
+    issue = Issue(
+        student_id=student.id,
+        student_first_name=student.first_name,
+        student_last_initial=student.last_initial,
+        opaque_student_reference="opaque-ref-status",
+        teacher_id=teacher.id,
+        join_code="JOINSTATUS1",
+        class_label="Block A",
+        category_id=category.id,
+        issue_type="general",
+        student_explanation="This needs investigation.",
+        student_expected_outcome="Review the issue.",
+        status=Issue.STATUS_ESCALATED_TO_DEV,
+    )
+    db.session.add(issue)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["is_system_admin"] = True
+        sess["sysadmin_id"] = sysadmin.id
+        sess["last_activity"] = datetime.now(timezone.utc).isoformat()
+
+    issue_ref = make_opaque_ref("issue", issue.id)
+
+    detail_resp = client.get(f"/sysadmin/issues/{issue_ref}")
+    assert detail_resp.status_code == 200
+    assert b'Update Status' in detail_resp.data
+    assert b'In Review' in detail_resp.data
+
+    resp = client.post(
+        f"/sysadmin/issues/{issue_ref}/status",
+        data={"status": "developer_review"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+
+    db.session.refresh(issue)
+    assert issue.status == "developer_review"
+    assert issue.sysadmin_id == sysadmin.id
+    assert issue.sysadmin_reviewed_at is not None
+
+    history_entry = IssueStatusHistory.query.filter_by(
+        issue_id=issue.id,
+        new_status="developer_review",
+    ).first()
+    assert history_entry is not None

--- a/tests/test_sysadmin_issue_rewards.py
+++ b/tests/test_sysadmin_issue_rewards.py
@@ -131,18 +131,18 @@ def test_sysadmin_can_update_escalated_issue_status_to_in_review(client):
 
     resp = client.post(
         f"/sysadmin/issues/{issue_ref}/status",
-        data={"status": "developer_review"},
+        data={"status": Issue.STATUS_DEV_IN_REVIEW},
         follow_redirects=False,
     )
     assert resp.status_code == 302
 
     db.session.refresh(issue)
-    assert issue.status == "developer_review"
+    assert issue.status == Issue.STATUS_DEV_IN_REVIEW
     assert issue.sysadmin_id == sysadmin.id
     assert issue.sysadmin_reviewed_at is not None
 
     history_entry = IssueStatusHistory.query.filter_by(
         issue_id=issue.id,
-        new_status="developer_review",
+        new_status=Issue.STATUS_DEV_IN_REVIEW,
     ).first()
     assert history_entry is not None


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Schema Change Gate Classification (Required for schema changes)

- [x] **EXPAND** – Additive, backward-compatible (no removals)
- [ ] **CONTRACT (CODE ONLY)** – Model attribute removal, DB schema unchanged
- [ ] **CONTRACT (DATABASE)** – Destructive migration only

## Description

This PR fixes a rent payment bug where a student could click the primary full-payment action and still end up recording a one-cent-short partial payment. Production investigation on the live server showed the affected March 20, 2026 payment for join code `HJ8BJP` was stored as a single `$569.99` rent payment with `late_fee_charged = 0.00`, and the matching ledger row was explicitly recorded as `Partial: $569.99 of $570.00`. That ruled out Numeric column drift and pointed instead to ambiguous request handling in the full-vs-partial payment flow.

The root cause was that the student rent route inferred intent from whether the `amount` field was populated. In incremental-payment mode, any submitted `amount` was treated as a partial payment, even when the user intended to click the full-payment button. This PR changes the route so full payment is the default safe path unless the request explicitly opts into `payment_mode=partial`, and it updates the rent page UI to separate the full-payment action from the custom partial-payment form.

This PR also restores the missing sysadmin escalated-issue status control and tightens the follow-up implementation based on review feedback. The escalated-issue page now has an explicit status-update form again, but it writes a canonical `DEV_IN_REVIEW` status instead of persisting the legacy `developer_review` value. Queue/grouping logic and badges were updated to understand that canonical in-review state while still reading legacy values for backward compatibility.

Finally, the ledger settlement fallback was hardened in two ways: it still quantizes before deriving `amount_cents`, but it now raises and logs an explicit error if it ever encounters a transaction with a null amount instead of silently coercing that case to zero.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [x] Added new tests for new functionality

Local checks run:
- `pytest tests/test_decimal_precision.py -q`
- `pytest tests/test_rent_display_dynamic.py -q`
- `pytest tests/test_sysadmin_issue_rewards.py -q`
- `pytest tests/test_sysadmin_issue_rewards.py tests/test_decimal_precision.py -q`

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

The production investigation used the remote server over Tailscale (`ssh root@cth`) and the live PostgreSQL database. The key finding was that the problematic payment was persisted as an intentional partial payment in application data, not as a rounding artifact in `NUMERIC` storage.

</details>

<details>
<summary>AUDIT PR SECTION (Click to expand)</summary>

## Audit Stage (Select Exactly ONE)

- [ ] Stage 1 – Static Structural Audit
- [ ] Stage 2 – Economic Invariant Risk Audit
- [ ] Stage 3 – Security & Boundary Scan
- [ ] Stage 4 – Test Coverage & Fragility Audit
- [ ] Stage 5 – Refactor Proposal (Plan Only)

## Audit Artifacts

- Primary report file:
  - docs/audits/...

- Additional artifacts (if any):
  - docs/audits/...

## Audit Confirmation

- [ ] I confirm that this PR modifies documentation only and includes no changes to source code, migrations, or database schema.

</details>
