### PR TITLE
[codex] enforce midnight attendance tap-out boundary

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -692,6 +692,9 @@ Version 1.0 has been successfully released with the following criteria met:
 4. Complete migration compliance re-audit and publish runbook updates
 5. Continue admin experience polish and export capabilities
 
+**Codex/v2.0 Follow-Up:**
+- Rebuild attendance tap-in/tap-out enforcement around explicit session ownership and stronger boundary semantics: persist the effective attendance timezone with the session/class, close cross-day sessions deterministically, and unify manual tap, dashboard status refresh, hall-pass transitions, and scheduled auto-tap-out behind one authoritative state machine so cap enforcement and day-boundary enforcement cannot drift apart.
+
 **Recent Releases:**
 - **v1.9.x** (2026-03-04+) - Active maintenance; see CHANGELOG [Unreleased]
 - **v1.9.0** (2026-03-04) - Docs Taxonomy Consolidation and Navigation Integrity

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -194,17 +194,21 @@ def _enforce_cross_date_tapout(student_id, period, join_code, *, student_block=N
     V1 rule: attendance sessions cannot span multiple Pacific calendar days.
     If the latest event is still active after midnight, create a backfilled
     inactive event at 12:00 AM Pacific and mark the previous day as done.
+
+    Queries by (student_id, period, is_deleted) without join_code so legacy
+    rows with join_code=NULL are still caught. The effective join_code is
+    resolved from the event itself first, falling back to the parameter.
     """
     pacific = pytz.timezone(PACIFIC_TZ)
     now_utc = ensure_utc(now_utc) or utc_now()
     today_pacific = now_utc.astimezone(pacific).date()
 
+    # Query without join_code filter to handle legacy rows where join_code=NULL.
     latest_event = (
         TapEvent.query
         .filter_by(
             student_id=student_id,
             period=period,
-            join_code=join_code,
             is_deleted=False,
         )
         .order_by(TapEvent.timestamp.desc())
@@ -212,6 +216,15 @@ def _enforce_cross_date_tapout(student_id, period, join_code, *, student_block=N
     )
 
     if not latest_event or latest_event.status != "active":
+        return latest_event
+
+    # Prefer the join_code recorded on the event; fall back to the parameter.
+    effective_join_code = latest_event.join_code or join_code
+    if not effective_join_code:
+        current_app.logger.warning(
+            f"Cannot enforce date boundary for student {student_id} period {period}: "
+            f"no join_code available on event or parameter"
+        )
         return latest_event
 
     latest_event_pacific_date = ensure_utc(latest_event.timestamp).astimezone(pacific).date()
@@ -222,18 +235,39 @@ def _enforce_cross_date_tapout(student_id, period, join_code, *, student_block=N
     midnight_utc = midnight_pacific.astimezone(timezone.utc)
     previous_day_pacific = today_pacific - timedelta(days=1)
 
+    # Idempotency guard: skip if a boundary tap-out already exists at midnight_utc
+    # (protects against duplicate rows from concurrent requests).
+    existing_boundary = (
+        TapEvent.query
+        .filter_by(
+            student_id=student_id,
+            period=period,
+            join_code=effective_join_code,
+            status="inactive",
+            reason="done for the day",
+            is_deleted=False,
+        )
+        .filter(TapEvent.timestamp == midnight_utc)
+        .first()
+    )
+    if existing_boundary:
+        return existing_boundary
+
     tap_out_event = TapEvent(
         student_id=student_id,
         period=period,
         status="inactive",
         timestamp=midnight_utc,
         reason="done for the day",
-        join_code=join_code,
+        join_code=effective_join_code,
     )
     db.session.add(tap_out_event)
 
     if student_block is None:
-        student_block = _get_or_create_student_block(student_id, period, join_code=join_code)
+        student_block = _get_or_create_student_block(student_id, period, join_code=effective_join_code)
+    elif not student_block.join_code or student_block.join_code != effective_join_code:
+        # Keep StudentBlock join_code in sync with the effective join_code.
+        student_block.join_code = effective_join_code
 
     student_block.done_for_day_date = previous_day_pacific
 

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -62,6 +62,8 @@ from app.payroll import get_pay_rate_for_block
 # Create blueprint
 api_bp = Blueprint('api', __name__, url_prefix='/api')
 
+PACIFIC_TZ = 'America/Los_Angeles'
+
 
 # -------------------- Rent Helpers --------------------
 
@@ -168,6 +170,23 @@ def _append_redemption_audit_log(*, student_item, student, teacher_id, action, n
     guard_state['inserted'] = True
 
 
+def _get_or_create_student_block(student_id, period, join_code=None):
+    """Return the StudentBlock for a student/period, creating one if absent."""
+    student_block = StudentBlock.query.filter_by(
+        student_id=student_id,
+        period=period,
+    ).first()
+    if not student_block:
+        student_block = StudentBlock(
+            student_id=student_id,
+            period=period,
+            join_code=join_code,
+            tap_enabled=True,
+        )
+        db.session.add(student_block)
+    return student_block
+
+
 def _enforce_cross_date_tapout(student_id, period, join_code, *, student_block=None, now_utc=None):
     """
     Close an active attendance session at the Pacific midnight boundary.
@@ -176,7 +195,7 @@ def _enforce_cross_date_tapout(student_id, period, join_code, *, student_block=N
     If the latest event is still active after midnight, create a backfilled
     inactive event at 12:00 AM Pacific and mark the previous day as done.
     """
-    pacific = pytz.timezone('America/Los_Angeles')
+    pacific = pytz.timezone(PACIFIC_TZ)
     now_utc = ensure_utc(now_utc) or utc_now()
     today_pacific = now_utc.astimezone(pacific).date()
 
@@ -214,19 +233,7 @@ def _enforce_cross_date_tapout(student_id, period, join_code, *, student_block=N
     db.session.add(tap_out_event)
 
     if student_block is None:
-        student_block = StudentBlock.query.filter_by(
-            student_id=student_id,
-            period=period,
-        ).first()
-
-    if not student_block:
-        student_block = StudentBlock(
-            student_id=student_id,
-            period=period,
-            join_code=join_code,
-            tap_enabled=True,
-        )
-        db.session.add(student_block)
+        student_block = _get_or_create_student_block(student_id, period, join_code=join_code)
 
     student_block.done_for_day_date = previous_day_pacific
 
@@ -2203,28 +2210,15 @@ def handle_tap():
     now = utc_now()
 
     # --- Check if tap is enabled for this student in this period ---
-    from app.models import StudentBlock
-    student_block = StudentBlock.query.filter_by(
-        student_id=student.id,
-        period=period
-    ).first()
-
-    # If no StudentBlock record exists, create one with default settings (tap_enabled=True)
-    if not student_block:
-        try:
-            student_block = StudentBlock(
-                student_id=student.id,
-                period=period,
-                tap_enabled=True
-            )
-            db.session.add(student_block)
-            db.session.commit()
-        except IntegrityError:
-            db.session.rollback()
-            student_block = StudentBlock.query.filter_by(
-                student_id=student.id,
-                period=period
-            ).first()
+    student_block = _get_or_create_student_block(student.id, period, join_code=join_code)
+    try:
+        db.session.flush()
+    except IntegrityError:
+        db.session.rollback()
+        student_block = StudentBlock.query.filter_by(
+            student_id=student.id,
+            period=period,
+        ).first()
 
     # Check if tap is disabled for this period
     if not student_block.tap_enabled:
@@ -2233,7 +2227,7 @@ def handle_tap():
     # --- Check "done for the day" lock ---
     if normalized_action == "start_work":
         # Use Pacific timezone for "done for the day" check
-        pacific = pytz.timezone('America/Los_Angeles')
+        pacific = pytz.timezone(PACIFIC_TZ)
         now_pacific = now.astimezone(pacific)
         today_pacific = now_pacific.date()
 
@@ -2307,11 +2301,11 @@ def handle_tap():
             # Check per-destination queue limits
             if pass_type_config and pass_type_config.get('queue_limit') is not None:
                 # Get user's timezone from session for today's count
-                tz_name = session.get('timezone', 'America/Los_Angeles')
+                tz_name = session.get('timezone', PACIFIC_TZ)
                 try:
                     user_tz = pytz.timezone(tz_name)
                 except pytz.UnknownTimeZoneError:
-                    user_tz = pytz.timezone('America/Los_Angeles')
+                    user_tz = pytz.timezone(PACIFIC_TZ)
 
                 now_user_tz = utc_now().astimezone(user_tz)
                 today_start_user_tz = now_user_tz.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -2449,7 +2443,7 @@ def handle_tap():
             daily_limit = get_daily_limit_seconds(period)
             if daily_limit:
                 # Use Pacific timezone for daily reset
-                pacific = pytz.timezone('America/Los_Angeles')
+                pacific = pytz.timezone(PACIFIC_TZ)
                 now_pacific = now.astimezone(pacific)
                 today_pacific = now_pacific.date()
 
@@ -2498,7 +2492,7 @@ def handle_tap():
         db.session.add(event)
 
         # Update "done for the day" status when Stopping Work with reason "done"
-        pacific = pytz.timezone('America/Los_Angeles')
+        pacific = pytz.timezone(PACIFIC_TZ)
         now_pacific = now.astimezone(pacific)
         today_pacific = now_pacific.date()
         # Clear done_for_day_date if it's a new day
@@ -2727,7 +2721,7 @@ def check_and_auto_tapout_if_limit_reached(student, commit=True):
     now_utc = utc_now()
 
     # Use Pacific timezone for daily reset
-    pacific = pytz.timezone('America/Los_Angeles')
+    pacific = pytz.timezone(PACIFIC_TZ)
     now_pacific = now_utc.astimezone(pacific)
     today_pacific = now_pacific.date()
 
@@ -2763,23 +2757,11 @@ def check_and_auto_tapout_if_limit_reached(student, commit=True):
                 )
                 continue
 
-            _enforce_cross_date_tapout(
+            latest_event = _enforce_cross_date_tapout(
                 student.id,
                 period_upper,
                 join_code,
                 now_utc=now_utc,
-            )
-
-            latest_event = (
-                TapEvent.query
-                .filter_by(
-                    student_id=student.id,
-                    period=period_upper,
-                    join_code=join_code,
-                    is_deleted=False,
-                )
-                .order_by(TapEvent.timestamp.desc())
-                .first()
             )
 
             if not latest_event or latest_event.status != "active":

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -168,6 +168,76 @@ def _append_redemption_audit_log(*, student_item, student, teacher_id, action, n
     guard_state['inserted'] = True
 
 
+def _enforce_cross_date_tapout(student_id, period, join_code, *, student_block=None, now_utc=None):
+    """
+    Close an active attendance session at the Pacific midnight boundary.
+
+    V1 rule: attendance sessions cannot span multiple Pacific calendar days.
+    If the latest event is still active after midnight, create a backfilled
+    inactive event at 12:00 AM Pacific and mark the previous day as done.
+    """
+    pacific = pytz.timezone('America/Los_Angeles')
+    now_utc = ensure_utc(now_utc) or utc_now()
+    today_pacific = now_utc.astimezone(pacific).date()
+
+    latest_event = (
+        TapEvent.query
+        .filter_by(
+            student_id=student_id,
+            period=period,
+            join_code=join_code,
+            is_deleted=False,
+        )
+        .order_by(TapEvent.timestamp.desc())
+        .first()
+    )
+
+    if not latest_event or latest_event.status != "active":
+        return latest_event
+
+    latest_event_pacific_date = ensure_utc(latest_event.timestamp).astimezone(pacific).date()
+    if latest_event_pacific_date >= today_pacific:
+        return latest_event
+
+    midnight_pacific = pacific.localize(datetime.combine(today_pacific, datetime.min.time()))
+    midnight_utc = midnight_pacific.astimezone(timezone.utc)
+    previous_day_pacific = today_pacific - timedelta(days=1)
+
+    tap_out_event = TapEvent(
+        student_id=student_id,
+        period=period,
+        status="inactive",
+        timestamp=midnight_utc,
+        reason="done for the day",
+        join_code=join_code,
+    )
+    db.session.add(tap_out_event)
+
+    if student_block is None:
+        student_block = StudentBlock.query.filter_by(
+            student_id=student_id,
+            period=period,
+        ).first()
+
+    if not student_block:
+        student_block = StudentBlock(
+            student_id=student_id,
+            period=period,
+            join_code=join_code,
+            tap_enabled=True,
+        )
+        db.session.add(student_block)
+
+    student_block.done_for_day_date = previous_day_pacific
+
+    current_app.logger.info(
+        f"Hard tap-out at date boundary for student {student_id} in period {period} "
+        f"at {midnight_utc.isoformat()} (session started on {latest_event_pacific_date.isoformat()})"
+    )
+
+    return tap_out_event
+
+
 # -------------------- TIPS API --------------------
 
 @api_bp.route('/tips/<user_type>')
@@ -2174,6 +2244,14 @@ def handle_tap():
         if student_block.done_for_day_date == today_pacific:
             return jsonify({"error": "You are done for the day. You cannot Start Work again until tomorrow."}), 403
 
+    _enforce_cross_date_tapout(
+        student.id,
+        period,
+        join_code,
+        student_block=student_block,
+        now_utc=now,
+    )
+
 
     # --- Hall Pass Logic for Stop Work ---
     if normalized_action == 'stop_work':
@@ -2674,6 +2752,39 @@ def check_and_auto_tapout_if_limit_reached(student, commit=True):
         )
 
         if latest_event and latest_event.status == "active":
+            join_code = latest_event.join_code
+            if not join_code:
+                join_code = get_join_code_for_student_period(student.id, period_upper)
+
+            if not join_code:
+                current_app.logger.warning(
+                    f"Unable to resolve join_code for student {student.id} in period {period_upper} "
+                    f"for date-boundary tap-out. TapEvent ID is {latest_event.id}."
+                )
+                continue
+
+            _enforce_cross_date_tapout(
+                student.id,
+                period_upper,
+                join_code,
+                now_utc=now_utc,
+            )
+
+            latest_event = (
+                TapEvent.query
+                .filter_by(
+                    student_id=student.id,
+                    period=period_upper,
+                    join_code=join_code,
+                    is_deleted=False,
+                )
+                .order_by(TapEvent.timestamp.desc())
+                .first()
+            )
+
+            if not latest_event or latest_event.status != "active":
+                continue
+
             # Get teacher_id for this block (needed for settings lookup)
             teacher_id = None
             # Try to find seat for this block

--- a/tests/test_tap_flow.py
+++ b/tests/test_tap_flow.py
@@ -2,7 +2,9 @@ from app import db, Student
 from werkzeug.security import generate_password_hash
 from app.hash_utils import hash_username, get_random_salt
 from bs4 import BeautifulSoup
+from datetime import datetime, timezone
 import json
+import pytz
 
 def login(client, username, pin):
     return client.post('/student/login', data={'username': username, 'pin': pin})
@@ -253,3 +255,121 @@ def test_auto_tapout_skips_when_join_code_missing(client, caplog):
         f"TapEvent ID is {legacy_event.id}" in record.message
         for record in caplog.records
     ), f"Expected warning about missing join_code was not logged. Records: {[r.message for r in caplog.records]}"
+
+
+def test_cross_date_active_session_hard_taps_out_on_status_check(client, monkeypatch):
+    from app import TapEvent
+    from app.models import Admin, StudentBlock, StudentTeacher
+    from app.routes.api import check_and_auto_tapout_if_limit_reached
+    import pyotp
+
+    fixed_now = datetime(2026, 4, 20, 7, 0, 5, tzinfo=timezone.utc)  # 12:00:05 AM Pacific
+    monkeypatch.setattr('app.routes.api.utc_now', lambda: fixed_now)
+
+    teacher = Admin(username="boundary-status-teacher", totp_secret=pyotp.random_base32())
+    db.session.add(teacher)
+    db.session.flush()
+
+    salt = get_random_salt()
+    username = "boundary_status"
+    stu = Student(
+        first_name="Boundary",
+        last_initial="S",
+        block="A",
+        salt=salt,
+        username_hash=hash_username(username, salt),
+        pin_hash=generate_password_hash("0000"),
+    )
+    db.session.add(stu)
+    db.session.flush()
+
+    db.session.add(StudentTeacher(student_id=stu.id, admin_id=teacher.id))
+    create_claimed_seat(teacher.id, stu.id, "A", "JOIN-BOUNDARY-STATUS", salt)
+    db.session.commit()
+
+    db.session.add(TapEvent(
+        student_id=stu.id,
+        period="A",
+        status="active",
+        timestamp=datetime(2026, 4, 20, 6, 59, 59, tzinfo=timezone.utc),  # 11:59:59 PM Pacific previous day
+        join_code="JOIN-BOUNDARY-STATUS",
+    ))
+    db.session.commit()
+
+    check_and_auto_tapout_if_limit_reached(stu)
+
+    boundary_tap_out = (
+        TapEvent.query
+        .filter_by(student_id=stu.id, period="A", status="inactive", join_code="JOIN-BOUNDARY-STATUS")
+        .order_by(TapEvent.timestamp.desc())
+        .first()
+    )
+    assert boundary_tap_out is not None
+    assert boundary_tap_out.reason == "done for the day"
+    assert boundary_tap_out.timestamp == datetime(2026, 4, 20, 7, 0, 0, tzinfo=timezone.utc)
+
+    student_block = StudentBlock.query.filter_by(student_id=stu.id, period="A").first()
+    assert student_block is not None
+    assert student_block.done_for_day_date == pytz.timezone('America/Los_Angeles').localize(
+        datetime(2026, 4, 19, 12, 0, 0)
+    ).date()
+
+
+def test_start_work_after_midnight_closes_previous_day_session(client, monkeypatch):
+    from app import TapEvent
+    from app.models import Admin, StudentTeacher
+    import pyotp
+
+    fixed_now = datetime(2026, 4, 20, 7, 0, 5, tzinfo=timezone.utc)  # 12:00:05 AM Pacific
+    monkeypatch.setattr('app.routes.api.utc_now', lambda: fixed_now)
+
+    teacher = Admin(username="boundary-tap-teacher", totp_secret=pyotp.random_base32())
+    db.session.add(teacher)
+    db.session.flush()
+
+    salt = get_random_salt()
+    username = "boundary_tap"
+    stu = Student(
+        first_name="Boundary",
+        last_initial="T",
+        block="A",
+        salt=salt,
+        username_hash=hash_username(username, salt),
+        pin_hash=generate_password_hash("0000"),
+    )
+    db.session.add(stu)
+    db.session.flush()
+
+    db.session.add(StudentTeacher(student_id=stu.id, admin_id=teacher.id))
+    create_claimed_seat(teacher.id, stu.id, "A", "JOIN-BOUNDARY-TAP", salt)
+    db.session.commit()
+
+    db.session.add(TapEvent(
+        student_id=stu.id,
+        period="A",
+        status="active",
+        timestamp=datetime(2026, 4, 20, 6, 50, 0, tzinfo=timezone.utc),  # 11:50 PM Pacific previous day
+        join_code="JOIN-BOUNDARY-TAP",
+    ))
+    db.session.commit()
+
+    login(client, username, "0000")
+    response = client.post('/api/tap', json={'period': 'A', 'action': 'tap_in', 'pin': '0000'})
+
+    assert response.status_code == 200
+    assert response.json["status"] == "ok"
+    assert response.json["active"] is True
+
+    events = (
+        TapEvent.query
+        .filter_by(student_id=stu.id, period="A", join_code="JOIN-BOUNDARY-TAP")
+        .order_by(TapEvent.timestamp.asc())
+        .all()
+    )
+    assert len(events) == 3
+    assert events[0].status == "active"
+    assert events[1].status == "inactive"
+    assert events[1].reason == "done for the day"
+    assert events[1].timestamp == datetime(2026, 4, 20, 7, 0, 0, tzinfo=timezone.utc)
+    assert events[2].status == "active"
+    assert events[2].timestamp == fixed_now

--- a/tests/test_tap_flow.py
+++ b/tests/test_tap_flow.py
@@ -373,3 +373,64 @@ def test_start_work_after_midnight_closes_previous_day_session(client, monkeypat
     assert events[1].timestamp == datetime(2026, 4, 20, 7, 0, 0, tzinfo=timezone.utc)
     assert events[2].status == "active"
     assert events[2].timestamp == fixed_now
+
+
+def test_cross_date_null_join_code_still_enforced_when_seat_exists(app, monkeypatch):
+    """Legacy TapEvent with join_code=None is still closed at midnight when a claimed seat exists."""
+    from app import TapEvent
+    from app.models import Admin, StudentBlock, StudentTeacher
+    from app.routes.api import check_and_auto_tapout_if_limit_reached
+    import pyotp
+
+    fixed_now = datetime(2026, 4, 20, 7, 0, 5, tzinfo=timezone.utc)  # 12:00:05 AM Pacific
+    monkeypatch.setattr('app.routes.api.utc_now', lambda: fixed_now)
+
+    with app.app_context():
+        teacher = Admin(username="legacy-jc-teacher", totp_secret=pyotp.random_base32())
+        db.session.add(teacher)
+        db.session.flush()
+
+        salt = get_random_salt()
+        username = "legacy_jc_student"
+        stu = Student(
+            first_name="Legacy",
+            last_initial="J",
+            block="A",
+            salt=salt,
+            username_hash=hash_username(username, salt),
+            pin_hash=generate_password_hash("0000"),
+        )
+        db.session.add(stu)
+        db.session.flush()
+
+        db.session.add(StudentTeacher(student_id=stu.id, admin_id=teacher.id))
+        create_claimed_seat(teacher.id, stu.id, "A", "JOIN-LEGACY-NULL", salt)
+
+        # Legacy active TapEvent with join_code=None from the previous Pacific day
+        db.session.add(TapEvent(
+            student_id=stu.id,
+            period="A",
+            status="active",
+            timestamp=datetime(2026, 4, 20, 6, 30, 0, tzinfo=timezone.utc),  # 11:30 PM Pacific previous day
+            join_code=None,
+        ))
+        db.session.commit()
+
+        check_and_auto_tapout_if_limit_reached(stu)
+
+        # Boundary tap-out should be created with the resolved join_code
+        boundary = (
+            TapEvent.query
+            .filter_by(student_id=stu.id, period="A", status="inactive", join_code="JOIN-LEGACY-NULL")
+            .order_by(TapEvent.timestamp.desc())
+            .first()
+        )
+        assert boundary is not None, "Expected midnight boundary tap-out to be created for legacy NULL join_code event"
+        assert boundary.reason == "done for the day"
+        assert boundary.timestamp == datetime(2026, 4, 20, 7, 0, 0, tzinfo=timezone.utc)
+
+        student_block = StudentBlock.query.filter_by(student_id=stu.id, period="A").first()
+        assert student_block is not None
+        assert student_block.done_for_day_date == pytz.timezone('America/Los_Angeles').localize(
+            datetime(2026, 4, 19, 12, 0, 0)
+        ).date()


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Schema Change Gate Classification (Required for schema changes)

- [ ] **EXPAND** – Additive, backward-compatible (no removals)
- [ ] **CONTRACT (CODE ONLY)** – Model attribute removal, DB schema unchanged
- [ ] **CONTRACT (DATABASE)** – Destructive migration only

## Description

This PR fixes a v1 attendance correctness bug where an active session could span a Pacific date boundary and remain active into the next day. When that happened, the next day's limit enforcement no longer owned a clean session boundary, so automatic tap-out behavior for the new day could drift or fail to fire as expected.

The root cause was that attendance sessions were allowed to persist across calendar days, while daily-cap enforcement and done-for-the-day logic assumed day-scoped sessions. This change adds a small, targeted hard boundary: if the latest tap event for a student/period/class is still active after midnight Pacific, the app backfills an inactive "done for the day" tap-out at exactly 12:00:00 AM Pacific, attributes that close to the day that ended, and lets the new day start clean.

The enforcement is wired into both the interactive tap route and the existing auto-check path so the stale session is closed before duplicate-state handling or daily-limit enforcement runs. A follow-up note was also added to DEVELOPMENT.md for `codex/v2.0` describing the stronger long-term design: explicit session ownership, persisted timezone semantics, and one authoritative attendance state machine for manual taps, status refresh, hall-pass transitions, and scheduled auto-enforcement.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [x] Added new tests for new functionality

Targeted verification run:
- `pytest tests/test_tap_flow.py -q -k "cross_date_active_session_hard_taps_out_on_status_check or start_work_after_midnight_closes_previous_day_session"`

Note: the full `tests/test_tap_flow.py -q` file still has two pre-existing failures around ordinary dashboard `done` state persistence after manual tap-out. Those failures reproduced during this work and were not introduced by this PR.

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

- This is intentionally a small v1 correctness fix only. It does not refactor the wider attendance model.
- The `codex/v2.0` note in DEVELOPMENT.md captures the desired stronger enforcement model for later architecture work.

---

</details>
