### PR TITLE
Fix v1 insurance recurring billing and derive local DB selection from branch presets

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,6 +19,7 @@ from flask import Flask, request, render_template, session, g, url_for, has_requ
 from werkzeug.exceptions import HTTPException
 from dotenv import load_dotenv
 from pathlib import Path
+from db_env import resolve_dev_database_url
 
 # Load environment variables from project root
 # Explicitly specify path to ensure .env is found regardless of working directory
@@ -30,6 +31,10 @@ dotenv_path = project_root / '.env'
 # Skip in explicit testing/CI contexts to preserve test harness isolation.
 if os.environ.get("FLASK_ENV") != "testing" and not os.environ.get("CI"):
     load_dotenv(dotenv_path=dotenv_path, override=False)
+
+derived_database_url = resolve_dev_database_url(os.environ, project_root=project_root)
+if derived_database_url and not os.environ.get("DATABASE_URL"):
+    os.environ["DATABASE_URL"] = derived_database_url
 
 # Validate required environment variables
 required_env_vars = ["SECRET_KEY", "DATABASE_URL", "FLASK_ENV", "ENCRYPTION_KEY", "PEPPER_KEY"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,11 +24,12 @@ from pathlib import Path
 # Explicitly specify path to ensure .env is found regardless of working directory
 project_root = Path(__file__).parent.parent
 dotenv_path = project_root / '.env'
-# Force-load .env so CLI commands pick up required settings even if env vars are absent
-# BUT skip if FLASK_ENV is already 'testing' (set by conftest.py or CI) to avoid overwriting test config
-# Also skip in CI environments to prevent unexpected behavior in automated testing
+# Load .env for local development defaults, but never override process-level
+# environment variables. This keeps deployed environments authoritative and lets
+# one-off CLI commands intentionally target a different DATABASE_URL.
+# Skip in explicit testing/CI contexts to preserve test harness isolation.
 if os.environ.get("FLASK_ENV") != "testing" and not os.environ.get("CI"):
-    load_dotenv(dotenv_path=dotenv_path, override=True)
+    load_dotenv(dotenv_path=dotenv_path, override=False)
 
 # Validate required environment variables
 required_env_vars = ["SECRET_KEY", "DATABASE_URL", "FLASK_ENV", "ENCRYPTION_KEY", "PEPPER_KEY"]

--- a/app/routes/student.py
+++ b/app/routes/student.py
@@ -61,6 +61,7 @@ from app.utils.insurance_eligibility import (
     evaluate_claim_transaction_eligibility,
     collect_reimbursed_source_tx_ids,
 )
+from app.utils.insurance_billing import insurance_next_payment_due
 from app.utils.economy_rebalance import activate_due_rebalances
 from app.utils.display_name_session import (
     get_teacher_display_name_cache,
@@ -320,17 +321,6 @@ def get_current_join_code():
     """
     context = get_current_class_context()
     return context['join_code'] if context else None
-
-
-def _insurance_next_payment_due(now_utc, charge_frequency):
-    frequency = (charge_frequency or 'monthly').lower()
-    if frequency == 'weekly':
-        return now_utc + timedelta(days=7)
-    if frequency == 'biweekly':
-        return now_utc + timedelta(days=14)
-    if frequency == 'semester':
-        return now_utc + timedelta(days=7 * 16)
-    return now_utc + timedelta(days=28)
 
 
 def get_feature_settings_for_student():
@@ -2339,7 +2329,7 @@ def purchase_insurance(policy_id):
         status='active',
         purchase_date=utc_now(),
         last_payment_date=utc_now(),
-        next_payment_due=_insurance_next_payment_due(utc_now(), policy.charge_frequency),
+        next_payment_due=insurance_next_payment_due(utc_now(), policy.charge_frequency),
         coverage_start_date=utc_now(),
         payment_current=True
     )

--- a/app/scheduled_tasks.py
+++ b/app/scheduled_tasks.py
@@ -5,8 +5,12 @@ Contains periodic tasks that run in the background to maintain system state.
 """
 
 import logging
-from datetime import datetime, timezone
+
 from app.utils.time import utc_now
+from app.utils.insurance_billing import (
+    insurance_next_payment_due,
+    should_reset_legacy_billing_cycle,
+)
 
 
 def enforce_daily_limits_job():
@@ -203,6 +207,141 @@ def database_maintenance_job():
         logger.error(f"Database maintenance job failed: {e}", exc_info=True)
 
 
+def reset_insurance_billing_cycles(now=None):
+    """Give pre-launch active enrollments one fresh billing cycle before enforcement begins."""
+    from app.extensions import db
+    from app.models import StudentInsurance
+
+    logger = logging.getLogger('scheduled_tasks')
+    now = now or utc_now()
+
+    active_enrollments = (
+        StudentInsurance.query
+        .filter(StudentInsurance.status == 'active')
+        .all()
+    )
+
+    reset_count = 0
+    for enrollment in active_enrollments:
+        if not should_reset_legacy_billing_cycle(enrollment, now):
+            continue
+
+        enrollment.last_payment_date = now
+        enrollment.next_payment_due = insurance_next_payment_due(
+            now,
+            enrollment.policy.charge_frequency if enrollment.policy else None,
+        )
+        enrollment.payment_current = True
+        enrollment.days_unpaid = 0
+        reset_count += 1
+
+    if reset_count:
+        db.session.commit()
+        logger.info("Reset %s active insurance enrollments to a fresh billing cycle", reset_count)
+    else:
+        logger.info("No legacy insurance enrollments required billing cycle reset")
+
+    return reset_count
+
+
+def _charge_insurance_enrollment(enrollment, now):
+    """Create the recurring premium transaction and advance billing dates."""
+    from app.extensions import db
+    from app.models import Transaction, TransactionStatus
+
+    premium_amount = enrollment.contract_premium
+    if premium_amount is None:
+        raise ValueError(f"Enrollment {enrollment.id} has no contract premium")
+
+    teacher_id = enrollment.policy.teacher_id if enrollment.policy else None
+
+    db.session.add(Transaction(
+        student_id=enrollment.student_id,
+        teacher_id=teacher_id,
+        join_code=enrollment.join_code,
+        amount=-premium_amount,
+        account_type='checking',
+        status=TransactionStatus.PENDING,
+        type='insurance_premium',
+        description=f"Insurance premium: {enrollment.contract_title}",
+        policy_id=enrollment.policy_id,
+    ))
+
+    enrollment.last_payment_date = now
+    enrollment.next_payment_due = insurance_next_payment_due(
+        now,
+        enrollment.policy.charge_frequency if enrollment.policy else None,
+    )
+    enrollment.payment_current = True
+    enrollment.days_unpaid = 0
+
+
+def process_insurance_billing_job(now=None):
+    """Charge or mark due insurance enrollments once their premium date arrives."""
+    from app.extensions import db
+    from app.models import StudentInsurance
+
+    logger = logging.getLogger('scheduled_tasks')
+    now = now or utc_now()
+
+    logger.info("Starting insurance billing job")
+
+    try:
+        reset_insurance_billing_cycles(now=now)
+
+        due_enrollments = (
+            StudentInsurance.query
+            .filter(
+                StudentInsurance.status == 'active',
+                StudentInsurance.next_payment_due.isnot(None),
+                StudentInsurance.next_payment_due <= now,
+            )
+            .all()
+        )
+
+        charged_count = 0
+        overdue_count = 0
+        cancelled_count = 0
+
+        for enrollment in due_enrollments:
+            policy = enrollment.policy
+            if not policy:
+                logger.warning("Skipping insurance enrollment %s with missing policy", enrollment.id)
+                continue
+
+            if policy.autopay:
+                balance = enrollment.student.get_checking_balance(
+                    teacher_id=policy.teacher_id,
+                    join_code=enrollment.join_code,
+                )
+                premium_amount = enrollment.contract_premium
+                if premium_amount is not None and balance >= premium_amount:
+                    _charge_insurance_enrollment(enrollment, now)
+                    charged_count += 1
+                    continue
+
+            enrollment.days_unpaid = (enrollment.days_unpaid or 0) + 1
+            enrollment.payment_current = False
+            overdue_count += 1
+
+            cancel_threshold = policy.auto_cancel_nonpay_days or 0
+            if cancel_threshold > 0 and enrollment.days_unpaid >= cancel_threshold:
+                enrollment.status = 'cancelled'
+                enrollment.cancel_date = now
+                cancelled_count += 1
+
+        db.session.commit()
+        logger.info(
+            "Insurance billing job completed. Charged %s enrollments, marked %s overdue, cancelled %s",
+            charged_count,
+            overdue_count,
+            cancelled_count,
+        )
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Insurance billing job failed: {e}", exc_info=True)
+
+
 def init_scheduled_tasks(app):
     """
     Initialize and start scheduled tasks.
@@ -228,6 +367,10 @@ def init_scheduled_tasks(app):
     def run_database_maintenance():
         with app.app_context():
             database_maintenance_job()
+
+    def run_insurance_billing():
+        with app.app_context():
+            process_insurance_billing_job()
 
     if not scheduler.running:
         # Add the auto tap-out enforcement job to run every hour
@@ -264,7 +407,21 @@ def init_scheduled_tasks(app):
             max_instances=1  # Prevent overlapping executions
         )
 
+        scheduler.add_job(
+            func=run_insurance_billing,
+            trigger='cron',
+            hour=0,
+            minute=5,
+            id='process_insurance_billing',
+            name='Process insurance billing',
+            replace_existing=True,
+            max_instances=1
+        )
+
         scheduler.start()
-        logger.info("Scheduled tasks initialized: auto tap-out (hourly), demo cleanup (5 min), database maintenance (2 AM UTC daily)")
+        logger.info(
+            "Scheduled tasks initialized: auto tap-out (hourly), demo cleanup (5 min), "
+            "insurance billing (12:05 AM UTC daily), database maintenance (2 AM UTC daily)"
+        )
     else:
         logger.info("Scheduler already running")

--- a/app/scheduled_tasks.py
+++ b/app/scheduled_tasks.py
@@ -8,6 +8,7 @@ import logging
 
 from app.utils.time import utc_now
 from app.utils.insurance_billing import (
+    INSURANCE_BILLING_LAUNCH_CUTOFF,
     insurance_next_payment_due,
     should_reset_legacy_billing_cycle,
 )
@@ -209,6 +210,8 @@ def database_maintenance_job():
 
 def reset_insurance_billing_cycles(now=None):
     """Give pre-launch active enrollments one fresh billing cycle before enforcement begins."""
+    from sqlalchemy import or_
+    from sqlalchemy.orm import joinedload
     from app.extensions import db
     from app.models import StudentInsurance
 
@@ -217,7 +220,15 @@ def reset_insurance_billing_cycles(now=None):
 
     active_enrollments = (
         StudentInsurance.query
-        .filter(StudentInsurance.status == 'active')
+        .options(joinedload(StudentInsurance.policy))
+        .filter(
+            StudentInsurance.status == 'active',
+            StudentInsurance.purchase_date < INSURANCE_BILLING_LAUNCH_CUTOFF,
+            or_(
+                StudentInsurance.next_payment_due.is_(None),
+                StudentInsurance.next_payment_due <= now,
+            ),
+        )
         .all()
     )
 
@@ -278,6 +289,7 @@ def _charge_insurance_enrollment(enrollment, now):
 
 def process_insurance_billing_job(now=None):
     """Charge or mark due insurance enrollments once their premium date arrives."""
+    from sqlalchemy.orm import joinedload
     from app.extensions import db
     from app.models import StudentInsurance
 
@@ -291,6 +303,10 @@ def process_insurance_billing_job(now=None):
 
         due_enrollments = (
             StudentInsurance.query
+            .options(
+                joinedload(StudentInsurance.student),
+                joinedload(StudentInsurance.policy),
+            )
             .filter(
                 StudentInsurance.status == 'active',
                 StudentInsurance.next_payment_due.isnot(None),
@@ -304,33 +320,47 @@ def process_insurance_billing_job(now=None):
         cancelled_count = 0
 
         for enrollment in due_enrollments:
-            policy = enrollment.policy
-            if not policy:
-                logger.warning("Skipping insurance enrollment %s with missing policy", enrollment.id)
-                continue
-
-            if policy.autopay:
-                balance = enrollment.student.get_checking_balance(
-                    teacher_id=policy.teacher_id,
-                    join_code=enrollment.join_code,
-                )
-                premium_amount = enrollment.contract_premium
-                if premium_amount is not None and balance >= premium_amount:
-                    _charge_insurance_enrollment(enrollment, now)
-                    charged_count += 1
+            try:
+                policy = enrollment.policy
+                if not policy:
+                    logger.warning("Skipping insurance enrollment %s with missing policy", enrollment.id)
                     continue
 
-            enrollment.days_unpaid = (enrollment.days_unpaid or 0) + 1
-            enrollment.payment_current = False
-            overdue_count += 1
+                if policy.autopay:
+                    balance = enrollment.student.get_checking_balance(
+                        teacher_id=policy.teacher_id,
+                        join_code=enrollment.join_code,
+                    )
+                    premium_amount = enrollment.contract_premium
+                    if premium_amount is not None and balance >= premium_amount:
+                        _charge_insurance_enrollment(enrollment, now)
+                        db.session.commit()
+                        charged_count += 1
+                        continue
 
-            cancel_threshold = policy.auto_cancel_nonpay_days or 0
-            if cancel_threshold > 0 and enrollment.days_unpaid >= cancel_threshold:
-                enrollment.status = 'cancelled'
-                enrollment.cancel_date = now
-                cancelled_count += 1
+                enrollment.days_unpaid = max(
+                    0,
+                    (now.date() - enrollment.next_payment_due.date()).days,
+                )
+                enrollment.payment_current = False
+                overdue_count += 1
 
-        db.session.commit()
+                cancel_threshold = policy.auto_cancel_nonpay_days or 0
+                if cancel_threshold > 0 and enrollment.days_unpaid >= cancel_threshold:
+                    enrollment.status = 'cancelled'
+                    enrollment.cancel_date = now
+                    cancelled_count += 1
+
+                db.session.commit()
+            except Exception as enroll_exc:
+                db.session.rollback()
+                logger.error(
+                    "Error processing insurance enrollment %s: %s",
+                    enrollment.id,
+                    enroll_exc,
+                    exc_info=True,
+                )
+
         logger.info(
             "Insurance billing job completed. Charged %s enrollments, marked %s overdue, cancelled %s",
             charged_count,

--- a/app/utils/insurance_billing.py
+++ b/app/utils/insurance_billing.py
@@ -23,7 +23,12 @@ def insurance_next_payment_due(now_utc, charge_frequency):
 
 
 def should_reset_legacy_billing_cycle(enrollment, now_utc):
-    """Return True when an active enrollment predates recurring billing launch."""
+    """Return True when an active enrollment predates recurring billing launch.
+
+    Designed to be a one-time gate: once the cycle is advanced post-launch the
+    enrollment will no longer qualify, preventing repeated free-cycle grants on
+    every subsequent billing run.
+    """
     if not enrollment or enrollment.status != 'active':
         return False
 
@@ -35,4 +40,22 @@ def should_reset_legacy_billing_cycle(enrollment, now_utc):
         return False
 
     next_due = ensure_utc(enrollment.next_payment_due)
-    return next_due is None or next_due <= now_utc
+
+    if next_due is None:
+        return True
+
+    if next_due > now_utc:
+        return False
+
+    # Only reset when the due date itself is pre-launch, OR when the enrollment
+    # has never had a post-launch payment (last_payment_date is still pre-cutoff).
+    # This prevents re-resetting once the billing cycle has been advanced past the
+    # cutoff via a normal payment or prior reset.
+    last_payment_date = ensure_utc(getattr(enrollment, 'last_payment_date', None))
+    return (
+        next_due < INSURANCE_BILLING_LAUNCH_CUTOFF
+        or (
+            last_payment_date is not None
+            and last_payment_date < INSURANCE_BILLING_LAUNCH_CUTOFF
+        )
+    )

--- a/app/utils/insurance_billing.py
+++ b/app/utils/insurance_billing.py
@@ -1,0 +1,38 @@
+"""Helpers for insurance billing cadence and legacy enrollment reset behavior."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.utils.time import ensure_utc
+
+
+# Launch date for recurring billing enforcement from FEAT-INS-002.
+# Pre-launch enrollments get one fresh billing cycle when enforcement first runs.
+INSURANCE_BILLING_LAUNCH_CUTOFF = datetime(2026, 4, 19, tzinfo=timezone.utc)
+
+
+def insurance_next_payment_due(now_utc, charge_frequency):
+    """Return the next premium due date for the given billing frequency."""
+    frequency = (charge_frequency or 'monthly').lower()
+    if frequency == 'weekly':
+        return now_utc + timedelta(days=7)
+    if frequency == 'biweekly':
+        return now_utc + timedelta(days=14)
+    if frequency == 'semester':
+        return now_utc + timedelta(days=7 * 16)
+    return now_utc + timedelta(days=28)
+
+
+def should_reset_legacy_billing_cycle(enrollment, now_utc):
+    """Return True when an active enrollment predates recurring billing launch."""
+    if not enrollment or enrollment.status != 'active':
+        return False
+
+    purchase_date = ensure_utc(enrollment.purchase_date)
+    if not purchase_date:
+        return False
+
+    if purchase_date >= INSURANCE_BILLING_LAUNCH_CUTOFF:
+        return False
+
+    next_due = ensure_utc(enrollment.next_payment_due)
+    return next_due is None or next_due <= now_utc

--- a/db_env.py
+++ b/db_env.py
@@ -1,0 +1,68 @@
+"""Branch-aware database URL resolution for local development and tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+V1_DEV_KEY = "V1_DEV_DATABASE_URL"
+V2_DEV_KEY = "V2_DEV_DATABASE_URL"
+V1_TEST_KEY = "V1_TEST_DATABASE_URL"
+V2_TEST_KEY = "V2_TEST_DATABASE_URL"
+
+
+def _project_root(explicit_root: str | Path | None = None) -> Path:
+    if explicit_root:
+        return Path(explicit_root)
+    return Path(__file__).resolve().parent
+
+
+def detect_branch_name(environ: dict[str, str] | None = None, project_root: str | Path | None = None) -> str | None:
+    env = environ or os.environ
+    for key in ("CTH_BRANCH", "GIT_BRANCH", "BRANCH_NAME"):
+        branch = env.get(key)
+        if branch:
+            return branch
+
+    repo_root = _project_root(project_root)
+    if not (repo_root / ".git").exists():
+        return None
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def branch_db_version(branch_name: str | None) -> str:
+    return "v2" if branch_name and branch_name.startswith("V2_") else "v1"
+
+
+def resolve_dev_database_url(environ: dict[str, str] | None = None, project_root: str | Path | None = None) -> str | None:
+    env = environ or os.environ
+    if env.get("DATABASE_URL"):
+        return env["DATABASE_URL"]
+
+    branch_name = detect_branch_name(env, project_root=project_root)
+    key = V2_DEV_KEY if branch_db_version(branch_name) == "v2" else V1_DEV_KEY
+    return env.get(key)
+
+
+def resolve_test_database_url(environ: dict[str, str] | None = None, project_root: str | Path | None = None) -> str | None:
+    env = environ or os.environ
+    if env.get("TEST_DATABASE_URL"):
+        return env["TEST_DATABASE_URL"]
+
+    branch_name = detect_branch_name(env, project_root=project_root)
+    key = V2_TEST_KEY if branch_db_version(branch_name) == "v2" else V1_TEST_KEY
+    return env.get(key)

--- a/docs/FEATURES/INSURANCE/FEAT-INS-002_Recurring_Billing_Implementation_Plan.md
+++ b/docs/FEATURES/INSURANCE/FEAT-INS-002_Recurring_Billing_Implementation_Plan.md
@@ -1,0 +1,263 @@
+# Insurance Recurring Billing — Implementation Plan
+
+| Reference Number | Version | Effective Date | Supersedes | Authority Level |
+|------------------|---------|----------------|------------|-----------------|
+| FEAT-INS-002 | 1.0 | 2026-04-19 | N/A | Normative |
+
+**Feature:** Insurance Recurring Billing & Student Bill Display
+**Date:** 2026-04-19
+**Status:** Approved for implementation
+**Branch:** `insurance-logic`
+
+---
+
+## 1. Audit Findings (Current State)
+
+### 1.1 What Works
+
+- Students pay a **one-time premium at purchase**. A `Transaction` of type `insurance_premium` is created and debited from checking.
+- `next_payment_due`, `last_payment_date`, `payment_current`, `days_unpaid` fields all exist on `StudentInsurance`.
+- `autopay`, `charge_frequency`, and `auto_cancel_nonpay_days` fields all exist on `InsurancePolicy`.
+- Claim eligibility correctly blocks claims when `payment_current = False`.
+- Admin voiding an `insurance_premium` transaction correctly sets `payment_current = False` and increments `days_unpaid`.
+
+### 1.2 What Does Not Work
+
+| Feature | Status | Evidence |
+|---------|--------|---------|
+| Recurring premium charges | ❌ Not implemented | No scheduled job creates subsequent `insurance_premium` transactions |
+| `autopay` enforcement | ❌ Not implemented | Field is stored but never read by any enforcement code |
+| `auto_cancel_nonpay_days` enforcement | ❌ Not implemented | Field is stored but no job checks it |
+| `days_unpaid` auto-increment | ❌ Not implemented | Only updated on manual admin void |
+| `payment_current` auto-update | ❌ Not implemented | Only updated on manual admin void |
+| Multi-policy (bundle) discounts | ❌ Not implemented | Fields exist but not applied at purchase |
+| Student bill due date display | ❌ Not implemented | `next_payment_due` is never surfaced to students |
+| Teacher bill-preview-window setting | ❌ Not implemented | No such field exists |
+
+### 1.3 Net Effect
+
+Every student who has ever purchased an insurance policy is currently receiving **free coverage indefinitely** after the initial premium. Policies are never charged again, never marked past due, and never auto-cancelled. The `autopay` toggle and `charge_frequency` settings have no mechanical effect.
+
+### 1.4 Existing Data Exposure
+
+As of 2026-04-19, the only live operator is the developer (single-user environment). No real student data is at risk from the migration strategy below.
+
+---
+
+## 2. Multi-Policy (Bundle) Discount — Separate Finding
+
+Bundle discount fields (`bundle_with_policy_ids`, `bundle_discount_percent`, `bundle_discount_amount`) exist on `InsurancePolicy` and are settable via the teacher UI. The discount is **never applied** at purchase time. This is a separate fix from billing enforcement and is tracked as a distinct item in Section 6.
+
+---
+
+## 3. Existing Policy Handling Strategy
+
+Because recurring billing was never enforced, all active enrollments have a `next_payment_due` that is already in the past. Enabling enforcement naively would immediately cancel every active policy.
+
+**Decision: Reset all active enrollments to a fresh billing cycle before enabling enforcement.**
+
+### 3.1 Migration Steps (run once, before deploying billing job)
+
+1. For every `StudentInsurance` with `status = 'active'`:
+   - Set `next_payment_due = now + 1 billing period` (using the policy's `charge_frequency`)
+   - Set `last_payment_date = now`
+   - Set `payment_current = True`
+   - Set `days_unpaid = 0`
+2. Log the count of enrollments reset for audit trail.
+
+This gives every student one free billing cycle grace and then enforcement begins normally.
+
+### 3.2 Rationale
+
+- No retroactive charges — students are not billed for past periods they were never asked to pay.
+- No retroactive cancellations — policies continue uninterrupted.
+- Enforcement starts cleanly from a known state.
+- Consistent with how a real insurer would handle a billing system launch (prospective-only).
+
+---
+
+## 4. Build Plan
+
+### Phase 1 — Recurring Billing Scheduled Job
+
+**File:** `app/scheduled_tasks.py`
+
+Add a nightly job `process_insurance_billing_job()` that runs after midnight. Logic:
+
+```
+for each StudentInsurance where status = 'active' and next_payment_due <= now:
+
+    if autopay is True:
+        attempt to debit frozen_premium from student checking (join_code-scoped):
+            if sufficient funds:
+                create Transaction(type='insurance_premium', amount=-frozen_premium)
+                set last_payment_date = now
+                set next_payment_due = now + 1 billing period
+                set payment_current = True
+                set days_unpaid = 0
+            else:
+                increment days_unpaid by 1
+                set payment_current = False
+                if days_unpaid >= auto_cancel_nonpay_days:
+                    set status = 'cancelled'
+                    set cancel_date = now
+
+    if autopay is False:
+        increment days_unpaid by 1
+        set payment_current = False
+        if days_unpaid >= auto_cancel_nonpay_days:
+            set status = 'cancelled'
+            set cancel_date = now
+```
+
+**Scoping rules:**
+- Use `frozen_premium` (not live `policy.premium`) — student is billed at the rate locked at purchase.
+- All transactions scoped by `join_code`.
+- Balance check uses `student.get_checking_balance(join_code, teacher_id)`.
+- Cancelled enrollments are not re-processed.
+
+**One-time migration:**
+- Before the first run of the job, execute the enrollment reset described in Section 3.1.
+- Can be implemented as a separate `reset_insurance_billing_cycles()` function called once on first deploy.
+
+---
+
+### Phase 2 — Teacher Setting: Bill Preview Window
+
+**Purpose:** When autopay is off, control how many days before the due date a student can see and manually pay their bill.
+
+#### 2a. Model change (`app/models.py`)
+
+Add to `InsurancePolicy`:
+```python
+bill_preview_days = db.Column(db.Integer, nullable=False, default=5)
+```
+
+Constraint: minimum value of 5 enforced at form validation level.
+
+#### 2b. Migration
+
+```
+flask db migrate -m "Add bill_preview_days to InsurancePolicy"
+```
+
+Follow full migration workflow per `.claude/rules/database-migrations.md`.
+
+#### 2c. Form (`app/forms.py`)
+
+Add to `InsurancePolicyForm`:
+```python
+bill_preview_days = IntegerField(
+    'Display insurance bill _ days before due',
+    validators=[NumberRange(min=5)],
+    default=5
+)
+```
+
+#### 2d. Teacher UI (`templates/admin_insurance.html` or edit template)
+
+- Add `bill_preview_days` field adjacent to the existing `autopay` toggle.
+- Show/hide with JS: only visible when `autopay` is unchecked.
+- Label: "Display insurance bill [ ] days before due (minimum 5)"
+
+---
+
+### Phase 3 — Student Persistent Bill Display
+
+**Location:** `templates/student_insurance_marketplace.html`, "My Policies" tab
+
+For each enrolled policy, add a status banner containing:
+
+| Condition | Display |
+|-----------|---------|
+| `payment_current = True` and `autopay = True` | ✅ Paid — Next autopay: [date] for $[amount] |
+| `payment_current = True` and `autopay = False` and `days_until_due > bill_preview_days` | ✅ Paid — Next bill due: [date] for $[amount] |
+| `payment_current = True` and `autopay = False` and `days_until_due <= bill_preview_days` | ✅ Paid — **Bill due [date] for $[amount] — Pay now** |
+| `payment_current = False` | 🔴 Past Due — $[amount] overdue |
+
+The "Pay now" action posts to a new route that manually charges the premium (same debit logic as autopay path).
+
+**New student route:**
+```
+POST /student/insurance/pay/<enrollment_id>
+```
+- Validates `autopay = False` and `payment_current = False` (or due within preview window)
+- Debits `frozen_premium` from checking
+- Updates `last_payment_date`, advances `next_payment_due`, resets `days_unpaid = 0`, sets `payment_current = True`
+
+---
+
+### Phase 4 — Multi-Policy Bundle Discount Fix
+
+**File:** `app/routes/student.py`, `purchase_insurance()` (line ~2295)
+
+After resolving the policy and before checking balance:
+
+```python
+# Check if student holds any policies in bundle_with_policy_ids
+discount_amount = Decimal('0')
+if policy.bundle_with_policy_ids:
+    bundle_ids = [int(x) for x in policy.bundle_with_policy_ids.split(',') if x.strip()]
+    active_bundle_policies = StudentInsurance.query.filter(
+        StudentInsurance.student_id == student.id,
+        StudentInsurance.join_code == join_code,
+        StudentInsurance.policy_id.in_(bundle_ids),
+        StudentInsurance.status == 'active'
+    ).count()
+    if active_bundle_policies > 0:
+        if policy.bundle_discount_percent:
+            discount_amount = policy.premium * (Decimal(str(policy.bundle_discount_percent)) / 100)
+        elif policy.bundle_discount_amount:
+            discount_amount = Decimal(str(policy.bundle_discount_amount))
+
+effective_premium = max(Decimal('0'), policy.premium - discount_amount)
+```
+
+Apply `effective_premium` to the balance check and transaction amount. Store `effective_premium` in `frozen_premium` so recurring billing charges the discounted rate.
+
+---
+
+## 5. Implementation Order
+
+| Step | Task | Depends On |
+|------|------|------------|
+| 1 | One-time enrollment reset migration | Nothing |
+| 2 | Phase 1: Billing scheduled job | Step 1 |
+| 3 | Phase 2a–d: `bill_preview_days` model + form + UI | Nothing |
+| 4 | Phase 3: Student bill display (read-only) | Step 2 |
+| 5 | Phase 3: Manual pay route | Step 2, Step 3 |
+| 6 | Phase 4: Bundle discount fix | Nothing |
+
+Steps 3 and 6 can be worked in parallel with Steps 1–2.
+
+---
+
+## 6. Out of Scope for This Branch
+
+- UI for teachers to view per-student payment history (already available via student policy detail page)
+- Email/notification on failed autopay (no email system exists)
+- Partial payment handling
+- Grace period configuration (currently hard-coded to `auto_cancel_nonpay_days`)
+
+---
+
+## 7. Testing Requirements
+
+Per `.claude/rules/testing.md`:
+
+- `test_billing_job_charges_autopay_student` — autopay student with sufficient funds is charged and `next_payment_due` advances
+- `test_billing_job_insufficient_funds_increments_days_unpaid` — autopay student with no funds gets `payment_current = False`
+- `test_billing_job_cancels_after_threshold` — student reaching `auto_cancel_nonpay_days` is cancelled
+- `test_billing_job_manual_pay_policy_skipped` — manual-pay policy not charged by job
+- `test_billing_job_scoped_by_join_code` — charges only affect correct class period
+- `test_enrollment_reset_migration` — all active enrollments get fresh `next_payment_due`
+- `test_bundle_discount_applied_at_purchase` — discount reduces effective premium when bundle policy held
+- `test_bundle_discount_not_applied_without_bundle_policy` — no discount when no qualifying policy held
+- `test_student_bill_display_shows_within_preview_window` — banner appears when within `bill_preview_days`
+- `test_manual_pay_route_advances_next_payment_due` — manual payment updates all fields correctly
+
+---
+
+**Last Updated:** 2026-04-19
+**Author:** Timothy Chang
+**Status:** Ready for implementation

--- a/docs/STANDARD_OPERATING_PROCEDURES/DATABASE/SOP-DB-010_Database_Switching.md
+++ b/docs/STANDARD_OPERATING_PROCEDURES/DATABASE/SOP-DB-010_Database_Switching.md
@@ -16,11 +16,11 @@ Protected v2.0 branches:
 
 These branches must always use:
 
-- `postgresql://postgres:postgres@localhost/classroom_economy`
+- `postgresql://postgres:postgres@localhost:5432/classroom_economy`
 
 All other branches may use:
 
-- `postgresql://postgres:postgres@localhost/production_dev`
+- `postgresql://postgres:postgres@localhost:5432/production_dev`
 
 ### How It Works
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,21 +1,15 @@
 #!/bin/bash
-# Branch-aware database switching hook.
+# Branch-aware database status hook.
 # V2_* branches use V2 dev/test databases; all others use V1 dev/test databases.
 
 set -e
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-ENV_FILE="$REPO_ROOT/.env"
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/lib/db_branch_config.sh"
-load_db_urls_from_env "$ENV_FILE"
-
-if [ ! -f "$ENV_FILE" ]; then
-  echo "Warning: .env file not found"
-  exit 0
-fi
+load_db_urls_from_env "$REPO_ROOT/.env"
 
 TARGET_VERSION=$(branch_db_version "$BRANCH_NAME")
 
@@ -27,21 +21,6 @@ else
   target_test_url="$V1_TEST_DATABASE_URL"
 fi
 
-update_env_var() {
-  local key="$1"
-  local value="$2"
-  local escaped_value
-
-  escaped_value=$(printf '%s' "$value" | sed 's/[&/|]/\\&/g')
-  if grep -q "^${key}=" "$ENV_FILE"; then
-    sed -i.bak "s|^${key}=.*|${key}=${escaped_value}|" "$ENV_FILE"
-  else
-    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
-  fi
-}
-
-update_env_var "DATABASE_URL" "$target_dev_url"
-update_env_var "TEST_DATABASE_URL" "$target_test_url"
-rm -f "$ENV_FILE.bak"
-
-echo "✓ Switched to $TARGET_VERSION databases ($BRANCH_NAME branch)"
+echo "✓ Active branch database selection: $TARGET_VERSION ($BRANCH_NAME branch)"
+echo "  DATABASE_URL=$target_dev_url"
+echo "  TEST_DATABASE_URL=$target_test_url"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,35 +1,47 @@
 #!/bin/bash
 # Branch-aware database switching hook.
-# Protected v2 branches always use classroom_economy to avoid migration-chain corruption.
+# V2_* branches use V2 dev/test databases; all others use V1 dev/test databases.
 
 set -e
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
+ENV_FILE="$REPO_ROOT/.env"
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/lib/db_branch_config.sh"
-
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-ENV_FILE="$REPO_ROOT/.env"
+load_db_urls_from_env "$ENV_FILE"
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "Warning: .env file not found"
   exit 0
 fi
 
-if is_protected_branch "$BRANCH_NAME"; then
-  target_url="$CLASSROOM_ECONOMY_DB_URL"
-  target_name="classroom_economy"
+TARGET_VERSION=$(branch_db_version "$BRANCH_NAME")
+
+if [ "$TARGET_VERSION" = "v2" ]; then
+  target_dev_url="$V2_DEV_DATABASE_URL"
+  target_test_url="$V2_TEST_DATABASE_URL"
 else
-  target_url="$PRODUCTION_DEV_DB_URL"
-  target_name="production_dev"
+  target_dev_url="$V1_DEV_DATABASE_URL"
+  target_test_url="$V1_TEST_DATABASE_URL"
 fi
 
-if grep -q "^DATABASE_URL=" "$ENV_FILE"; then
-  escaped_target_url=$(printf '%s' "$target_url" | sed 's/[&/|]/\\&/g')
-  sed -i.bak "s|^DATABASE_URL=.*|DATABASE_URL=$escaped_target_url|" "$ENV_FILE"
-  rm -f "$ENV_FILE.bak"
-else
-  echo "DATABASE_URL=$target_url" >> "$ENV_FILE"
-fi
+update_env_var() {
+  local key="$1"
+  local value="$2"
+  local escaped_value
 
-echo "✓ Switched to $target_name database ($BRANCH_NAME branch)"
+  escaped_value=$(printf '%s' "$value" | sed 's/[&/|]/\\&/g')
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i.bak "s|^${key}=.*|${key}=${escaped_value}|" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  fi
+}
+
+update_env_var "DATABASE_URL" "$target_dev_url"
+update_env_var "TEST_DATABASE_URL" "$target_test_url"
+rm -f "$ENV_FILE.bak"
+
+echo "✓ Switched to $TARGET_VERSION databases ($BRANCH_NAME branch)"

--- a/scripts/lib/db_branch_config.sh
+++ b/scripts/lib/db_branch_config.sh
@@ -1,22 +1,61 @@
 #!/bin/bash
-# Shared database/branch policy used by hook and manual switch script.
+# Shared database/branch policy used by hooks and manual switch scripts.
 
-PRODUCTION_DEV_DB_URL="postgresql://postgres:postgres@localhost:5432/production_dev"
-CLASSROOM_ECONOMY_DB_URL="postgresql://postgres:postgres@localhost:5432/classroom_economy"
+DEFAULT_V1_DEV_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/production_dev"
+DEFAULT_V2_DEV_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/classroom_economy"
+DEFAULT_V1_TEST_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/classroom_economy_test"
+DEFAULT_V2_TEST_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/classroom_economy_v2_test"
 
-PROTECTED_BRANCHES=(
-  "join-code-centric-architecture-rebuild"
-  "codex/fix-database-model-for-dob-sum-storage"
-  "codex/v2.0"
-)
+_db_env_value() {
+  local env_file="$1"
+  local key="$2"
 
-is_protected_branch() {
+  if [ -f "$env_file" ]; then
+    awk -F= -v target="$key" '$1 == target { sub(/^[^=]*=/, "", $0); print $0; exit }' "$env_file"
+  fi
+}
+
+load_db_urls_from_env() {
+  local env_file="$1"
+
+  V1_DEV_DATABASE_URL="${V1_DEV_DATABASE_URL:-$(_db_env_value "$env_file" "V1_DEV_DATABASE_URL")}"
+  V2_DEV_DATABASE_URL="${V2_DEV_DATABASE_URL:-$(_db_env_value "$env_file" "V2_DEV_DATABASE_URL")}"
+  V1_TEST_DATABASE_URL="${V1_TEST_DATABASE_URL:-$(_db_env_value "$env_file" "V1_TEST_DATABASE_URL")}"
+  V2_TEST_DATABASE_URL="${V2_TEST_DATABASE_URL:-$(_db_env_value "$env_file" "V2_TEST_DATABASE_URL")}"
+
+  V1_DEV_DATABASE_URL="${V1_DEV_DATABASE_URL:-$DEFAULT_V1_DEV_DATABASE_URL}"
+  V2_DEV_DATABASE_URL="${V2_DEV_DATABASE_URL:-$DEFAULT_V2_DEV_DATABASE_URL}"
+  V1_TEST_DATABASE_URL="${V1_TEST_DATABASE_URL:-$DEFAULT_V1_TEST_DATABASE_URL}"
+  V2_TEST_DATABASE_URL="${V2_TEST_DATABASE_URL:-$DEFAULT_V2_TEST_DATABASE_URL}"
+}
+
+is_v2_branch() {
   local branch="$1"
-  local protected
-  for protected in "${PROTECTED_BRANCHES[@]}"; do
-    if [ "$branch" = "$protected" ]; then
+  case "$branch" in
+    V2_*)
       return 0
-    fi
-  done
-  return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+branch_db_version() {
+  local branch="$1"
+  if is_v2_branch "$branch"; then
+    printf 'v2'
+  else
+    printf 'v1'
+  fi
+}
+
+db_urls_for_branch() {
+  local branch="$1"
+
+  if is_v2_branch "$branch"; then
+    printf '%s\n%s\n' "$V2_DEV_DATABASE_URL" "$V2_TEST_DATABASE_URL"
+  else
+    printf '%s\n%s\n' "$V1_DEV_DATABASE_URL" "$V1_TEST_DATABASE_URL"
+  fi
 }

--- a/scripts/switch-db.sh
+++ b/scripts/switch-db.sh
@@ -1,64 +1,77 @@
 #!/bin/bash
 # Manual database switcher script
-# Usage: ./scripts/switch-db.sh [production_dev|classroom_economy]
+# Usage:
+#   ./scripts/switch-db.sh            # auto-detect from current branch
+#   ./scripts/switch-db.sh v1|v2      # force version
+
+set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/lib/db_branch_config.sh"
+load_db_urls_from_env "$ENV_FILE"
 
-if [ -z "$1" ]; then
-    echo "Usage: ./scripts/switch-db.sh [production_dev|classroom_economy]"
+BRANCH_NAME=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+TARGET_VERSION="${1:-$(branch_db_version "$BRANCH_NAME")}"
+
+case "$TARGET_VERSION" in
+  v1|V1)
+    TARGET_VERSION="v1"
+    DEV_DB_URL="$V1_DEV_DATABASE_URL"
+    TEST_DB_URL="$V1_TEST_DATABASE_URL"
+    ;;
+  v2|V2)
+    TARGET_VERSION="v2"
+    DEV_DB_URL="$V2_DEV_DATABASE_URL"
+    TEST_DB_URL="$V2_TEST_DATABASE_URL"
+    ;;
+  "")
+    echo "Unable to determine branch version."
+    exit 1
+    ;;
+  *)
+    echo "Usage: ./scripts/switch-db.sh [v1|v2]"
     echo ""
-    if [ -f "$REPO_ROOT/.env" ] && grep -q "^DATABASE_URL=" "$REPO_ROOT/.env"; then
-        echo "Current DATABASE_URL:"
-        grep "^DATABASE_URL=" "$REPO_ROOT/.env"
+    echo "Current branch: $BRANCH_NAME"
+    if [ -f "$ENV_FILE" ]; then
+      echo "Current DATABASE_URL:"
+      grep "^DATABASE_URL=" "$ENV_FILE" || true
+      echo "Current TEST_DATABASE_URL:"
+      grep "^TEST_DATABASE_URL=" "$ENV_FILE" || true
     else
-        echo "No DATABASE_URL found in $REPO_ROOT/.env"
+      echo "No .env file found at $ENV_FILE"
     fi
     exit 1
-fi
-
-DB_NAME=$1
-ENV_FILE="$REPO_ROOT/.env"
-BRANCH_NAME=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-
-case $DB_NAME in
-    production_dev)
-        if is_protected_branch "$BRANCH_NAME"; then
-            echo "Error: '$BRANCH_NAME' must use classroom_economy to protect v2.0 migration chain."
-            echo "production_dev is off-limits for this branch."
-            exit 1
-        fi
-        DB_URL="$PRODUCTION_DEV_DB_URL"
-        ;;
-    classroom_economy)
-        DB_URL="$CLASSROOM_ECONOMY_DB_URL"
-        ;;
-    *)
-        echo "Error: Invalid database name. Use 'production_dev' or 'classroom_economy'."
-        exit 1
-        ;;
+    ;;
 esac
 
-# Create .env file if it doesn't exist
-if [ ! -f "$ENV_FILE" ]; then
-    echo "DATABASE_URL=$DB_URL" > "$ENV_FILE"
-    echo "✓ Created .env file and set $DB_NAME database"
-    echo "  DATABASE_URL=$DB_URL"
-    exit 0
-fi
+ensure_env_var() {
+  local key="$1"
+  local value="$2"
 
-# Check if DATABASE_URL line exists
-if grep -q "^DATABASE_URL=" "$ENV_FILE"; then
-    # Update existing line
-    escaped_db_url=$(printf '%s' "$DB_URL" | sed 's/[&/|]/\\&/g')
-    sed -i.bak "s|^DATABASE_URL=.*|DATABASE_URL=$escaped_db_url|" "$ENV_FILE"
+  if [ ! -f "$ENV_FILE" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+    return
+  fi
+
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    local escaped_value
+    escaped_value=$(printf '%s' "$value" | sed 's/[&/|]/\\&/g')
+    sed -i.bak "s|^${key}=.*|${key}=${escaped_value}|" "$ENV_FILE"
     rm -f "$ENV_FILE.bak"
-else
-    # Append new line
-    echo "DATABASE_URL=$DB_URL" >> "$ENV_FILE"
-fi
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  fi
+}
 
-echo "✓ Switched to $DB_NAME database"
-echo "  DATABASE_URL=$DB_URL"
+touch "$ENV_FILE"
+ensure_env_var "DATABASE_URL" "$DEV_DB_URL"
+ensure_env_var "TEST_DATABASE_URL" "$TEST_DB_URL"
+
+echo "✓ Switched database URLs for $TARGET_VERSION"
+echo "  Branch: $BRANCH_NAME"
+echo "  DATABASE_URL=$DEV_DB_URL"
+echo "  TEST_DATABASE_URL=$TEST_DB_URL"

--- a/scripts/switch-db.sh
+++ b/scripts/switch-db.sh
@@ -10,11 +10,11 @@ source "$REPO_ROOT/scripts/lib/db_branch_config.sh"
 if [ -z "$1" ]; then
     echo "Usage: ./scripts/switch-db.sh [production_dev|classroom_economy]"
     echo ""
-    if [ -f ".env" ] && grep -q "^DATABASE_URL=" .env; then
+    if [ -f "$REPO_ROOT/.env" ] && grep -q "^DATABASE_URL=" "$REPO_ROOT/.env"; then
         echo "Current DATABASE_URL:"
-        grep "^DATABASE_URL=" .env
+        grep "^DATABASE_URL=" "$REPO_ROOT/.env"
     else
-        echo "No DATABASE_URL found in .env"
+        echo "No DATABASE_URL found in $REPO_ROOT/.env"
     fi
     exit 1
 fi

--- a/scripts/switch-db.sh
+++ b/scripts/switch-db.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Manual database switcher script
+# Branch-aware database selector helper.
 # Usage:
-#   ./scripts/switch-db.sh            # auto-detect from current branch
-#   ./scripts/switch-db.sh v1|v2      # force version
+#   ./scripts/switch-db.sh            # show auto-derived URLs for current branch
+#   ./scripts/switch-db.sh v1|v2      # show URLs for a specific version
 
 set -e
 
@@ -34,44 +34,15 @@ case "$TARGET_VERSION" in
     ;;
   *)
     echo "Usage: ./scripts/switch-db.sh [v1|v2]"
-    echo ""
-    echo "Current branch: $BRANCH_NAME"
-    if [ -f "$ENV_FILE" ]; then
-      echo "Current DATABASE_URL:"
-      grep "^DATABASE_URL=" "$ENV_FILE" || true
-      echo "Current TEST_DATABASE_URL:"
-      grep "^TEST_DATABASE_URL=" "$ENV_FILE" || true
-    else
-      echo "No .env file found at $ENV_FILE"
-    fi
     exit 1
     ;;
 esac
 
-ensure_env_var() {
-  local key="$1"
-  local value="$2"
-
-  if [ ! -f "$ENV_FILE" ]; then
-    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
-    return
-  fi
-
-  if grep -q "^${key}=" "$ENV_FILE"; then
-    local escaped_value
-    escaped_value=$(printf '%s' "$value" | sed 's/[&/|]/\\&/g')
-    sed -i.bak "s|^${key}=.*|${key}=${escaped_value}|" "$ENV_FILE"
-    rm -f "$ENV_FILE.bak"
-  else
-    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
-  fi
-}
-
-touch "$ENV_FILE"
-ensure_env_var "DATABASE_URL" "$DEV_DB_URL"
-ensure_env_var "TEST_DATABASE_URL" "$TEST_DB_URL"
-
-echo "✓ Switched database URLs for $TARGET_VERSION"
+echo "✓ Derived database URLs for $TARGET_VERSION"
 echo "  Branch: $BRANCH_NAME"
 echo "  DATABASE_URL=$DEV_DB_URL"
 echo "  TEST_DATABASE_URL=$TEST_DB_URL"
+echo ""
+echo "No .env rewrite performed."
+echo "For a one-off override:"
+echo "  DATABASE_URL=$DEV_DB_URL TEST_DATABASE_URL=$TEST_DB_URL <command>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import sys
 from dotenv import load_dotenv
+from pathlib import Path
+from db_env import resolve_test_database_url
 
 # Load environment variables from .env file
 load_dotenv()
@@ -8,8 +10,10 @@ load_dotenv()
 # Override env vars for testing.
 # Prefer a real PostgreSQL test database when configured; otherwise fall back to
 # in-memory SQLite for isolated environments that do not provide one.
-resolved_test_db_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("V1_TEST_DATABASE_URL")
+project_root = Path(__file__).resolve().parent.parent
+resolved_test_db_url = resolve_test_database_url(os.environ, project_root=project_root)
 if resolved_test_db_url:
+    os.environ["TEST_DATABASE_URL"] = resolved_test_db_url
     os.environ["DATABASE_URL"] = resolved_test_db_url
 else:
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,20 +56,21 @@ def _terminate_other_postgres_sessions():
     if not db_name:
         return
 
+    import logging
+    _log = logging.getLogger("conftest")
+
     # Safety guard: only terminate sessions when we can positively identify a
     # dedicated test database, preventing accidental impact on local dev sessions.
     is_test_db = db_name.endswith("_test") or bool(os.environ.get("TEST_DATABASE_URL"))
     if not is_test_db:
-        import logging
-        logging.getLogger("conftest").warning(
+        _log.warning(
             "Skipping session termination: %r does not look like a test DB "
             "(name does not end with '_test' and TEST_DATABASE_URL is not set)",
             db_name,
         )
         return
 
-    import logging
-    logging.getLogger("conftest").info("Terminating stale sessions for test database: %s", db_name)
+    _log.info("Terminating stale sessions for test database: %s", db_name)
 
     admin_url = engine_url.set(database="postgres")
     admin_engine = create_engine(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,13 @@ import os
 import sys
 from dotenv import load_dotenv
 from pathlib import Path
-from db_env import resolve_test_database_url
 
 # Load environment variables from .env file
 load_dotenv()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from db_env import resolve_test_database_url
 
 # Override env vars for testing.
 # Prefer a real PostgreSQL test database when configured; otherwise fall back to
@@ -28,9 +31,6 @@ os.environ.setdefault("RATELIMIT_STORAGE_URI", "memory://")
 # Use valid Fernet keys (32 url-safe base64-encoded bytes)
 os.environ.setdefault("ENCRYPTION_KEY", "jhe53bcYZI4_MZS4Kb8hu8-xnQHHvwqSX8LN4sDtzbw=")
 os.environ.setdefault("PEPPER_KEY", "tKiXIAgaPqsOOhR1PqvdEQo4BelrN5SP3cpWxVYrsHk=")
-
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
 from sqlalchemy import create_engine, event, text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,29 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
     cursor.close()
 
 
+def _terminate_other_postgres_sessions():
+    """Kill stale sessions against the dedicated Postgres test DB before schema reset."""
+    if db.engine.dialect.name != "postgresql":
+        return
+
+    db_name = db.engine.url.database
+    if not db_name:
+        return
+
+    db.session.execute(
+        text(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = :db_name
+              AND pid <> pg_backend_pid()
+            """
+        ),
+        {"db_name": db_name},
+    )
+    db.session.commit()
+
+
 @pytest.fixture
 def app():
     """Provide the Flask app instance for tests."""
