### PR TITLE
fix: align item redemption passphrase field with backend expectation

### DIFF
--- a/templates/student_shop.html
+++ b/templates/student_shop.html
@@ -481,7 +481,7 @@
                     </div>
                     <div class="mb-3">
                         <label for="usePassphrase" class="form-label">Enter your Passphrase to confirm:</label>
-                        <input type="password" class="form-control" id="usePassphrase" name="passphrase"  pattern="*" required>
+                        <input type="password" class="form-control" id="usePassphrase" name="passphrase" required>
                     </div>
                 </form>
             </div>

--- a/templates/student_shop.html
+++ b/templates/student_shop.html
@@ -915,6 +915,10 @@
         document.getElementById('usePassphrase').focus();
     });
 
+    document.getElementById('useItemForm').addEventListener('submit', (e) => {
+        e.preventDefault();
+    });
+
     document.getElementById('confirmUseBtn').addEventListener('click', () => {
         const form = document.getElementById('useItemForm');
         const itemId = form.querySelector('#useModalItemId').value;
@@ -929,7 +933,7 @@
 
         const requestBody = {
             student_item_id: itemId,
-            passphrase: passphrase,
+            passphrase,
         };
 
         // Include redemption details if provided

--- a/templates/student_shop.html
+++ b/templates/student_shop.html
@@ -481,7 +481,7 @@
                     </div>
                     <div class="mb-3">
                         <label for="usePassphrase" class="form-label">Enter your Passphrase to confirm:</label>
-                        <input type="password" class="form-control" id="usePassphrase" name="pin" inputmode="numeric" pattern="[0-9]*" required>
+                        <input type="password" class="form-control" id="usePassphrase" name="passphrase"  pattern="*" required>
                     </div>
                 </form>
             </div>
@@ -918,18 +918,18 @@
     document.getElementById('confirmUseBtn').addEventListener('click', () => {
         const form = document.getElementById('useItemForm');
         const itemId = form.querySelector('#useModalItemId').value;
-        const pin = form.querySelector('#usePassphrase').value;
+        const passphrase = form.querySelector('#usePassphrase').value;
         const redemptionDetails = form.querySelector('#redemptionDetails').value;
         const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
-        if (!pin) {
-            alert('Please enter your PIN.');
+        if (!passphrase) {
+            alert('Please enter your Passphrase.');
             return;
         }
 
         const requestBody = {
             student_item_id: itemId,
-            passphrase: pin
+            passphrase: passphrase,
         };
 
         // Include redemption details if provided


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Schema Change Gate Classification (Required for schema changes)

N/A — no schema changes.

## Description

The item redemption modal in `student_shop.html` had a frontend/backend field mismatch. The `<input>` used `name="pin"` with `inputmode="numeric"` and `pattern="[0-9]*"`, treating the credential as a numeric PIN. However, the backend `/api/use-item` endpoint reads `data.get('passphrase')` and verifies it against `student.passphrase_hash`.

Changes:
- Input `name` changed from `pin` to `passphrase`
- Removed `inputmode="numeric"` and `pattern="[0-9]*"` (passphrase is not numeric-only)
- JS variable renamed from `pin` to `passphrase` for clarity
- Validation alert updated from "Please enter your PIN." to "Please enter your Passphrase."

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

The fix is a template-only change aligning the form field name and JS with the existing backend contract — no new logic introduced.

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

The label on the input already read "Enter your Passphrase to confirm" before this fix — only the `name` attribute, `inputmode`, `pattern`, and JS variable were misaligned.

---

</details>