### PR TITLE
fix(security): close final exception exposure alert

### DIFF
--- a/app/feats/transaction_void_feat.py
+++ b/app/feats/transaction_void_feat.py
@@ -18,6 +18,14 @@ class VoidTransactionResult:
     reversal_transaction_id: int | None
 
 
+class ImmediatePurchaseNotVoidable(ValueError):
+    pass
+
+
+class UsedDelayedPurchaseNotVoidable(ValueError):
+    pass
+
+
 def execute_void_transaction(tx: Transaction) -> VoidTransactionResult:
     """Ledger-led FEAT for transaction void orchestration."""
     is_pending = tx.status == TransactionStatus.PENDING
@@ -69,7 +77,7 @@ def _void_purchase(tx: Transaction) -> None:
     if not store_item:
         raise ValueError("Purchase item record was not found. This transaction cannot be voided.")
     if store_item.item_type == 'immediate':
-        raise ValueError("Immediate-use item purchases are not voidable.")
+        raise ImmediatePurchaseNotVoidable
     if store_item.item_type != 'delayed':
         raise ValueError("Only delayed-use item purchases are voidable.")
     matching_items = StudentItem.query.filter(
@@ -100,7 +108,7 @@ def _void_purchase(tx: Transaction) -> None:
 
     used_statuses = {'processing', 'completed', 'redeemed'}
     if any((student_item.status or '').lower() in used_statuses for student_item in selected_items):
-        raise ValueError("Delayed-use item has already been used (redemption requested or completed) and cannot be voided.")
+        raise UsedDelayedPurchaseNotVoidable
 
     ledger_service.create_pending_transaction(
         seat_id=tx.seat_id,

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -150,7 +150,11 @@ from app.utils.transaction_idempotency import create_idempotent_transaction, voi
 from app.feats.admin_adjustment_feat import execute_admin_adjustments
 from app.feats.attendance import student_tap
 from app.feats.insurance_claim_feat import execute_insurance_claim_resolution
-from app.feats.transaction_void_feat import execute_void_transaction
+from app.feats.transaction_void_feat import (
+    ImmediatePurchaseNotVoidable,
+    UsedDelayedPurchaseNotVoidable,
+    execute_void_transaction,
+)
 from app.hash_utils import get_random_salt, hash_hmac, hash_username, hash_username_lookup
 from app.payroll import calculate_payroll_breakdown, get_cached_payroll_with_meta
 from app.attendance import (
@@ -8050,6 +8054,14 @@ def void_transaction(transaction_id):
         db.session.rollback()
         current_app.logger.info("Transaction void denied for %s: %s", transaction_id, e)
         return _void_error("You do not have permission to void this transaction.", status_code=403)
+    except ImmediatePurchaseNotVoidable:
+        db.session.rollback()
+        return _void_error("Immediate-use item purchases are not voidable.")
+    except UsedDelayedPurchaseNotVoidable:
+        db.session.rollback()
+        return _void_error(
+            "Delayed-use item has already been used and cannot be voided.",
+        )
     except ValueError as e:
         db.session.rollback()
         current_app.logger.info("Transaction void validation failed for %s: %s", transaction_id, e)

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -245,23 +245,6 @@ _BANKING_REDIRECT_QUERY_KEYS = {
     "settings_block",
 }
 
-_SAFE_VOID_ERROR_MESSAGES = {
-    "This purchase transaction cannot be voided automatically.",
-    "Transaction is missing class scope (class_id) and cannot be voided safely.",
-    "Purchase item record was not found. This transaction cannot be voided.",
-    "Immediate-use item purchases are not voidable.",
-    "Only delayed-use item purchases are voidable.",
-    "No matching student item was found for this purchase.",
-    "Unable to map this transaction to purchasable student items.",
-    "Delayed-use item has already been used (redemption requested or completed) and cannot be voided.",
-}
-
-
-def _safe_known_message(message, allowed_messages, default_message):
-    if message in allowed_messages:
-        return message
-    return default_message
-
 ADMIN_FEATURE_ENDPOINTS = {
     "admin.payroll": "payroll",
     "admin.store_management": "store",
@@ -8070,9 +8053,7 @@ def void_transaction(transaction_id):
     except ValueError as e:
         db.session.rollback()
         current_app.logger.info("Transaction void validation failed for %s: %s", transaction_id, e)
-        return _void_error(
-            _safe_known_message(str(e), _SAFE_VOID_ERROR_MESSAGES, "Transaction could not be voided."),
-        )
+        return _void_error("Transaction could not be voided.")
     except SQLAlchemyError as e:
         db.session.rollback()
         current_app.logger.error(f"Failed to void transaction {transaction_id}: {e}", exc_info=True)


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Description

Closes the final CodeQL `py/stack-trace-exposure` alert on `codex/v2.0`.

The transaction void route now returns a fixed generic validation message instead of passing allowlisted text derived from `ValueError` into the client response. Detailed exception information remains server-side in the application log.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

Validation:

- `python3 -m py_compile app/routes/admin.py`
- `python3 scripts/policy_guardrails.py --git-diff-base origin/codex/v2.0 --git-diff-head HEAD`
- `git diff --check`

## Accessibility Validation

- [x] Not applicable: this PR does not touch template/UI scope covered by `INV-ARC-020`
- [ ] Applicable: this PR includes template/UI scope and the accessibility report below is complete

**Accessibility Scope**

Not applicable.

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Additional Notes

This is a narrow follow-up to #1206 for the one default-branch CodeQL alert that remained after merge.

</details>

<details>
<summary>AUDIT PR SECTION (Click to expand)</summary>

<!-- Not applicable: standard PR -->

</details>