@@ -59,6 +82,8 @@ def app():
     
     # Ensure strict separation - if connection fails, test fails
     with flask_app.app_context():
+        db.session.remove()
+        _terminate_other_postgres_sessions()
         db.drop_all()
         db.create_all()
 
@@ -84,6 +109,7 @@ def client(app):
     # Teardown: Drop all tables after test
     limiter.reset()
     db.session.remove()
+    _terminate_other_postgres_sessions()
     db.drop_all()
     ctx.pop()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,21 @@ def _terminate_other_postgres_sessions():
     if not db_name:
         return
 
+    # Safety guard: only terminate sessions when we can positively identify a
+    # dedicated test database, preventing accidental impact on local dev sessions.
+    is_test_db = db_name.endswith("_test") or bool(os.environ.get("TEST_DATABASE_URL"))
+    if not is_test_db:
+        import logging
+        logging.getLogger("conftest").warning(
+            "Skipping session termination: %r does not look like a test DB "
+            "(name does not end with '_test' and TEST_DATABASE_URL is not set)",
+            db_name,
+        )
+        return
+
+    import logging
+    logging.getLogger("conftest").info("Terminating stale sessions for test database: %s", db_name)
+
     admin_url = engine_url.set(database="postgres")
     admin_engine = create_engine(
         admin_url,
@@ -135,7 +150,7 @@ def client(app):
         @event.listens_for(test_session(), "after_transaction_end")
         def restart_savepoint(session, transaction):
             nonlocal nested_transaction
-            if transaction.nested and not transaction._parent.nested:
+            if transaction.nested and not transaction.parent.nested:
                 nested_transaction = connection.begin_nested()
 
         client = flask_app.test_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,9 @@ os.environ.setdefault("PEPPER_KEY", "tKiXIAgaPqsOOhR1PqvdEQo4BelrN5SP3cpWxVYrsHk
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
-from sqlalchemy import event, text
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
 from app import app as flask_app, db, Student
 from app.extensions import limiter
 
@@ -45,25 +47,36 @@ def _terminate_other_postgres_sessions():
     if db.engine.dialect.name != "postgresql":
         return
 
-    db_name = db.engine.url.database
+    engine_url = db.engine.url
+    db_name = engine_url.database
     if not db_name:
         return
 
-    db.session.execute(
-        text(
-            """
-            SELECT pg_terminate_backend(pid)
-            FROM pg_stat_activity
-            WHERE datname = :db_name
-              AND pid <> pg_backend_pid()
-            """
-        ),
-        {"db_name": db_name},
+    admin_url = engine_url.set(database="postgres")
+    admin_engine = create_engine(
+        admin_url,
+        poolclass=NullPool,
+        isolation_level="AUTOCOMMIT",
     )
-    db.session.commit()
+
+    try:
+        with admin_engine.connect() as conn:
+            conn.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :db_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"db_name": db_name},
+            )
+    finally:
+        admin_engine.dispose()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def app():
     """Provide the Flask app instance for tests."""
     # Use a separate test database to avoid clashing with dev data.
@@ -93,25 +106,61 @@ def app():
 @pytest.fixture
 def client(app):
     """
-    Test client that creates a fresh database for each test.
-    Ensures isolation between tests.
+    Test client with per-test database isolation.
+
+    On PostgreSQL, keep the schema stable and wrap each test in an outer
+    transaction plus a nested savepoint so explicit commits inside tests do not
+    leak state into the next test.
     """
     ctx = app.app_context()
     ctx.push()
-    
-    # Create all tables for the test
+
+    limiter.reset()
+
+    if db.engine.dialect.name == 'postgresql':
+        connection = db.engine.connect()
+        outer_transaction = connection.begin()
+        nested_transaction = connection.begin_nested()
+
+        session_factory = sessionmaker(bind=connection)
+        test_session = scoped_session(session_factory)
+
+        original_session = db.session
+        db.session = test_session
+
+        @event.listens_for(test_session(), "after_transaction_end")
+        def restart_savepoint(session, transaction):
+            nonlocal nested_transaction
+            if transaction.nested and not transaction._parent.nested:
+                nested_transaction = connection.begin_nested()
+
+        client = flask_app.test_client()
+
+        try:
+            yield client
+        finally:
+            event.remove(test_session(), "after_transaction_end", restart_savepoint)
+            limiter.reset()
+            test_session.remove()
+            db.session = original_session
+            if nested_transaction.is_active:
+                nested_transaction.rollback()
+            if outer_transaction.is_active:
+                outer_transaction.rollback()
+            connection.close()
+            ctx.pop()
+        return
+
+    # SQLite fallback for isolated environments without PostgreSQL.
     db.create_all()
-    limiter.reset()
-    
     client = flask_app.test_client()
-    yield client
-    
-    # Teardown: Drop all tables after test
-    limiter.reset()
-    db.session.remove()
-    _terminate_other_postgres_sessions()
-    db.drop_all()
-    ctx.pop()
+    try:
+        yield client
+    finally:
+        limiter.reset()
+        db.session.remove()
+        db.drop_all()
+        ctx.pop()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,15 @@ from dotenv import load_dotenv
 # Load environment variables from .env file
 load_dotenv()
 
-# Override env vars for testing
+# Override env vars for testing.
+# Prefer a real PostgreSQL test database when configured; otherwise fall back to
+# in-memory SQLite for isolated environments that do not provide one.
+resolved_test_db_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("V1_TEST_DATABASE_URL")
+if resolved_test_db_url:
+    os.environ["DATABASE_URL"] = resolved_test_db_url
+else:
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 os.environ["SECRET_KEY"] = "test-secret"
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 os.environ["FLASK_ENV"] = "testing"
 os.environ["PEPPER_KEY"] = "test-primary-pepper"
 os.environ["PEPPER_LEGACY_KEYS"] = "legacy-pepper"
@@ -38,7 +44,8 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 def app():
     """Provide the Flask app instance for tests."""
     # Use a separate test database to avoid clashing with dev data.
-    # Prefer TEST_DATABASE_URL if set, otherwise use DATABASE_URL (sqlite in-memory in tests).
+    # Prefer TEST_DATABASE_URL when present; DATABASE_URL has already been
+    # rewritten above to the resolved test database for import-time safety.
     test_db_url = os.environ.get("TEST_DATABASE_URL", os.environ["DATABASE_URL"])
 
     flask_app.config.update(

--- a/tests/test_attendance.py
+++ b/tests/test_attendance.py
@@ -1,5 +1,4 @@
-import pytest
-from app import app, db, Student, TapEvent, Transaction
+from app import db, Student, TapEvent, Transaction
 from app.attendance import (
     get_last_payroll_time,
     calculate_unpaid_attendance_seconds,
@@ -8,16 +7,6 @@ from app.attendance import (
     get_all_block_statuses
 )
 from datetime import datetime, timedelta, timezone
-
-@pytest.fixture
-def client():
-    app.config['TESTING'] = True
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    with app.test_client() as client:
-        with app.app_context():
-            db.create_all()
-            yield client
-            db.drop_all()
 
 def test_get_last_payroll_time(client):
     # Test with no payroll transactions

--- a/tests/test_insurance_recurring_billing.py
+++ b/tests/test_insurance_recurring_billing.py
@@ -1,0 +1,258 @@
+from datetime import timedelta
+from decimal import Decimal
+
+from app.extensions import db
+from app.models import (
+    Admin,
+    InsurancePolicy,
+    Student,
+    StudentInsurance,
+    StudentTeacher,
+    TeacherBlock,
+    Transaction,
+)
+from app.scheduled_tasks import process_insurance_billing_job, reset_insurance_billing_cycles
+from app.utils.insurance_billing import (
+    INSURANCE_BILLING_LAUNCH_CUTOFF,
+    insurance_next_payment_due,
+)
+from app.utils.time import ensure_utc
+
+
+def _build_teacher_student(join_code='INSJOIN1', block='A'):
+    teacher = Admin(username=f"teacher_{join_code}", totp_secret="secret")
+    db.session.add(teacher)
+    db.session.flush()
+
+    student = Student(first_name="Ins", last_initial="T", block=block, salt=b'salt')
+    db.session.add(student)
+    db.session.flush()
+
+    db.session.add(StudentTeacher(student_id=student.id, admin_id=teacher.id, join_code=join_code))
+    db.session.add(TeacherBlock(
+        teacher_id=teacher.id,
+        block=block,
+        join_code=join_code,
+        student_id=student.id,
+        is_claimed=True,
+        first_name='Ins',
+        last_initial='T',
+        last_name_hash_by_part=[],
+        dob_sum=0,
+        salt=b'salt',
+        first_half_hash=f'hash-{join_code}',
+    ))
+    db.session.flush()
+    return teacher, student
+
+
+def _policy(teacher_id, code, title, premium='10.00', autopay=True, auto_cancel_nonpay_days=3, charge_frequency='monthly'):
+    policy = InsurancePolicy(
+        policy_code=code,
+        teacher_id=teacher_id,
+        title=title,
+        description='',
+        premium=Decimal(premium),
+        charge_frequency=charge_frequency,
+        autopay=autopay,
+        auto_cancel_nonpay_days=auto_cancel_nonpay_days,
+        claim_type='transaction_monetary',
+        is_monetary=True,
+    )
+    db.session.add(policy)
+    db.session.flush()
+    return policy
+
+
+def _enrollment(student_id, policy_id, join_code, *, purchase_date, next_payment_due, days_unpaid=0, payment_current=True, status='active'):
+    enrollment = StudentInsurance(
+        student_id=student_id,
+        policy_id=policy_id,
+        join_code=join_code,
+        status=status,
+        purchase_date=purchase_date,
+        last_payment_date=purchase_date,
+        next_payment_due=next_payment_due,
+        coverage_start_date=purchase_date,
+        days_unpaid=days_unpaid,
+        payment_current=payment_current,
+    )
+    db.session.add(enrollment)
+    db.session.flush()
+    enrollment.freeze_policy_snapshot(enrollment.policy)
+    db.session.commit()
+    return enrollment
+
+
+def _deposit(student_id, teacher_id, join_code, amount):
+    db.session.add(Transaction(
+        student_id=student_id,
+        teacher_id=teacher_id,
+        join_code=join_code,
+        amount=Decimal(amount),
+        account_type='checking',
+        type='deposit',
+        description='Initial funds',
+    ))
+    db.session.commit()
+
+
+def test_enrollment_reset_migration_only_resets_legacy_active_plans(app):
+    with app.app_context():
+        teacher, student = _build_teacher_student('LEGACY1')
+        policy = _policy(teacher.id, 'LEGACY-POL', 'Legacy Coverage')
+
+        legacy_purchase = INSURANCE_BILLING_LAUNCH_CUTOFF - timedelta(days=30)
+        modern_purchase = INSURANCE_BILLING_LAUNCH_CUTOFF + timedelta(days=1)
+        now = INSURANCE_BILLING_LAUNCH_CUTOFF + timedelta(days=2)
+
+        legacy = _enrollment(
+            student.id,
+            policy.id,
+            'LEGACY1',
+            purchase_date=legacy_purchase,
+            next_payment_due=legacy_purchase + timedelta(days=28),
+        )
+        modern = _enrollment(
+            student.id,
+            policy.id,
+            'LEGACY1',
+            purchase_date=modern_purchase,
+            next_payment_due=modern_purchase + timedelta(days=28),
+        )
+
+        reset_count = reset_insurance_billing_cycles(now=now)
+
+        db.session.refresh(legacy)
+        db.session.refresh(modern)
+
+        assert reset_count == 1
+        assert ensure_utc(legacy.last_payment_date) == now
+        assert ensure_utc(legacy.next_payment_due) == insurance_next_payment_due(now, policy.charge_frequency)
+        assert legacy.payment_current is True
+        assert legacy.days_unpaid == 0
+
+        assert ensure_utc(modern.last_payment_date) == modern_purchase
+        assert ensure_utc(modern.next_payment_due) == modern_purchase + timedelta(days=28)
+
+
+def test_billing_job_charges_autopay_student_and_scopes_by_join_code(app):
+    with app.app_context():
+        teacher, student = _build_teacher_student('BILLA')
+        db.session.add(TeacherBlock(
+            teacher_id=teacher.id,
+            block='B',
+            join_code='BILLB',
+            student_id=student.id,
+            is_claimed=True,
+            first_name='Ins',
+            last_initial='T',
+            last_name_hash_by_part=[],
+            dob_sum=0,
+            salt=b'salt',
+            first_half_hash='hash-BILLB',
+        ))
+        db.session.commit()
+
+        policy_a = _policy(teacher.id, 'AUTO-A', 'Coverage A', premium='10.00')
+        policy_b = _policy(teacher.id, 'AUTO-B', 'Coverage B', premium='10.00')
+        now = INSURANCE_BILLING_LAUNCH_CUTOFF + timedelta(days=10)
+
+        enrollment_a = _enrollment(
+            student.id,
+            policy_a.id,
+            'BILLA',
+            purchase_date=now - timedelta(days=10),
+            next_payment_due=now - timedelta(days=1),
+        )
+        enrollment_b = _enrollment(
+            student.id,
+            policy_b.id,
+            'BILLB',
+            purchase_date=now - timedelta(days=10),
+            next_payment_due=now - timedelta(days=1),
+        )
+        _deposit(student.id, teacher.id, 'BILLA', '25.00')
+
+        process_insurance_billing_job(now=now)
+
+        db.session.refresh(enrollment_a)
+        db.session.refresh(enrollment_b)
+
+        assert enrollment_a.payment_current is True
+        assert enrollment_a.days_unpaid == 0
+        assert ensure_utc(enrollment_a.next_payment_due) == insurance_next_payment_due(now, policy_a.charge_frequency)
+        assert Transaction.query.filter_by(
+            student_id=student.id,
+            join_code='BILLA',
+            type='insurance_premium',
+        ).count() == 1
+
+        assert enrollment_b.payment_current is False
+        assert enrollment_b.days_unpaid == 1
+        assert Transaction.query.filter_by(
+            student_id=student.id,
+            join_code='BILLB',
+            type='insurance_premium',
+        ).count() == 0
+
+
+def test_billing_job_manual_pay_policy_skipped_and_marked_overdue(app):
+    with app.app_context():
+        teacher, student = _build_teacher_student('MANPAY1')
+        policy = _policy(teacher.id, 'MANUAL-1', 'Manual Coverage', premium='12.00', autopay=False)
+        now = INSURANCE_BILLING_LAUNCH_CUTOFF + timedelta(days=10)
+
+        enrollment = _enrollment(
+            student.id,
+            policy.id,
+            'MANPAY1',
+            purchase_date=now - timedelta(days=5),
+            next_payment_due=now - timedelta(days=1),
+        )
+        _deposit(student.id, teacher.id, 'MANPAY1', '50.00')
+
+        process_insurance_billing_job(now=now)
+
+        db.session.refresh(enrollment)
+
+        assert enrollment.payment_current is False
+        assert enrollment.days_unpaid == 1
+        assert enrollment.status == 'active'
+        assert Transaction.query.filter_by(
+            student_id=student.id,
+            join_code='MANPAY1',
+            type='insurance_premium',
+        ).count() == 0
+
+
+def test_billing_job_cancels_after_threshold(app):
+    with app.app_context():
+        teacher, student = _build_teacher_student('CANCEL1')
+        policy = _policy(
+            teacher.id,
+            'CANCEL-POL',
+            'Cancel Coverage',
+            premium='8.00',
+            autopay=False,
+            auto_cancel_nonpay_days=2,
+        )
+        now = INSURANCE_BILLING_LAUNCH_CUTOFF + timedelta(days=10)
+
+        enrollment = _enrollment(
+            student.id,
+            policy.id,
+            'CANCEL1',
+            purchase_date=now - timedelta(days=3),
+            next_payment_due=now - timedelta(days=1),
+            days_unpaid=1,
+        )
+
+        process_insurance_billing_job(now=now)
+
+        db.session.refresh(enrollment)
+
+        assert enrollment.payment_current is False
+        assert enrollment.days_unpaid == 2
+        assert enrollment.status == 'cancelled'
+        assert ensure_utc(enrollment.cancel_date) == now


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details open>
<summary>STANDARD PR SECTION</summary>

## Schema Change Gate Classification (Required for schema changes)

- [ ] **EXPAND** – Additive, backward-compatible (no removals)
- [ ] **CONTRACT (CODE ONLY)** – Model attribute removal, DB schema unchanged
- [ ] **CONTRACT (DATABASE)** – Destructive migration only

## Description

Implements the minimal v1 insurance recurring billing fix from FEAT-INS-002 and adds the one-time legacy enrollment reset path for existing active plans.

Also refactors local database selection and test configuration so:
- local dev/test databases are derived from branch name plus the four canonical v1/v2 preset URLs
- `.env` no longer stores duplicated active `DATABASE_URL` / `TEST_DATABASE_URL` values
- pytest defaults to PostgreSQL test databases instead of SQLite
- the shared test harness better handles PostgreSQL-backed execution

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [x] Added new tests for new functionality

Tested:
- `pytest tests/test_insurance_recurring_billing.py -q`
- `pytest tests/test_void_transaction_rules.py -k insurance_premium`
- `pytest tests/test_scheduled_tasks_store_item_cleanup.py`
- `python3 -m compileall app/scheduled_tasks.py app/routes/student.py app/utils/insurance_billing.py tests/test_insurance_recurring_billing.py`
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/classroom_economy_test pytest tests/test_insurance_recurring_billing.py -q`
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/classroom_economy_test pytest tests/test_attendance.py -q`
- `TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/classroom_economy_test pytest tests/test_announcements.py -q`

Note:
- Full PostgreSQL-backed `pytest` is still surfacing additional failures in the broader suite, but the PR branch now uses the intended Postgres test path instead of the old SQLite-default behavior.

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

**Migration file location:**
<!-- N/A -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

- No Alembic migration was added for the insurance fix; the existing fields were already present.
- `classroom_economy_test` was rebuilt and stamped cleanly so PostgreSQL-backed tests can run against a dedicated v1 test database.
- In production, explicit runtime secrets still win; branch-derived database selection is only a local fallback when active URLs are not already set.

---</details>

<details>
<summary>AUDIT PR SECTION</summary>

## Audit Stage (Select Exactly ONE)

- [ ] Stage 1 – Static Structural Audit
- [ ] Stage 2 – Economic Invariant Risk Audit
- [ ] Stage 3 – Security & Boundary Scan
- [ ] Stage 4 – Test Coverage & Fragility Audit
- [ ] Stage 5 – Refactor Proposal (Plan Only)

## Audit Artifacts

- Primary report file:
  - docs/audits/...

- Additional artifacts (if any):
  - docs/audits/...

## Audit Confirmation

- [ ] I confirm that this PR modifies documentation only and includes no changes to source code, migrations, or database schema.

</details>
