### PR TITLE
Harden hall pass verification against DB disconnects

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -332,6 +332,10 @@ def create_app():
         ENV=flask_env,
         SECRET_KEY=os.environ["SECRET_KEY"],
         SQLALCHEMY_DATABASE_URI=os.environ["DATABASE_URL"],
+        SQLALCHEMY_ENGINE_OPTIONS={
+            "pool_pre_ping": True,
+            "pool_recycle": int(os.getenv("SQLALCHEMY_POOL_RECYCLE_SECONDS", "1800")),
+        },
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         SESSION_COOKIE_SECURE=flask_env == "production",  # Only require HTTPS in production
         SESSION_COOKIE_HTTPONLY=True,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,6 +32,18 @@ dotenv_path = project_root / '.env'
 if os.environ.get("FLASK_ENV") != "testing" and not os.environ.get("CI"):
     load_dotenv(dotenv_path=dotenv_path, override=False)
 
+
+def _parse_int_env(name, default):
+    """Return int value of env var *name*, falling back to *default* on missing or invalid values."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 derived_database_url = resolve_dev_database_url(os.environ, project_root=project_root)
 if derived_database_url and not os.environ.get("DATABASE_URL"):
     os.environ["DATABASE_URL"] = derived_database_url
@@ -334,7 +346,7 @@ def create_app():
         SQLALCHEMY_DATABASE_URI=os.environ["DATABASE_URL"],
         SQLALCHEMY_ENGINE_OPTIONS={
             "pool_pre_ping": True,
-            "pool_recycle": int(os.getenv("SQLALCHEMY_POOL_RECYCLE_SECONDS", "1800")),
+            "pool_recycle": _parse_int_env("SQLALCHEMY_POOL_RECYCLE_SECONDS", 1800),
         },
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         SESSION_COOKIE_SECURE=flask_env == "production",  # Only require HTTPS in production

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -11,6 +11,7 @@ from datetime import timezone
 from flask import Blueprint, redirect, url_for, jsonify, current_app, session, request
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import selectinload
 
 from app.extensions import db, limiter
 from app.models import Admin
@@ -347,7 +348,9 @@ def verify_hall_pass(teacher_public_token):
     try:
         # Query today's hall pass records for this join_code.
         # Only include actionable statuses (not pending/rejected).
-        passes_query = HallPassLog.query.filter(
+        passes_query = HallPassLog.query.options(
+            selectinload(HallPassLog.student)
+        ).filter(
             HallPassLog.join_code == selected_join_code,
             HallPassLog.request_time >= today_start_db,
             HallPassLog.request_time <= today_end_db,

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -253,28 +253,37 @@ def verify_hall_pass(teacher_public_token):
 
     _GENERIC_UNAVAILABLE = "Verification page not available."
 
-    # Look up teacher by token
-    teacher = Admin.query.filter_by(hall_pass_verify_token=teacher_public_token).first()
-
-    if not teacher:
+    def _unavailable(status_code):
         return render_template(
             'hall_pass_verify.html',
             unavailable=True,
             message=_GENERIC_UNAVAILABLE
-        ), 404
+        ), status_code
 
-    # Get teacher's active classes (distinct join_codes with labels)
-    # Use plain .distinct() (all columns) + Python deduplication for cross-DB compat
-    classes_rows = (
-        db.session.query(TeacherBlock.join_code, TeacherBlock.block, TeacherBlock.class_label)
-        .filter(
-            TeacherBlock.teacher_id == teacher.id,
-            TeacherBlock.join_code.isnot(None),
+    try:
+        # Look up teacher by token.
+        teacher = Admin.query.filter_by(hall_pass_verify_token=teacher_public_token).first()
+
+        if not teacher:
+            return _unavailable(404)
+
+        # Get teacher's active classes (distinct join_codes with labels)
+        # Use plain .distinct() (all columns) + Python deduplication for cross-DB compat.
+        classes_rows = (
+            db.session.query(TeacherBlock.join_code, TeacherBlock.block, TeacherBlock.class_label)
+            .filter(
+                TeacherBlock.teacher_id == teacher.id,
+                TeacherBlock.join_code.isnot(None),
+            )
+            .group_by(TeacherBlock.join_code, TeacherBlock.block, TeacherBlock.class_label)
+            .order_by(TeacherBlock.block)
+            .all()
         )
-        .group_by(TeacherBlock.join_code, TeacherBlock.block, TeacherBlock.class_label)
-        .order_by(TeacherBlock.block)
-        .all()
-    )
+    except SQLAlchemyError:
+        db.session.rollback()
+        current_app.logger.exception("Hall pass verification database unavailable")
+        return _unavailable(503)
+
     # Build list: [{"join_code": ..., "label": ...}, ...]
     classes = []
     seen_codes = set()
@@ -335,29 +344,34 @@ def verify_hall_pass(teacher_public_token):
     today_start_db = normalize_for_db(today_start_utc)
     today_end_db = normalize_for_db(today_end_utc)
 
-    # Query today's hall pass records for this join_code.
-    # Only include actionable statuses (not pending/rejected).
-    passes_query = HallPassLog.query.filter(
-        HallPassLog.join_code == selected_join_code,
-        HallPassLog.request_time >= today_start_db,
-        HallPassLog.request_time <= today_end_db,
-        HallPassLog.status.in_(['approved', 'left', 'returned'])
-    ).order_by(HallPassLog.request_time.desc())
+    try:
+        # Query today's hall pass records for this join_code.
+        # Only include actionable statuses (not pending/rejected).
+        passes_query = HallPassLog.query.filter(
+            HallPassLog.join_code == selected_join_code,
+            HallPassLog.request_time >= today_start_db,
+            HallPassLog.request_time <= today_end_db,
+            HallPassLog.status.in_(['approved', 'left', 'returned'])
+        ).order_by(HallPassLog.request_time.desc())
 
-    # Filter in Python (first_name is PII-encrypted, can't filter in DB).
-    # Stop at 2 matches: enough to distinguish unique vs ambiguous.
-    matched = []
-    for entry in passes_query.yield_per(100):
-        student = entry.student
-        if not student:
-            continue
-        stored_norm = _normalize_first_name(student.first_name)
-        stored_initial = (student.last_initial or '').strip().upper()
-        if stored_norm == first_name_norm and stored_initial == last_initial_norm:
-            matched.append(entry)
-        if len(matched) >= 2:
-            # Ambiguous — stop early
-            break
+        # Filter in Python (first_name is PII-encrypted, can't filter in DB).
+        # Stop at 2 matches: enough to distinguish unique vs ambiguous.
+        matched = []
+        for entry in passes_query.yield_per(100):
+            student = entry.student
+            if not student:
+                continue
+            stored_norm = _normalize_first_name(student.first_name)
+            stored_initial = (student.last_initial or '').strip().upper()
+            if stored_norm == first_name_norm and stored_initial == last_initial_norm:
+                matched.append(entry)
+            if len(matched) >= 2:
+                # Ambiguous: stop early.
+                break
+    except SQLAlchemyError:
+        db.session.rollback()
+        current_app.logger.exception("Hall pass verification database unavailable")
+        return _unavailable(503)
 
     if len(matched) == 0:
         result = {'outcome': 'no_match'}

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -281,7 +281,10 @@ def verify_hall_pass(teacher_public_token):
             .all()
         )
     except SQLAlchemyError:
-        db.session.rollback()
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
         current_app.logger.exception("Hall pass verification database unavailable")
         return _unavailable(503)
 
@@ -372,7 +375,10 @@ def verify_hall_pass(teacher_public_token):
                 # Ambiguous: stop early.
                 break
     except SQLAlchemyError:
-        db.session.rollback()
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
         current_app.logger.exception("Hall pass verification database unavailable")
         return _unavailable(503)
 

--- a/tests/test_hall_pass_verify.py
+++ b/tests/test_hall_pass_verify.py
@@ -14,6 +14,7 @@ Validates the privacy-respecting single-student verification per spec v1.0:
 import pytest
 import unicodedata
 from datetime import datetime, timezone, timedelta
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.extensions import db
 from app.models import Admin, Student, StudentTeacher, TeacherBlock, HallPassLog
@@ -106,6 +107,27 @@ def test_get_verify_page_invalid_token(client):
     html = resp.data.decode()
     assert "Verification page not available" in html
     # Must not expose any teacher info
+    assert "teacher_id" not in html.lower()
+
+
+def test_get_verify_page_db_disconnect_fails_closed(client, monkeypatch):
+    """A database disconnect during token lookup returns a generic unavailable response."""
+    import app.routes.main as main_routes
+
+    class BrokenQuery:
+        def filter_by(self, **kwargs):
+            raise SQLAlchemyError("SSL connection has been closed unexpectedly")
+
+    class BrokenAdmin:
+        query = BrokenQuery()
+
+    monkeypatch.setattr(main_routes, "Admin", BrokenAdmin)
+
+    resp = client.get("/verify/hallpass/deadbeef1234deadbeef1234deadbeef1234deadbeef1234deadbeef1234dead")
+    assert resp.status_code == 503
+    html = resp.data.decode()
+    assert "Verification page not available" in html
+    assert "SSL connection" not in html
     assert "teacher_id" not in html.lower()
 
 


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Schema Change Gate Classification (Required for schema changes)

N/A — no schema changes in this PR.

## Description

Wraps the two database-touching code paths in `verify_hall_pass` (`app/routes/main.py`) with `try/except SQLAlchemyError` so that a stale or dropped connection (e.g. a Postgres SSL disconnect) returns a clean HTTP 503 with the generic "Verification page not available." message instead of a 500 traceback. Adds `pool_pre_ping` and configurable `pool_recycle` to the SQLAlchemy engine options in `app/__init__.py` to proactively detect and evict stale connections before they reach a request handler.

**Affected paths:**
- Initial teacher token lookup + class list query
- Per-class hall pass record query + in-Python PII matching loop

Both paths now call `db.session.rollback()` and log the exception before returning the `_unavailable(503)` response, ensuring no PII leaks through error messages and the session is left in a clean state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added new tests for new functionality

New test: `tests/test_hall_pass_verify.py::test_get_verify_page_db_disconnect_fails_closed`
- Monkeypatches `Admin.query` to raise `SQLAlchemyError` simulating an SSL disconnect
- Asserts HTTP 503 is returned
- Asserts generic unavailable message is shown
- Asserts no internal error detail (e.g. "SSL connection") leaks to the response
- Asserts no `teacher_id` is exposed

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

The `SQLALCHEMY_POOL_RECYCLE_SECONDS` env var defaults to `1800` (30 min), matching the typical Postgres idle connection timeout. It can be overridden in `.env` if the hosting environment has a different timeout.

---

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnGwnPMe51bXbzUGhZDekk)_