### PR TITLE
Fix block deletion cleanup for rent waivers

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -876,13 +876,15 @@ def _hard_delete_join_code_scope(join_code, teacher_id):
         TeacherBlock.student_id.isnot(None),
         TeacherBlock.join_code != join_code,
     ).subquery()
-    orphan_student_ids = [
-        student_id
-        for (student_id,) in db.session.query(Student.id)
-        .filter(Student.id.in_(scoped_student_ids))
-        .filter(~Student.id.in_(sa.select(remaining_student_ids_subq)))
-        .all()
-    ]
+    orphan_student_ids = []
+    if scoped_student_ids:
+        orphan_student_ids = [
+            student_id
+            for (student_id,) in db.session.query(Student.id)
+            .filter(Student.id.in_(scoped_student_ids))
+            .filter(~Student.id.in_(sa.select(remaining_student_ids_subq)))
+            .all()
+        ]
     for student_id in orphan_student_ids:
         remove_student_from_teacher_scope(student_id, teacher_id)
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -876,18 +876,15 @@ def _hard_delete_join_code_scope(join_code, teacher_id):
         TeacherBlock.student_id.isnot(None),
         TeacherBlock.join_code != join_code,
     ).subquery()
-    orphan_student_ids = (
-        db.session.query(Student.id)
+    orphan_student_ids = [
+        student_id
+        for (student_id,) in db.session.query(Student.id)
         .filter(Student.id.in_(scoped_student_ids))
         .filter(~Student.id.in_(sa.select(remaining_student_ids_subq)))
-        .subquery()
-    )
-    StudentTeacher.query.filter(
-        StudentTeacher.student_id.in_(sa.select(orphan_student_ids))
-    ).delete(synchronize_session=False)
-    Student.query.filter(
-        Student.id.in_(sa.select(orphan_student_ids))
-    ).delete(synchronize_session=False)
+        .all()
+    ]
+    for student_id in orphan_student_ids:
+        remove_student_from_teacher_scope(student_id, teacher_id)
 
     # Clean up PayrollSettings and RentSettings for any block name that now has no
     # remaining TeacherBlock entries for this teacher.  These models are scoped by

--- a/tests/test_legacy_bulk_deletion.py
+++ b/tests/test_legacy_bulk_deletion.py
@@ -11,7 +11,7 @@ import pyotp
 from datetime import datetime, timezone
 
 from app import db
-from app.models import Admin, Student, StudentTeacher, TeacherBlock, Transaction
+from app.models import Admin, RentWaiver, Student, StudentTeacher, TeacherBlock, Transaction
 from app.hash_utils import get_random_salt, hash_hmac
 
 
@@ -347,6 +347,47 @@ def test_block_deletion_with_improved_transactions(client):
     
     # Verify transactions in deleted class join code are deleted
     assert Transaction.query.filter_by(student_id=student1_id).first() is None
+
+
+def test_block_deletion_removes_rent_waivers_for_orphaned_students(client):
+    """Deleting a block should remove rent waivers before hard-deleting orphaned students."""
+    teacher, secret = _create_admin("teacher-block-waiver")
+    student = _create_claimed_student("Piper", "piper_username", teacher, "G")
+
+    join_code = TeacherBlock.query.filter_by(teacher_id=teacher.id, block="G").first().join_code
+    waiver = RentWaiver(
+        student_id=student.id,
+        join_code=join_code,
+        waiver_start_date=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        waiver_end_date=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        periods_count=1,
+        reason="cleanup regression",
+        created_by_admin_id=teacher.id,
+    )
+    db.session.add(waiver)
+    db.session.commit()
+
+    student_id = student.id
+    waiver_id = waiver.id
+
+    _login_admin(client, teacher, secret)
+
+    response = client.post(
+        "/admin/students/delete-block",
+        json={
+            "block": "G",
+            "gate_phrase": "DELETE BLOCK G",
+            "gate_countdown_seconds": 30,
+            "gate_hold_seconds": 10,
+        },
+        content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "success"
+    assert db.session.get(Student, student_id) is None
+    assert db.session.get(RentWaiver, waiver_id) is None
 
 
 def test_bulk_delete_legacy_unclaimed_no_block_provided(client):


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

## Description

Fix `/admin/students/delete-block` so orphaned students are removed through the canonical teacher-scope deletion helper instead of direct bulk `Student` deletion. This ensures dependent rows such as `rent_waivers` are cleaned up before the student row is deleted and prevents foreign-key failures during block deletion.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [x] Added new tests for new functionality

Local validation:
- `./venv/bin/python -m py_compile app/routes/admin.py tests/test_legacy_bulk_deletion.py`
- `pytest -q tests/test_legacy_bulk_deletion.py -k "block_deletion"`
- `git diff --check`

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

- The untracked `docs/development/tracking/` directory in the local worktree was intentionally left out of this PR.
