### PR TITLE
docs: terminology audit and normative vocabulary standards (REF-TERM)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ All documents are classified into one of three tiers. See [SOP-DOC-000 Section V
 | Tier               | Authority                              | Namespaces / Locations                        |
 |--------------------|----------------------------------------|-----------------------------------------------|
 | **Constitutional** | Inviolable — cannot be overridden      | `INV-CORE-*`, `INV-ARC-*`                    |
-| **Normative**      | Binding — must be followed             | `ARC`, `DOM`, `FEAT`, `SOP`, `.claude/rules/`, `SEC-CONT-*` |
+| **Normative**      | Binding — must be followed             | `ARC`, `DOM`, `FEAT`, `REF`, `SOP`, `.claude/rules/`, `SEC-CONT-*` |
 | **Informative**    | Descriptive — no normative authority   | `LOG`, `SEC-AUD/INC/VUL/THR-*`, root files   |
 
 ---
@@ -32,6 +32,12 @@ All documents are classified into one of three tiers. See [SOP-DOC-000 Section V
 | **[TESTING/](TESTING/)** | Normative | Test creation, validation, and accessibility compliance |
 | **[STANDARD_OPERATING_PROCEDURES/](STANDARD_OPERATING_PROCEDURES/)** | Normative | SOPs for database, deployment, devops, documentation |
 | **[SECURITY/](SECURITY/)** | Normative (CONT) / Informative | Security controls, audits, incidents, threat models |
+
+### Reference
+
+| Directory | Tier | Purpose |
+|-----------|------|---------|
+| **[REFERENCE/](REFERENCE/)** | Normative | Authoritative vocabulary and terminology (`REF-TERM-*`) |
 
 ### Planning & Status
 

--- a/docs/REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md
+++ b/docs/REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md
@@ -1,0 +1,320 @@
+# REF-TERM-001: Developer Vocabulary
+
+| Reference Number | Version | Effective Date | Supersedes | Authority Level |
+|------------------|---------|----------------|------------|-----------------|
+| REF-TERM-001     | 1.0     | 2026-06-15     | N/A        | Normative       |
+
+## I. Purpose
+
+Define the authoritative developer-facing vocabulary for the Classroom Token Hub architecture. Every term in this glossary represents an independent concept referenced in constitutional (INV-\*), domain (DOM-\*), or architectural documents and is expected to survive architectural evolution.
+
+## II. Scope
+
+This glossary covers terms used in specifications, code review, domain contracts, and internal documentation. It does not include:
+
+- Schema-level field names or table names without independent conceptual meaning (see `ARC-OPS-007_Database_Schema.md`)
+- Feature-specific behavioral rules that belong in their respective feature specs
+- User-facing vocabulary (see `REF-TERM-002`)
+
+Terms that appear in both this document and REF-TERM-002 carry their developer-facing definition here and their user-facing definition there. Where definitions diverge, this document is authoritative for implementation semantics.
+
+## III. Authority Level
+
+Normative. Subordinate to `INV-CORE-000` and `INV-CORE-001`.
+
+## III-A. Dependencies
+
+- `docs/INVARIANT/CORE/INV-CORE-000_CORE_INVARIANTS.md`
+- `docs/INVARIANT/CORE/INV-CORE-001_CAPABILITY_BASED_ARCHITECTURE_AND_AUTHORITY_MODEL.md`
+- `docs/DOMAIN/DOM-CORE-000_DOMAIN_FOUNDATION.md`
+- `docs/DOMAIN/DOM-CORE-001_DOMAIN_AUTHORITY_SUMMARY.md`
+
+## IV. Glossary
+
+### A
+
+**Activation Intent**
+The abstract timing mode attached to a policy transition: immediate, next-boundary, or manual. Governs when a pending policy version becomes the active constitutional truth. Subsumes the `next_boundary` activation mode.
+
+**Append-Only Policy Evolution**
+Core economic governance rule that policy changes are represented as new transition lineage (`policy_transitions` → `policy_versions`), never as in-place mutation of the active record. The inverse of the forbidden Hidden Deferred Mutation pattern (formerly operationalized as `economy_pending_rebalance_json`).
+
+**Attendance Sessions** (`attendance_sessions`)
+Canonical v2 table for tap-in/tap-out attendance facts. Coexists with legacy `tap_events` during the dual-write transition. New attendance writes target this table; it is the authoritative attendance fact source for v2.
+
+**Audit Event**
+High-integrity append-only record for security-sensitive, identity-sensitive, and money-moving side effects. Stored in `audit_log`. Distinguished from general `operational_events` by its compliance and traceability guarantees.
+
+### B
+
+**Budget Survival Test**
+Named solvency check asking whether students can still preserve a minimum weekly savings buffer after recurring costs. Used as a decision criterion in economy validation and analytics. See also: Catastrophe Stability Rule.
+
+### C
+
+**Canonical Class Time**
+The class-local current time derived from UTC plus the class IANA timezone. Modeled as the `class_time` field inside `TemporalContext`. All behavioral evaluation (attendance boundaries, due dates, accrual windows) must use this rather than raw UTC or server-local time.
+
+**Catastrophe Stability Rule**
+Economy solvency rule testing whether a student can recover within roughly one cycle from a pair of shocks such as fines or loss. Distinguished from Budget Survival Test by its focus on shock recovery rather than steady-state viability.
+
+**Claim Artifacts**
+Seat-owned verification credentials used to prove entitlement to a rostered participant position during the claim flow. Part of the Claim Lifecycle; their existence is the precondition for seat binding.
+
+**Claim Lifecycle**
+Identity flow that binds a global `user` to a class-local `seat` after verifying class-specific claim artifacts. Transitions a seat from unclaimed to bound.
+
+**Class Day**
+The canonical classroom day boundary defined as midnight-to-midnight in class timezone, then converted to UTC query bounds. All daily limits, attendance windows, and day-scoped features use this definition.
+
+**Class Timezone**
+Immutable IANA timezone owned by the class and used to evaluate class days, period boundaries, due dates, accrual windows, and attendance boundaries. Set at class creation; cannot be changed after the class has active seats.
+
+**Class Universe**
+The isolated classroom-economy boundary represented canonically by `class_id` and operationalized through class-local seats. All activity, records, and permissions remain within one resolved class universe.
+
+**Classroom Token Hub (CTH)**
+The canonical product name for the classroom economy platform.
+
+**Classroom Wage Index (CWI)**
+Expected weekly income for perfect attendance. The baseline economic unit against which all recommended pricing, solvency ratios, and policy-mode guidance are measured.
+
+**Comfortable**
+The most generous of three policy modes. Lowers economic pressure and accelerates progression relative to CWI. See also: Default, Tight, Policy Mode.
+
+**Correlation ID** (`correlation_id`)
+System-wide workflow identifier propagated across requests, FEATs, reversals, audits, jobs, and incidents to preserve causal linkage. Every side-effecting operation must carry or generate one.
+
+**Correlation Pack**
+Immutable support snapshot that captures request-trace and error context at issue submission time. Stored in `ticket_correlation_packs`. Once written, it is never updated — it represents the diagnostic state at the moment of report.
+
+### D
+
+**Default (Policy Mode)**
+The balanced middle policy mode used as the baseline classroom economy climate. See also: Comfortable, Tight, Policy Mode.
+
+**Display Metadata** (`display_name`, `section`)
+Class-level metadata fields used for teacher-facing display. `display_name` is the human-facing class title; `section` is the canonical period label (e.g., "Block A", "Period 1"). Neither field carries authority — they are metadata only, not scoping keys.
+
+**Distributed Trust**
+Teacher-recovery principle requiring one verifying student per active class so no single student can recover a teacher account alone. Implemented through student-assisted recovery flows using hashed recovery codes.
+
+**Domain Blindness**
+Ledger rule that money rows record operational provenance (SYSTEM / MANUAL / ADJUSTMENT) but never business meaning such as rent or store semantics. The ledger does not know why a transaction occurred — only where it came from.
+
+### E
+
+**Entitlement Balance**
+Derived count or value of obligation-linked perks. Computed from `entitlement_events` and never stored as authoritative state. Distinguished from monetary balances by being event-derived and non-cacheable.
+
+**Entitlement Events** (`entitlement_events`)
+Append-only event stream for obligation-linked grants, consumption, and revocations such as rent-linked hall-pass quota. Owned by the Obligations domain.
+
+### F
+
+**FEAT**
+Atomic feature-execution orchestration unit and the only lawful mechanism for state mutation, money movement, binding, and cross-domain coordination. Routes and background jobs must invoke a FEAT; they must not call `db.session.add/commit` directly on domain models. The FEAT resolves identity context before any domain interaction, validates intent through read-only domain guards, executes all mutations within a single transaction boundary, and emits an auditable execution trace.
+
+**Foundational**
+Highest documentation authority level. Assigned to system identity documents and non-negotiable invariants (`INV-CORE-*`). Documents at this level cannot be superseded by normative or informational documents.
+
+**Future Economic Law**
+Pending policy state treated as visible announced law rather than hidden backend configuration. Teachers, students, and operational domains must be able to see what will change and when. The disclosure principle behind `visible future economic law`.
+
+### H
+
+**Health Check Events** (`health_check_events`)
+Operations-domain events capturing liveness, readiness, or correctness checks for components and workflows.
+
+### I
+
+**Idempotency Key** (`idempotency_key`)
+Unique replay-protection key attached to writes so retries cannot create duplicate effects. Every FEAT must accept or generate one. Used across ledger writes, obligation events, and activation flows.
+
+**Identity Profiles** (`identity_profiles`)
+Seat-owned display-identity table for encrypted first name and public-facing initials. Not an authority or credential table — it carries display state only, with PII encrypted at rest.
+
+**Identity Rebinding**
+Recovery principle that restores credential access on the same identity record without creating new records or moving economic state. The student's seat, balances, and history are untouched; only the authentication path is re-established.
+
+**Incident Events** (`incident_events`)
+Append-only lifecycle events describing incident creation, updates, comments, and resolution. Owned by the Operations domain.
+
+**Incident Summary** (`incident_summary`)
+Cache/projection of the current state of an incident, derived from its append-only event history. Owned by the Operations domain.
+
+**Interest Payout**
+The lawful posting of accrued interest into a student's savings balance through FEAT and ledger execution. Distinguished from interest accrual (earning) and compounding (reinvesting).
+
+**Interpretation Axes**
+The two orthogonal dimensions of analytics interpretation. _Behavioral Interpretation_ explains how seats behave over completed payroll cycles using domain event logs. _Structural Interpretation_ evaluates class configuration and economy health relative to CWI and the modeled system structure. Every metric belongs to exactly one axis and must not blend them into one authority path.
+
+**Issue Categories** (`issue_categories`)
+System-managed taxonomy used to classify student support issues. Owned by the Support domain.
+
+**Issue Resolution Actions** (`issue_resolution_actions`)
+Append-only declaration log of support actions such as reversals or waivers. Records what action was declared, not the underlying money effect (which goes through FEAT → Ledger).
+
+**Issue Status History** (`issue_status_history`)
+Append-only audit trail of every support issue status transition. Owned by the Support domain.
+
+### J
+
+**Job Events** (`job_events`)
+Operations-domain event log for scheduled and background work such as invariant runs, activation jobs, retries, and failures.
+
+**Join Code** (`join_code`)
+Human-facing class entry alias that resolves to `class_id` before any authority-sensitive action. Still a primary operational key on ~30 tables during the v1→v2 transition; the v2 architectural goal is alias-only status where `class_id` is the sole internal scoping key.
+
+### L
+
+**Last Active Seat ID** (`last_active_seat_id`)
+Sticky-context pointer on `users` that restores the last resolved class-local actor context across devices and logins. Part of the Sticky Context mechanism.
+
+**Ledger Balance Snapshot** (`ledger_balance_snapshot`)
+Canonical v2 spendable-balance cache owned by the Ledger domain. Re-derivable from posted transactions; if the cache disagrees with the event log, the event log is authoritative.
+
+**Ledger Transaction** (`ledger_transaction`)
+Canonical immutable money-movement record. Domain-blind — records operational provenance but not business meaning. All money posts, voids, and reversals produce rows in this table through FEAT execution.
+
+### M
+
+**Money Velocity**
+Core class-level metric describing how quickly currency circulates through the classroom economy. Used in analytics and interpretation to detect stagnation or hyperinflation.
+
+### O
+
+**Obligation Lifecycle** (`obligation_lifecycle`)
+Derived per-assessment state row describing whether an obligation is due, overdue, paid, waived, or reversed. Owned by the Obligations domain.
+
+**Obligation Reversal** (`obligation_reversal`)
+Immutable record that nullifies a prior assessment. A reversal overrides any prior satisfaction history when computing the real status of an assessment.
+
+**Obligation Satisfaction** (`obligation_satisfaction`)
+Immutable record of how a debt was resolved, such as payment or waiver. Owned by the Obligations domain.
+
+**Operational Events** (`operational_events`)
+Structured JSON operational logs with indexed trace fields (`timestamp`, `correlation_id`, `domain`, `level`) separated from the payload blob. Distinguished from `audit_log` by being observability-focused rather than compliance-focused.
+
+### P
+
+**Passkey**
+WebAuthn-based passwordless authentication capability owned by `users` and optionally used by teacher and sysadmin accounts.
+
+**Policy Mode**
+Teacher-selectable economy climate (tight, default, comfortable) that shapes recommended ratios, pacing, and solvency expectations. Stored in `economy_policy_mode`; in v2 it is an operational projection derived from `policy_versions` rather than independent constitutional truth.
+
+**Policy Transitions** (`policy_transitions`)
+Append-only lineage objects describing source/target policy versions, activation mode (see Activation Intent), status, and supersession relationships. The backbone of append-only policy evolution.
+
+**Policy Versions** (`policy_versions`)
+Immutable constitutional policy records representing the active or historical economic truth for a class/domain pair. Once created, a policy version is never modified — it is superseded by a new version through a policy transition.
+
+### S
+
+**Seat**
+Class-local participant position and the canonical actor identity for economic and operational activity inside one class universe. Distinguished by role: Student Seat or Teacher Seat. All economic records (transactions, obligations, entitlements) hang from `seat_id`.
+
+**Seat-Scoped Isolation**
+Rule that debt, money movement, entitlement usage, attendance facts, and other actor activity stay bound to one seat within one class. No cross-seat leakage is permitted.
+
+**Seat Attendance State** (`seat_attendance_state`)
+Per-seat mutable attendance gate row used for tap enablement and done-for-day locking. Owned by the Attendance domain.
+
+**Seat ID** (`seat_id`)
+Canonical actor identifier for class-local activity. All economic and operational records reference it. Distinguished from `user_id` (global identity) by being class-scoped.
+
+**Seat Public ID** (`seats.public_id`, `actor_public_id`)
+UUID-encoded deidentified public actor identifier used in class-scoped participant navigation and sysadmin-safe references. `actor_public_id` is a support-facing copy used in escalation views so support workflows do not expose raw seat/student identifiers.
+
+**Share Class Name With Sysadmin** (`share_class_name_with_sysadmin`)
+Explicit teacher-consent flag controlling whether class name and context can be shown during issue escalation. A privacy boundary within the support domain.
+
+**Spendable Balance**
+The authoritative sum of posted ledger transactions for a seat/account context. The balance truth that other domains query for solvency decisions. Distinguished from _available balance_ (posted + pending delta, used for real-time reads) and _current balance_ (posted-only, used after settlement). In the banking domain, _eligible savings balance_ is the accrual-period-specific slice that qualifies to earn interest.
+
+**Sticky Context**
+The last-active class/seat restoration mechanism used to keep users in the correct class context across sessions and devices. Operationalized through `last_active_seat_id`.
+
+**Store Items** (`store_items`)
+Store-domain catalog rows describing price, item behavior, inventory, collective-goal settings, and rent-link flags.
+
+**Student Items** (`student_items`)
+Store-held purchased or granted entitlements attached to a seat, including status, expiry, bundle, and use counters.
+
+**Student Seat**
+Seat whose role is student. Acts as the earning, spending, and claiming actor inside a class. See also: Teacher Seat.
+
+### T
+
+**Teacher Seat**
+Seat whose role is teacher. Owns class-scoped operational authority within one class universe. See also: Student Seat.
+
+**Ticket Correlation Packs** (`ticket_correlation_packs`)
+Support-owned immutable 1:1 diagnostic snapshots tying an issue to frozen request traces and error references.
+
+**Tight**
+Most restrictive policy mode. Emphasizes survival, slower savings growth, and higher economic pressure. See also: Default, Comfortable, Policy Mode.
+
+### U
+
+**Unified Identity Model**
+V2 identity architecture where teachers, students, and sysadmins share `users`/`seats`/`classes` primitives instead of separate role-specific tables.
+
+**User Recovery Tokens** (`user_recovery_tokens`)
+Canonical user-owned recovery-token lifecycle rows for v2 recovery authority. Distinct from short-lived bridge-era reset-code fields.
+
+**Username Lookup Hash** (`username_lookup_hash`)
+Deterministic hashed lookup key used to locate a user during login and recovery without storing plaintext usernames.
+
+**Users** (`users`)
+Canonical global identity table that owns authentication, recovery, session security, and role law. The only table that exists outside a class universe — it represents the human across all classes.
+
+### V
+
+**Visible Future Economic Law**
+The disclosure principle that pending policy state must be visible to affected teachers, students, and operational domains. Pending changes are announced law, not hidden backend configuration.
+
+---
+
+## V. Banking Domain Terms
+
+These terms form a coherent sub-vocabulary within the banking/savings domain.
+
+**Accrual Frequency**
+How often savings interest is earned (daily, weekly, monthly). Distinct from Compound Frequency and payout timing.
+
+**Accrued Interest**
+Interest earned but not yet posted into spendable savings. Exists as intermediate banking state until Interest Payout occurs.
+
+**Compound Frequency**
+How often accrued interest joins the future earning base. Distinct from Accrual Frequency. Includes the Compound Participation sub-rule: whether accrued-but-unpaid interest participates in future accrual calculations.
+
+**Interest Payout**
+(Cross-referenced from Section IV.) The lawful posting of accrued interest into a student's savings balance through FEAT and ledger execution.
+
+---
+
+## VI. Excluded Terms
+
+The following term categories are intentionally excluded from this glossary:
+
+### Moved to Schema Documentation (`ARC-OPS-007`)
+
+Database column names, table names, and implementation artifacts that carry no independent architectural meaning: `account_balances`, `anonymous_code`, `balance_cache`, `class_economies`, `ClassEconomy`, `ClassMembership`, `done_for_day_date`, `hall_pass_verify_token`, `money_action_cooldown_until`, `payroll_fines`, `payroll_rewards`, `queue_enabled`, `queue_limit`, `recovery_status`, `redemption_audit_logs`, `redemption_prompt`, `rent_hall_passes`, `student_recovery_codes`, `tap_enabled`, `teacher_public_id`, `teacher_public_token`, `user_reports`.
+
+### Moved to Feature Specs
+
+Feature-specific behavioral rules: Mid-Period Lock, Rent Late Fee Reversal, rent-linked store item, Top-Off Logic, Waiver-Aware Paid Status, Public Verification Portal, Unclaimed seat, RecoveryRequest, System Health Metrics, Economy Balance Checker.
+
+### Removed (Replaced or Premature)
+
+Legacy terms being replaced by canonical vocabulary: `block` (→ section), `StudentBlock` (→ seat_attendance_state), `tap_events` (→ attendance_sessions), `teacher_blocks` (removed from codebase). Premature terms: `TemporalContext` (no code yet). Derivable model names: `AnalyticsAlert`, `AnalyticsSnapshot`.
+
+---
+
+## VII. Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-06-15 | Terminology Audit | Initial creation from TERMINOLOGY_AUDIT_V1.md governance classification. 82 terms retained, 18 merged, 22 moved to schema docs, 10 moved to feature specs, 7 removed. |

--- a/docs/REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md
+++ b/docs/REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md
@@ -53,7 +53,7 @@ Named solvency check asking whether students can still preserve a minimum weekly
 ### C
 
 **Canonical Class Time**
-The class-local current time derived from UTC plus the class IANA timezone. Modeled as the `class_time` field inside `TemporalContext`. All behavioral evaluation (attendance boundaries, due dates, accrual windows) must use this rather than raw UTC or server-local time.
+The class-local current time derived from UTC plus the class IANA timezone. In the planned v2 temporal model, this is the `class_time` field inside a per-request temporal context object. All behavioral evaluation (attendance boundaries, due dates, accrual windows) must use canonical class time rather than raw UTC or server-local time.
 
 **Catastrophe Stability Rule**
 Economy solvency rule testing whether a student can recover within roughly one cycle from a pair of shocks such as fines or loss. Distinguished from Budget Survival Test by its focus on shock recovery rather than steady-state viability.
@@ -309,7 +309,7 @@ Feature-specific behavioral rules: Mid-Period Lock, Rent Late Fee Reversal, rent
 
 ### Removed (Replaced or Premature)
 
-Legacy terms being replaced by canonical vocabulary: `block` (→ section), `StudentBlock` (→ seat_attendance_state), `tap_events` (→ attendance_sessions), `teacher_blocks` (removed from codebase). Premature terms: `TemporalContext` (no code yet). Derivable model names: `AnalyticsAlert`, `AnalyticsSnapshot`.
+Legacy terms being replaced by canonical vocabulary: `block` (→ section), `StudentBlock` (→ seat_attendance_state), `tap_events` (→ attendance_sessions), `teacher_blocks` (model removed from `models.py`; legacy references remain in a few admin routes and CLI commands). Premature terms: `TemporalContext` (no code yet). Derivable model names: `AnalyticsAlert`, `AnalyticsSnapshot`.
 
 ---
 

--- a/docs/REFERENCE/REF-TERM-002_USER_VOCABULARY.md
+++ b/docs/REFERENCE/REF-TERM-002_USER_VOCABULARY.md
@@ -93,7 +93,7 @@ A per-student daily lock that prevents further attendance taps after the student
 An individual classroom economy. Each class has its own join code, settings, students, and financial records. A teacher may run multiple classes; a student may belong to multiple classes.
 
 **Join Code**
-The short code students use to find and join a class. It is the public-facing name for a class; internally, the system uses a private class ID.
+The short code students use to find and join a class. It is the public-facing identifier for a class (distinct from the class display name); internally, the system uses a private class ID.
 
 **Section**
 A label for the class period — for example, "Block A" or "Period 3." Used for display only; it does not affect how the system scopes data.

--- a/docs/REFERENCE/REF-TERM-002_USER_VOCABULARY.md
+++ b/docs/REFERENCE/REF-TERM-002_USER_VOCABULARY.md
@@ -1,0 +1,180 @@
+# REF-TERM-002: User Vocabulary
+
+| Reference Number | Version | Effective Date | Supersedes | Authority Level |
+|------------------|---------|----------------|------------|-----------------|
+| REF-TERM-002     | 1.0     | 2026-06-15     | N/A        | Normative       |
+
+## I. Purpose
+
+Define the authoritative user-facing vocabulary for the Classroom Token Hub. These are the terms that appear in teacher and student interfaces, user guides, help text, and support communications.
+
+## II. Scope
+
+This glossary covers terms that teachers or students encounter during normal use. Each term carries a plain-language definition suitable for non-technical audiences. Implementation details, internal table names, and developer-only concepts belong in `REF-TERM-001`.
+
+Terms that also appear in REF-TERM-001 carry their user-facing definition here and their implementation-facing definition there.
+
+## III. Authority Level
+
+Normative. User-interface text, help copy, and user documentation must use these terms as defined here.
+
+## III-A. Dependencies
+
+- `REF-TERM-001_DEVELOPER_VOCABULARY.md` (developer-facing counterpart)
+
+---
+
+## IV. Glossary
+
+### Economy & Policy
+
+**Classroom Token Hub**
+The name of this classroom economy platform.
+
+**Classroom Wage Index (CWI)**
+The expected weekly income a student earns for perfect attendance. All prices, savings goals, and economic recommendations are measured against this number.
+
+**Policy Mode**
+The overall economic climate of a class, selected by the teacher. There are three modes:
+
+- **Comfortable** — Lower pressure, faster savings growth, more room for mistakes.
+- **Default** — Balanced middle ground; the recommended starting point.
+- **Tight** — Higher pressure, slower savings growth, more economic challenge.
+
+**Economy Health**
+A teacher-facing dashboard that shows whether current class settings (wages, rent, prices) are aligned with the selected policy mode and whether the economy is sustainable.
+
+**Budget Survival Test**
+A check that asks: can students still save a minimum amount each week after paying all recurring costs? If not, the economy may need rebalancing.
+
+**Catastrophe Stability Rule**
+A check that asks: can a student recover within about one week from two unexpected costs (like fines or lost items)?
+
+### Money & Balances
+
+**Checking Balance**
+The amount of money a student can spend right now.
+
+**Savings Balance**
+Money a student has set aside in savings. May earn interest depending on class banking settings.
+
+**Spendable Balance**
+The total amount available for purchases or transfers — equivalent to checking balance in most contexts.
+
+**Accrued Interest**
+Interest that has been earned on savings but not yet added to the spendable savings balance. It will be posted at the next payout.
+
+**Accrual Frequency**
+How often savings interest is earned — daily, weekly, or monthly, as set by the teacher.
+
+**Compound Frequency**
+How often previously earned interest starts earning its own interest.
+
+**Interest Payout**
+When accrued interest is officially added to a student's savings balance so it can be spent or continue earning.
+
+### Attendance
+
+**Attendance Session**
+A record of when a student tapped in and tapped out of class. Used to calculate daily earnings.
+
+**Class Day**
+The school day as defined by the class timezone — midnight to midnight. Daily limits and attendance windows are measured within this boundary.
+
+**Tap Enabled**
+Whether a student is currently allowed to tap in for attendance. A teacher can disable this without erasing prior attendance history.
+
+**Done for Day**
+A per-student daily lock that prevents further attendance taps after the student has completed their session for the day.
+
+### Class & Identity
+
+**Class**
+An individual classroom economy. Each class has its own join code, settings, students, and financial records. A teacher may run multiple classes; a student may belong to multiple classes.
+
+**Join Code**
+The short code students use to find and join a class. It is the public-facing name for a class; internally, the system uses a private class ID.
+
+**Section**
+A label for the class period — for example, "Block A" or "Period 3." Used for display only; it does not affect how the system scopes data.
+
+**Seat**
+A student's or teacher's position within a specific class. Everything a student does in a class — earning, spending, attendance — is attached to their seat in that class.
+
+**Student Seat**
+A seat held by a student. The student earns, spends, and participates through this seat.
+
+**Teacher Seat**
+A seat held by the teacher. The teacher manages the class through this seat.
+
+### Store & Goals
+
+**Store Item**
+A product, privilege, or reward available for purchase in the class store. Teachers set the price and availability.
+
+**Collective Goal**
+A shared class savings objective. All participating students contribute toward a common target, encouraging teamwork.
+
+**Redemption Prompt**
+Instructions attached to a store item that tell the teacher how to fulfill the purchase when a student redeems it.
+
+### Hall Passes
+
+**Hall Pass**
+A time-tracked pass that allows a student to leave the classroom. Passes can be requested, approved, and timed through the system.
+
+**Queue**
+When enabled, students request hall passes and wait in line rather than receiving them immediately. The teacher controls queue settings and simultaneous limits.
+
+### Rent & Obligations
+
+**Rent**
+A recurring cost that students pay at regular intervals — for example, weekly desk rent. Rent can include linked benefits like hall passes.
+
+**Obligation**
+A scheduled financial responsibility assigned to a student, such as rent or an assessment. The system tracks whether each obligation is due, paid, overdue, or waived.
+
+**Waiver**
+A teacher action that marks an obligation as satisfied without requiring payment.
+
+### Recovery & Security
+
+**Reset Code**
+A short code shown to the teacher that a student can use to recover access to their account without affecting their class balance or history.
+
+**Passkey**
+A modern, passwordless way for teachers to log in using biometrics or a security key instead of a password.
+
+**Two-Factor Authentication (2FA)**
+An extra security step required for teacher accounts. After entering a password, the teacher must also enter a time-based code from an authenticator app.
+
+### Policy Changes
+
+**Activation Intent**
+When a teacher changes an economy setting, this controls when the change takes effect: immediately, at the start of the next period, or manually at a chosen time.
+
+**Future Economic Law**
+A pending change to class settings that has been announced but hasn't taken effect yet. Students and teachers can see what will change and when.
+
+### Analytics
+
+**Money Velocity**
+A measure of how quickly money circulates through the classroom economy. High velocity means money is being earned and spent actively; low velocity may indicate stagnation.
+
+---
+
+## V. Terms Not Used in User-Facing Contexts
+
+The following terms from the developer vocabulary (`REF-TERM-001`) do not appear in user interfaces and should not be used in student- or teacher-facing text:
+
+`class_id`, `seat_id`, `correlation_id`, `idempotency_key`, `FEAT`, `domain guard`, `ledger_transaction`, `audit_log`, `policy_versions`, `policy_transitions`, `append-only policy evolution`, `domain blindness`, `operational events`, `TemporalContext`.
+
+If user-facing text needs to refer to the concept behind one of these terms, use the corresponding plain-language term from this glossary instead.
+
+---
+
+## VI. Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-06-15 | Terminology Audit | Initial creation from TERMINOLOGY_AUDIT_V1.md governance classification. Covers all user-facing terms from the 82-term KEEP set plus plain-language definitions for merged concepts. |

--- a/docs/STANDARD_OPERATING_PROCEDURES/SOP-DOC-002_DOCUMENTATION_INDEX.md
+++ b/docs/STANDARD_OPERATING_PROCEDURES/SOP-DOC-002_DOCUMENTATION_INDEX.md
@@ -112,6 +112,10 @@ These documents conform to the V2 capability-based architecture and domain autho
 - [MAP/MAP-CLASS-002_CLASS_SCOPE_NORMALIZATION_TARGET.md](MAP/MAP-CLASS-002_CLASS_SCOPE_NORMALIZATION_TARGET.md)
 - [MAP/MAP-CORE-001_DOMAIN_TO_FEAT_CAPABILITY_MAP.md](MAP/MAP-CORE-001_DOMAIN_TO_FEAT_CAPABILITY_MAP.md)
 
+### Reference — Terminology (REF-TERM)
+- [REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md](../REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md) — Authoritative developer-facing vocabulary
+- [REFERENCE/REF-TERM-002_USER_VOCABULARY.md](../REFERENCE/REF-TERM-002_USER_VOCABULARY.md) — Authoritative user-facing vocabulary
+
 ---
 
 ## VI. Legacy Specifications (Deprecated/Transitional)

--- a/docs/STANDARD_OPERATING_PROCEDURES/SOP-DOC-002_DOCUMENTATION_INDEX.md
+++ b/docs/STANDARD_OPERATING_PROCEDURES/SOP-DOC-002_DOCUMENTATION_INDEX.md
@@ -113,8 +113,8 @@ These documents conform to the V2 capability-based architecture and domain autho
 - [MAP/MAP-CORE-001_DOMAIN_TO_FEAT_CAPABILITY_MAP.md](MAP/MAP-CORE-001_DOMAIN_TO_FEAT_CAPABILITY_MAP.md)
 
 ### Reference — Terminology (REF-TERM)
-- [REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md](../REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md) — Authoritative developer-facing vocabulary
-- [REFERENCE/REF-TERM-002_USER_VOCABULARY.md](../REFERENCE/REF-TERM-002_USER_VOCABULARY.md) — Authoritative user-facing vocabulary
+- [REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md](REFERENCE/REF-TERM-001_DEVELOPER_VOCABULARY.md) — Authoritative developer-facing vocabulary
+- [REFERENCE/REF-TERM-002_USER_VOCABULARY.md](REFERENCE/REF-TERM-002_USER_VOCABULARY.md) — Authoritative user-facing vocabulary
 
 ---
 

--- a/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
+++ b/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
@@ -2,128 +2,123 @@
 
 > Part 1 of the documentation audit. Inventory only; no rewriting.
 > Date: 2026-06-15
+> Revision: 2 — accuracy corrections, frequency fixes, removal candidates flagged
+
+## Corrections Applied (Revision 2)
+
+| # | Term | Issue | Fix |
+|---|---|---|---|
+| 1 | block | Definition incomplete; frequency wildly inflated (8250→~3700, many are model names like `StudentBlock`) | Rewrote definition to reflect current transitional state; corrected frequency |
+| 2 | class_economies | Marked v1-only but the Python model `ClassEconomy` is still the active class anchor (mapped to `classes` table) | Changed to "both"; clarified table-name vs model-name distinction |
+| 3 | ClassEconomy | Marked v1-only but it is the active runtime model | Changed to "both" |
+| 4 | ClassMembership | Marked v1-only but still active in routes and listed in CLAUDE.md as current scoping authority | Changed to "both" |
+| 5 | balance_cache | Marked v1-only but `BalanceCache` model is active (backed by `ledger_balance_snapshot` table) | Changed to "both"; clarified the table rename |
+| 6 | StudentBlock | Marked v1-only but still actively used in routes for per-seat per-class state | Changed to "both" |
+| 7 | tap_events | Marked v1-only/superseded but still in active dual-write transition | Changed to "both" |
+| 8 | Economy Balance Checker | Marked v1 but the class and route are active in current codebase | Changed to "both" |
+| 9 | Economy Health | Marked v1 but the route and feature are active | Changed to "both" |
+| 10 | default (policy mode) | Frequency 1456 massively inflated by Python `default=` keyword across codebase | Corrected to ~280 (policy-mode-specific) |
+| 11 | FEAT | Frequency 9200 overstated; measured ~6300 (dominated by docs) | Corrected |
+| 12 | join_code | "alias-only in v2" is aspirational; it remains a primary operational key on ~30 tables | Clarified definition |
+| 13 | Canonical class time | Name is correct per docs; definition accurate but tightened to reference TemporalContext | Tightened definition |
+
+---
+
+## Terminology Table
 
 | Term | Definition | Usage/Context | Version | Facing | Frequency |
 |---|---|---|---|---|---|
-| Account Lifecycle Map | The non-normative human-story map of teacher and student identity progression from provisioning through operation and recovery. | Identity onboarding and developer orientation. | v2 | dev | 2 |
 | account_balances | Planned v2 per-account checkpoint/cache table keyed by class, seat, and account type for available/current balance tracking. | Future banking/ledger rebuild design. | v2 | dev | 7 |
 | Accrual Frequency | How often savings interest is earned (daily, weekly, monthly), distinct from compounding and payout timing. | Banking policy and execution scheduling. | v2 | both | 5 |
 | Accrued Interest | Interest earned but not yet posted into spendable savings; it exists as intermediate banking state until payout. | Banking domain accrual and payout model. | v2 | both | 14 |
 | Activation Intent | The abstract timing mode attached to a policy transition that says whether a change is immediate, at the next lawful boundary, or manual. | Economic policy governance and disclosure. | v2 | both | 14 |
 | actor_public_id | Support-facing copy of a seat public ID used in sysadmin views so support workflows do not expose raw seat/student identifiers. | Support tickets, correlation packs, escalation views. | v2 | dev | 150 |
-| Aggregate Analytics Principle | Rule that analytics should describe class-level ecosystem health and drift, not rank or surveil individual students. | Economy analytics philosophy. | both | both | 2 |
-| Alignment Status | Teacher-facing indication of whether live class settings align with the selected economy policy mode and recommendations. | Economy Health and rebalance workflow. | v1 | both | 3 |
-| AnalyticsAlert | Legacy/sysadmin alert object raised from analytics snapshots when a class economy crosses health thresholds. | v1 sysadmin observability and alerting. | v1 | dev | 57 |
-| AnalyticsSnapshot | Immutable aggregate class-health snapshot captured for analytics and sysadmin alerting without exposing individual student data. | Analytics, alerting, and legacy sysadmin monitoring. | both | dev | 55 |
+| Alignment Status | Teacher-facing indication of whether live class settings align with the selected economy policy mode and recommendations. | Economy Health and rebalance workflow. | both | both | 3 |
+| AnalyticsAlert | Sysadmin alert object raised from analytics snapshots when a class economy crosses health thresholds. | Sysadmin observability and alerting. | both | dev | 57 |
+| AnalyticsSnapshot | Immutable aggregate class-health snapshot captured for analytics and sysadmin alerting without exposing individual student data. | Analytics, alerting, and sysadmin monitoring. | both | dev | 55 |
 | anonymous_code | HMAC-derived opaque reference displayed for free-form user reports instead of raw identity. | Support/user report workflow. | v2 | dev | 23 |
 | append-only policy evolution | Core economic governance rule that policy changes are represented as new transition lineage, never in-place mutation of active truth. | Economic policy governance and migration away from hidden delayed mutation. | v2 | dev | 2 |
-| Attendance Event Log | Conceptual append-only timeline formed by attendance sessions and hall-pass events as the authoritative attendance fact history. | Attendance domain model. | v2 | dev | 2 |
-| attendance_sessions | Canonical v2 table for tap-in/tap-out attendance facts; the successor to legacy tap_events. | Attendance tracking, payroll inputs, and temporal rules. | v2 | both | 66 |
+| attendance_sessions | Canonical v2 table for tap-in/tap-out attendance facts; coexists with legacy tap_events in a dual-write transition. | Attendance tracking, payroll inputs, and temporal rules. | v2 | both | 66 |
 | Audit Event | High-integrity append-only record for security-sensitive, identity-sensitive, and money-moving side effects. | Operations domain audit trail. | v2 | dev | 14 |
 | audit_log | Operations-owned audit table that stores structured before/after records for sensitive side effects and FEAT execution traces. | Audit lineage and operational compliance. | v2 | dev | 115 |
 | available_balance | Operational balance that includes posted balance plus pending delta and is used for real-time reads and preconditions. | Ledger reads, banking UI, overdraft checks, and settlement contract. | both | both | 43 |
-| Axis Exclusivity | Interpretation rule that every metric belongs to exactly one axis—behavioral or structural—and must not blend them into one authority path. | Interpretation domain invariants. | v2 | dev | 3 |
-| balance_cache | Legacy balance cache term for the derived money cache used before the canonical ledger_balance_snapshot/account-balance direction. | v1/v1.5 ledger implementation and migration bridge. | v1 | dev | 114 |
-| Behavioral Interpretation | Interpretation axis that explains how seats behave over completed payroll cycles using domain event logs. | Interpretation/analytics meaning layer. | v2 | both | 3 |
-| block | Legacy label used for periods/sections and sometimes policy scope; v2 treats it as metadata only and forbids label-based authority. | v1 scoping model and v2 prohibition boundary. | both | both | 8250 |
+| balance_cache | Legacy table name for the derived money cache; the Python model `BalanceCache` is still active, now backed by the `ledger_balance_snapshot` table. | Ledger implementation and migration bridge. | both | dev | 114 |
+| block | Legacy label for periods/sections. Still used operationally in routes and models (e.g. `StudentBlock.period`) during v1→v2 transition; v2 goal is to treat it as display-only metadata under the canonical `section` field, forbidding label-based authority. | v1 scoping model and v2 migration target. | both | both | ~3700 |
 | Budget Survival Test | Canonical solvency check asking whether students can still preserve a minimum weekly savings buffer after recurring costs. | Economy governance, validation, and analytics. | both | both | 19 |
-| Canonical class time | The class-local notion of current time derived from UTC plus the class timezone and used for all behavioral evaluation. | Temporal architecture and class-scoped execution. | v2 | dev | 6 |
+| Canonical class time | The class-local current time derived from UTC plus the class IANA timezone; modeled as the `class_time` field inside `TemporalContext`. | Temporal architecture and class-scoped execution. | v2 | dev | 6 |
 | Catastrophe Stability rule | Economy solvency rule testing whether a student can recover within roughly one cycle from a pair of shocks such as fines or loss. | Economic policy validation and recommendations. | both | both | 3 |
 | claim artifacts | Seat-owned verification artifacts used to prove entitlement to a rostered participant position during the claim flow. | Student seat claim and roster provisioning. | v2 | dev | 13 |
 | Claim Lifecycle | Identity flow that binds a global user to a class-local seat after verifying class-specific claim artifacts. | Identity onboarding and seat binding. | v2 | both | 6 |
-| Claim-Based Model | Public hall-pass verification model that only answers a specific student claim instead of exposing a roster or pass list. | Public hall-pass verification portal. | both | both | 2 |
 | class day | The canonical classroom day boundary defined as midnight-to-midnight in class timezone, then converted to UTC query bounds. | Temporal architecture, attendance, and daily limits. | v2 | dev | 4 |
-| Class Drift | Identity/context problem where a session restores or remains in the wrong class; sticky-context rules exist to prevent it. | Identity session restoration. | v2 | both | 2 |
 | class timezone | Immutable IANA timezone owned by the class and used to evaluate days, periods, due dates, accrual windows, and attendance boundaries. | Temporal model, interpretation, obligations, and banking. | v2 | both | 33 |
 | class universe | The isolated classroom-economy boundary represented canonically by class_id and operationalized through class-local seats. | Identity architecture and scoping law. | v2 | both | 33 |
-| class-scoped isolation | Rule that all class activity, records, and permissions remain within one resolved class boundary with no cross-class leakage. | Core invariants, request context, and domain ownership. | both | both | 1 |
-| class_economies | Legacy v1 class container model that held class identity and join code before the canonical classes/class_id v2 model. | v1 architecture and migration references. | v1 | dev | 420 |
+| class_economies | Legacy v1 table name (now renamed to `classes`). The Python model `ClassEconomy` is still the active class anchor mapped to the `classes` table. | Identity and class universe references. | both | dev | 420 |
 | class_features | Class Configuration table whose row existence per feature acts as authoritative feature enablement for a class. | Feature enablement and class policy surfaces. | v2 | dev | 56 |
-| class_id | Canonical private class-universe identifier and internal scoping boundary for all authority-sensitive v2 behavior. | Identity, policy, ledger, attendance, and isolation invariants. | both | both | 7791 |
-| ClassEconomy | Legacy v1 private tenant container for a classroom economy, paired with a public join code. | v1 multi-tenancy and class identity model. | v1 | dev | 887 |
-| classes | Canonical v2 class-anchor table that defines the universe boundary and carries join code token, display name, and section metadata. | Identity and all class-wide configuration references. | v2 | dev | 840 |
-| ClassMembership | Legacy membership/bridge record linking a person to a class; v2 replaces this with seat existence as membership truth. | v1 identity and scoping model, plus migration discussions. | v1 | dev | 269 |
-| Classroom Token Hub (CTH) | The classroom economy platform whose documentation uses CTH/ Classroom Token Hub as the canonical product name. | Cross-document product identity. | both | both | 11 |
+| class_id | Canonical private class-universe identifier and internal scoping boundary for all authority-sensitive behavior. | Identity, policy, ledger, attendance, and isolation invariants. | both | both | ~7100 |
+| ClassEconomy | Active Python model for the class universe anchor, now mapped to the `classes` table (was `class_economies` in v1). Paired with a public `join_code`. | Multi-tenancy and class identity model. | both | dev | 887 |
+| classes | Canonical v2 class-anchor table (renamed from `class_economies`) that defines the universe boundary and carries join code token, display name, and section metadata. | Identity and all class-wide configuration references. | v2 | dev | 840 |
+| ClassMembership | Active membership record linking a person to a class; v2 aspires to replace this with seat existence as membership truth, but the model remains operationally active. | Identity and scoping model. | both | dev | 269 |
+| Classroom Token Hub (CTH) | The classroom economy platform whose documentation uses CTH/Classroom Token Hub as the canonical product name. | Cross-document product identity. | both | both | 11 |
 | Classroom Wage Index (CWI) | Expected weekly income for perfect attendance; the baseline economic unit that all recommended pricing and solvency ratios are measured against. | Economy governance, analytics, policy modes, and recommendations. | both | both | 16 |
 | Collective Goal | A shared class objective or store-goal construct priced relative to CWI to encourage coordinated saving and participation. | Economy design, store catalog, and analytics. | both | both | 115 |
 | collective_goal_instance_code | Instance key that groups one or more collective-goal store items into the same progress bucket. | Store catalog and collective-goal tracking. | both | dev | 95 |
 | comfortable | The most generous policy mode, intended to lower pressure and accelerate progression relative to CWI. | Economy governance and teacher policy selection. | both | both | 49 |
 | Compound Frequency | How often accrued interest joins the future earning base; distinct from earning frequency and payout frequency. | Banking policy and accrual math. | v2 | both | 10 |
 | Compound Participation | The rule deciding whether accrued-but-unpaid interest is allowed to participate in future accrual calculations. | Banking domain semantics. | v2 | both | 4 |
-| ConsumptionIntent | Attendance-originated trigger concept for using an obligation-linked entitlement such as a rent-granted hall pass. | Attendance-to-Obligations coordination. | v2 | dev | 2 |
-| Context-First Execution | FEAT rule that a user, seat, and class context must be resolved before any domain interaction or mutation occurs. | Feature execution contract. | v2 | dev | 2 |
-| Core Orchestrator | A FEAT designated as a reusable high-integrity orchestration unit, especially for money posting/voiding and similar cross-domain actions. | Feature-execution architecture. | v2 | dev | 4 |
 | correlation pack | Immutable support snapshot that captures request-trace and error context at issue submission time. | Support diagnostics and escalation. | v2 | dev | 13 |
 | correlation_id | System-wide workflow identifier propagated across requests, FEATs, reversals, audits, jobs, and incidents to preserve causality. | Operations, ledger, FEAT, and support tracing. | both | both | 1048 |
 | current_balance | Authoritative posted-only account balance used after settlement and reconciliation, distinct from available balance. | Banking/ledger settlement model. | both | both | 42 |
 | current_session_nonce | Per-login nonce stored on users that binds all requests to one current session and invalidates older sessions on next sign-in. | Identity session security. | v2 | dev | 20 |
-| default | The balanced middle policy mode used as the baseline classroom economy climate. | Economy governance and teacher settings. | both | both | 1456 |
-| Diagnostic Drill-Down Metrics | Analytics metrics revealed only after interaction so a teacher can inspect context without making student ranking the default view. | Analytics and interpretation UX. | both | both | 2 |
+| default (policy mode) | The balanced middle policy mode used as the baseline classroom economy climate. | Economy governance and teacher settings. | both | both | ~280 |
 | display_name | Human-facing class title metadata, normally paired with section for teacher-facing class display. | Identity/class metadata and UI labels. | both | both | 394 |
 | Distributed trust | Teacher-recovery principle requiring one verifying student per active class so no single student can recover a teacher account alone. | Teacher account recovery. | v2 | both | 4 |
 | Domain Blindness | Ledger rule that money rows record operational provenance but not business meaning such as rent or store semantics. | Ledger domain architecture. | v2 | dev | 6 |
-| Domain Guard | Standardized read-only domain check that returns allowed/reason/metadata for FEAT orchestration instead of mutating or throwing business errors. | Capability and FEAT interaction pattern. | v2 | dev | 5 |
-| Domain Law | Shorthand for the codified domain authority model that says each domain owns one bounded truth and mutation boundary. | V2 restructuring and authority summary. | v2 | dev | 2 |
 | done_for_day_date | Per-seat attendance lock date used for O(1) gating; if it disagrees with the event log, attendance history remains authoritative. | Attendance state and daily lock behavior. | both | both | 68 |
-| Drift & Anomaly Metrics | Trend-oriented analytics that surface divergence from expected classroom-economy behavior instead of reporting totals alone. | Analytics and interpretation surfaces. | both | both | 3 |
-| drift indicators | Derived interpretation outputs that flag comparative movement away from expected system behavior over time. | Interpretation domain state classification. | v2 | dev | 2 |
-| Economy Balance Checker | Shared recommendation/validation engine that checks whether a class economy fits policy-mode guidance and solvency expectations. | Economy Health, rebalance preview, and recommendation APIs. | v1 | both | 11 |
-| Economy Health | Teacher-facing surface for policy mode, alignment review, recommendation visibility, and rebalance actions. | Economy feature/UI. | v1 | both | 62 |
+| Economy Balance Checker | Shared recommendation/validation engine that checks whether a class economy fits policy-mode guidance and solvency expectations. | Economy Health, rebalance preview, and recommendation APIs. | both | both | 11 |
+| Economy Health | Teacher-facing surface for policy mode, alignment review, recommendation visibility, and rebalance actions. | Economy feature/UI. | both | both | 62 |
 | economy_pending_rebalance_json | Deprecated compatibility field that stored delayed rebalance payloads before append-only policy transitions became the constitutional model. | Migration bridge from v1 delayed mutation to v2 governance. | both | dev | 24 |
 | economy_policy_alignment_status | Stored teacher-facing result showing whether current settings are aligned or misaligned with policy guidance. | Legacy feature_settings economy mode support. | v1 | both | 7 |
 | economy_policy_mode | Stored policy climate selector (tight/default/comfortable); in v2 it is an operational projection rather than independent constitutional truth. | Class configuration and economy UI. | both | both | 129 |
 | Eligible Savings Balance | The authoritative posted balance slice that actually qualifies to earn interest in a given accrual period. | Banking accrual rules and projections. | v2 | both | 2 |
 | Entitlement Balance | Derived count/value of obligation-linked perks; it is computed from events and is never stored as authoritative state. | Obligations and entitlement usage. | v2 | both | 5 |
 | entitlement_events | Append-only event stream for obligation-linked grants, consumption, and revocations such as rent-linked hall-pass quota. | Obligations domain. | v2 | dev | 50 |
-| Event-Log Authority | V2 rule that authoritative truth comes from immutable event records or explicit projections derived from them. | Core schema and domain summary. | v2 | dev | 4 |
-| Event-Log Fallback | Ledger rule that the posted transaction log can always recompute the spendable-balance cache if the cache is missing or inconsistent. | Ledger invariants and recovery behavior. | v2 | dev | 2 |
-| FEAT | Atomic feature-execution orchestration unit and the only lawful place for state mutation, money movement, binding, and cross-domain coordination. | Core execution architecture. | v2 | dev | 9200 |
+| FEAT | Atomic feature-execution orchestration unit and the only lawful place for state mutation, money movement, binding, and cross-domain coordination. | Core execution architecture. | v2 | dev | ~6300 |
 | Foundational | Highest documentation authority level for system identity and non-negotiable invariants. | Documentation governance model. | both | dev | 93 |
 | Future Economic Law | Pending policy state treated as visible announced law rather than hidden backend configuration. | Economic policy transitions and disclosure. | v2 | both | 19 |
-| Generic Placeholder | Teacher-created unclaimed seat waiting for a future student claim/binding. | Roster provisioning and identity lifecycle. | v2 | both | 2 |
 | hall pass balance | Combined pass availability model where rent-granted quota is tracked separately from purchased or other pass sources. | Hall-pass and entitlement behavior. | both | both | 10 |
 | hall_pass_logs | Attendance-owned lifecycle records for hall-pass requests, approvals, departures, and returns. | Hall-pass execution history. | both | both | 121 |
 | hall_pass_settings | Class-owned configuration for queueing, pass types, and simultaneous limits. | Class configuration and hall-pass feature. | both | both | 139 |
-| hall_pass_verify_token | Legacy hall-pass public verification token retained only as a compatibility surface; newer docs prefer UUID/public-token patterns. | v1 public hall-pass verification. | both | both | 68 |
+| hall_pass_verify_token | Legacy hall-pass public verification token retained as a compatibility surface; newer docs prefer UUID/public-token patterns. | Public hall-pass verification. | both | both | 68 |
 | health_check_events | Operations events capturing liveness, readiness, or correctness checks for components and workflows. | Operational health model. | v2 | dev | 15 |
-| Hidden Deferred Mutation | Forbidden pattern where future economic changes live only in opaque delayed payloads instead of visible transition lineage. | Economic governance and FEAT compliance. | v2 | dev | 2 |
-| Idempotency Lock | Ledger/system guard enforcing uniqueness of write intent at the database level. | Ledger state classification and FEAT retry safety. | v2 | dev | 3 |
 | idempotency_key | Unique replay-protection key attached to writes so retries cannot create duplicate effects. | FEAT execution, ledger writes, obligations, and activation flows. | both | both | 1797 |
 | identity rebinding | Recovery principle that restores credential access on the same identity record without creating or moving economic state. | Student and teacher account recovery. | v2 | both | 6 |
 | identity_profiles | Seat-owned display-identity table for encrypted first name and public-facing initials; not an authority or credential table. | Identity display layer. | v2 | dev | 95 |
 | incident_events | Append-only lifecycle events describing incident creation, updates, comments, and resolution. | Operations incident management. | v2 | dev | 15 |
 | incident_summary | Cache/projection of the current state of an incident, derived from its append-only event history. | Operations and status page surfaces. | v2 | dev | 15 |
-| Interest Payout | The lawful posting of accrued interest into a student’s savings balance through FEAT and ledger execution. | Banking domain and payout scheduling. | v2 | both | 12 |
-| Interpretation Snapshot | Cached materialization of a computed behavioral or structural metric window for a class. | Interpretation domain performance layer. | v2 | dev | 2 |
+| Interest Payout | The lawful posting of accrued interest into a student's savings balance through FEAT and ledger execution. | Banking domain and payout scheduling. | v2 | both | 12 |
 | issue_categories | System-managed taxonomy used to classify student support issues. | Support domain. | v2 | both | 31 |
 | issue_resolution_actions | Append-only declaration log of support actions such as reversals or waivers, without owning the underlying money effect. | Support domain and FEAT-linked remediation. | v2 | dev | 44 |
 | issue_status_history | Append-only audit trail of every support issue status transition. | Support domain lifecycle tracking. | v2 | dev | 40 |
 | job_events | Operations event log for scheduled/background work such as invariant runs, activation jobs, retries, and failures. | Operations domain. | v2 | dev | 20 |
-| join_code | Human-facing class entry alias that resolves to class_id before any authority-sensitive action; canonical in v1, alias-only in v2. | Student claim, routing, recovery, and class selection. | both | both | 6110 |
+| join_code | Human-facing class entry alias that resolves to class_id before any authority-sensitive action. Still a primary operational key on ~30 tables during v1→v2 transition; v2 goal is alias-only. | Student claim, routing, recovery, and class selection. | both | both | 6110 |
 | last_active_seat_id | Sticky-context pointer on users that restores the last resolved class-local actor context across devices and logins. | Identity session restoration. | v2 | dev | 30 |
 | ledger_balance_snapshot | Canonical v2 spendable-balance cache owned by the Ledger domain and re-derivable from posted transactions. | Ledger performance/read model. | v2 | dev | 54 |
 | ledger_transaction | Canonical immutable money-movement record used by the Ledger domain. | Ledger authority, FEAT posting, reversals, and audit. | v2 | dev | 98 |
-| Liveness / Readiness / Correctness | Three-part health model distinguishing process uptime, dependency availability, and invariant/business correctness. | Operations health semantics. | v2 | dev | 1 |
 | Mid-Period Lock | Rule that rent-item type semantics cannot change after a valid payment has occurred in the current coverage period. | Rent-linked perks and rent feature behavior. | v1 | both | 7 |
 | money velocity | Core class-level metric describing how quickly currency circulates through the classroom economy. | Analytics and interpretation. | both | both | 18 |
 | money_action_cooldown_until | Global rate-limit field on users that gates rapid financial mutations. | Identity security state and money-action safety. | v2 | dev | 30 |
 | next_boundary | Activation mode meaning a pending policy should take effect at the next lawful operational boundary rather than immediately. | Economic transition governance. | v2 | both | 4 |
-| obligation-linked entitlements | Perks whose grant/consumption is controlled by the Obligations domain because they arise from rent/assessment satisfaction rather than store purchase. | Obligations-store boundary. | v2 | both | 1 |
 | obligation_lifecycle | Derived per-assessment state row describing whether an obligation is due, overdue, paid, waived, or reversed. | Obligations domain. | v2 | dev | 44 |
 | obligation_reversal | Immutable record that nullifies a prior assessment and forces downstream interpretation to treat the obligation as non-existent. | Obligations corrections. | v2 | dev | 57 |
 | obligation_satisfaction | Immutable record of how a debt was resolved, such as payment or waiver. | Obligations domain lifecycle. | v2 | dev | 46 |
 | Operational Provenance | Ledger classification idea behind category fields such as SYSTEM/MANUAL/ADJUSTMENT; it records where a transaction came from, not its business meaning. | Ledger domain-blind design. | v2 | dev | 6 |
-| Operational Truth | Operations-domain truth about system behavior, health, incidents, jobs, and alerts—not business facts like balances or attendance. | Operations domain definition. | v2 | dev | 4 |
 | operational_events | Structured JSON operational logs with indexed trace fields outside the payload blob. | Operations observability. | v2 | dev | 21 |
 | passkey | WebAuthn-based passwordless authentication capability owned by users and optionally used by teacher/sysadmin accounts. | Identity and login architecture. | both | both | 446 |
 | payroll_fines | Class-owned fine presets that FEAT can translate into deductions but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both | 75 |
 | payroll_rewards | Class-owned reward presets that FEAT can translate into payroll credits but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both | 75 |
-| pending slice | The eligible subset of pending transactions processed during settlement rather than a full historical ledger rescan. | Banking/ledger settlement design. | v2 | dev | 2 |
-| PeriodKey | Deterministic class-calendar/policy-schedule key that creates a one-to-one mapping between a liability period and an assessment. | Obligations idempotency and period logic. | v2 | dev | 2 |
 | policy mode | Teacher-selectable economy climate (tight, default, comfortable) that shapes recommended ratios, pacing, and solvency expectations. | Economy governance and classroom configuration. | both | both | 49 |
 | policy_transitions | Append-only lineage objects describing source/target policy versions, activation mode, status, and supersession relationships. | Economic governance and class configuration. | v2 | dev | 89 |
 | policy_versions | Immutable constitutional policy records representing the active or historical economic truth for a class/domain pair. | Economic governance and class configuration. | v2 | dev | 100 |
-| Posted Balance Snapshot | The cached spendable-balance view derived from posted transactions only; authoritative for spending if recomputable from the event log. | Ledger state model. | v2 | dev | 4 |
 | Public Verification Portal | Public hall-pass verification surface that verifies one claimed student situation without exposing broader roster history. | Hall-pass public-facing feature. | both | user | 2 |
 | queue_enabled | Hall-pass configuration toggle that determines whether queued pass requests are used for a class. | Hall-pass settings and teacher controls. | both | both | 21 |
 | queue_limit | Configured maximum number of concurrent or queued hall-pass requests allowed by a class or pass type. | Hall-pass settings and request-time gating. | both | both | 38 |
@@ -136,9 +131,6 @@
 | rent_hall_passes | Legacy/bridge count of hall passes granted from rent rather than purchased, used for top-off behavior. | Rent-linked hall-pass logic. | both | both | 72 |
 | Reset code | Short teacher-visible student recovery code used for identity rebinding without altering economic state. | Student recovery flow. | both | both | 62 |
 | resume PIN | Teacher-recovery resume secret that reconnects a later browser session to DB-persisted partial recovery progress. | Teacher account recovery. | v2 | both | 13 |
-| Reversal Primacy | Obligations rule that a reversal overrides any prior satisfaction history when computing the real status of an assessment. | Obligations invariants and interpretation. | v2 | dev | 2 |
-| Roster Provisioning Contract | Identity rule that roster upload provisions a user shell, class seat, display profile, and claim artifacts without activating credentials. | Student onboarding and seat creation. | v2 | dev | 2 |
-| Scheduled activation infrastructure | Operations-side evidence model for jobs that may trigger lawful policy activation without giving OPS authority over policy truth or timing legality. | OPS ↔ FEAT ↔ economic-governance integration. | v2 | dev | 2 |
 | seat | Class-local participant position and the canonical actor identity for economic/operational activity inside one class universe. | Identity, attendance, ledger, obligations, and store. | v2 | both | 5584 |
 | seat-scoped isolation | Rule that debt, money movement, entitlement usage, attendance facts, and other actor activity stay bound to one seat within one class. | Core v2 authority and domain design. | v2 | dev | 4 |
 | seat_attendance_state | Per-seat mutable attendance gate row used for tap enablement and done-for-day locking. | Attendance domain. | v2 | dev | 53 |
@@ -146,25 +138,21 @@
 | seats.public_id | UUID-encoded deidentified public actor identifier used in class-scoped participant navigation and sysadmin-safe references. | Identity, support, and scoped routing. | v2 | both | 35 |
 | section | Canonical metadata field for class-period labeling such as Block A or Period 1; useful for display but not authority. | Class identity and teacher-facing UI. | both | both | 629 |
 | share_class_name_with_sysadmin | Explicit teacher-consent flag controlling whether class name/context can be shown during issue escalation. | Support escalation privacy boundary. | v2 | both | 14 |
-| Signed Magnitude | Ledger rule that transaction direction is encoded by sign alone: positive credits and negative debits. | Ledger invariants and money math. | v2 | dev | 2 |
-| Single active session per seat | Attendance invariant that only one active attendance session may exist for a seat at a time. | Attendance concurrency and write-time enforcement. | v2 | dev | 2 |
-| Solvency Preservation Principle | Economic principle requiring system-recommended settings to keep ordinary fully-attending students financially viable. | Economy governance. | both | both | 2 |
 | Spendable Balance | The authoritative sum of posted ledger transactions for a seat/account context and the balance truth other domains query for solvency decisions. | Ledger derived state. | v2 | both | 6 |
 | Sticky Context | The last-active class/seat restoration mechanism used to keep users in the correct class context across sessions and devices. | Identity session handling. | v2 | both | 5 |
 | store_item_visibility | Seat-scoped visibility mapping that limits which seats may see a store item; absence of rows means visible to all class seats. | Store catalog scoping. | v2 | dev | 18 |
 | store_items | Store-owned catalog rows describing price, item behavior, inventory, collective-goal settings, and rent-link flags. | Store domain. | both | both | 237 |
 | Structural Interpretation | Interpretation axis that evaluates class configuration and economy health relative to the modeled system structure and CWI. | Interpretation/analytics meaning layer. | v2 | both | 4 |
-| Structured Operational Log | JSON log record with indexed trace fields such as timestamp, correlation_id, domain, and level separated from payload. | Operations observability. | v2 | dev | 2 |
 | Student Seat | Seat whose role is student and which acts as the earning/spending/claiming actor inside a class. | Identity and classroom economy participation. | v2 | both | 47 |
-| student-assisted recovery | Teacher-recovery pattern in which one student per active class helps verify the teacher’s identity by providing generated recovery codes. | Teacher account recovery. | v2 | both | 3 |
+| student-assisted recovery | Teacher-recovery pattern in which one student per active class helps verify the teacher's identity by providing generated recovery codes. | Teacher account recovery. | v2 | both | 3 |
 | student_items | Store-held purchased or granted entitlements attached to a seat, including status, expiry, bundle, and use counters. | Store domain. | both | both | 151 |
 | student_recovery_codes | Teacher-recovery rows storing hashed six-digit codes contributed by verifying student seats. | Teacher account recovery. | v2 | dev | 39 |
-| StudentBlock | Legacy v1 student-in-class object that carried class-local state such as passes or done-for-day markers before the seat-based v2 model. | v1 identity and attendance architecture. | v1 | dev | 253 |
-| System Health Metrics | Always-visible analytics metrics representing the classroom economy’s heartbeat, such as participation rate or money velocity. | Analytics feature. | both | both | 19 |
+| StudentBlock | Per-student per-class state record carrying tap_enabled, done_for_day_date, and rent_hall_passes. Still actively used in routes; v2 aspires to replace with seat_attendance_state and canonical seat-scoped tables. | Identity, attendance, and per-class student state. | both | dev | 253 |
+| System Health Metrics | Always-visible analytics metrics representing the classroom economy's heartbeat, such as participation rate or money velocity. | Analytics feature. | both | both | 19 |
 | tap_enabled | Teacher-controlled per-seat flag that allows or blocks future tap accumulation without erasing prior session history. | Attendance gate state. | both | both | 92 |
-| tap_events | Legacy v1 attendance event table superseded conceptually by attendance_sessions in the canonical v2 schema. | v1 attendance implementation and migration bridge. | v1 | dev | 179 |
+| tap_events | Legacy v1 attendance event table; coexists with attendance_sessions in a dual-write transition. New writes target attendance_sessions; tap_events still read for analytics and soft-deletion. | Attendance implementation and migration bridge. | both | dev | 179 |
 | Teacher Seat | Seat whose role is teacher and which owns class-scoped operational authority within one class universe. | Identity and teacher-side class administration. | v2 | both | 33 |
-| teacher_blocks | Legacy v1 table/model for teacher-to-block relationships superseded by seat/class ownership in v2. | v1 identity and class-scoping architecture. | v1 | dev | 258 |
+| teacher_blocks | Legacy v1 table for teacher-to-block relationships; Python model removed from models.py but still referenced in a few legacy code paths. | v1 identity and class-scoping architecture. | v1 | dev | 258 |
 | teacher_public_id | Legacy canonical public teacher identifier used for public flows before the unified seat public-ID direction. | v1 teacher identity and public verification. | v1 | both | 133 |
 | teacher_public_token | Public, non-enumerable verification token used for hall-pass verification portals. | Public hall-pass verification. | both | both | 23 |
 | TemporalContext | Immutable per-request object carrying UTC timestamp, class timezone, and derived class-local time as the only approved execution-time temporal truth. | Temporal architecture and future rebuild model. | v2 | dev | 20 |
@@ -179,6 +167,72 @@
 | users | Canonical global identity table that owns authentication, recovery, session security, and role law. | Identity domain and cross-class human identity. | v2 | dev | 535 |
 | visible future economic law | The disclosure principle that pending policy state must be visible to affected teachers, students, and operational domains. | Economic policy visibility. | v2 | both | 5 |
 | Waiver-Aware Paid Status | Rule that a rent coverage period counts as paid either by sufficient payment or by an active waiver that covers the due date. | Rent/obligation behavior. | v1 | both | 2 |
-| Withdrawal Participation | Banking rule that withdrawals reduce future eligible balance so interest is not paid on funds no longer represented in authoritative balance. | Banking eligibility. | v2 | both | 2 |
-| Zero-Cost Perk | Rent-linked store purchase that resolves at zero price when the seat already has the qualifying obligation-linked benefit. | Rent/store integration. | v1 | both | 1 |
-| Zero-Sum Transfers | Ledger invariant requiring all transactions in one correlated transfer group to net to zero atomically. | Ledger integrity and transfer orchestration. | v2 | dev | 2 |
+
+---
+
+## Removal Candidates
+
+Terms removed from the main table or flagged for removal, with justification.
+
+### Removed: One-off doc-only terms (≤1 occurrence outside this audit, no codebase presence)
+
+These terms appear in exactly one spec paragraph and function as inline explanations, not reusable vocabulary. They add noise to the glossary without aiding cross-document comprehension.
+
+| Term | Occurrences | Justification |
+|---|---|---|
+| Account Lifecycle Map | 1 | One-off narrative label in identity onboarding doc; not referenced elsewhere |
+| Aggregate Analytics Principle | 1 | Stated once as a design philosophy; the rule is self-evident from context |
+| ConsumptionIntent | 1 | Speculative v2 concept mentioned once; no model or code exists |
+| Context-First Execution | 1 | Restates the FEAT resolution contract; redundant with FEAT definition |
+| Domain Law | 1 | Informal shorthand used once; the authority model is described by DOM-CORE-001 |
+| Event-Log Fallback | 1 | Single mention describing ledger recovery; covered by ledger_balance_snapshot definition |
+| Hidden Deferred Mutation | 1 | Named anti-pattern mentioned once; the prohibition is covered by append-only policy evolution |
+| PeriodKey | 1 | Single mention in obligations spec; an implementation detail, not a glossary term |
+| Reversal Primacy | 1 | Single mention in obligations invariants; the rule is covered by obligation_reversal |
+| Roster Provisioning Contract | 1 | Single mention; the concept is covered by Claim Lifecycle and Unclaimed seat |
+| Signed Magnitude | 1 | Single mention describing ledger sign convention; self-evident from ledger_transaction |
+| Single active session per seat | 1 | Single invariant statement; covered by seat_attendance_state and attendance_sessions |
+| Solvency Preservation Principle | 1 | Single mention; the concept is operationalized as Budget Survival Test |
+| Zero-Sum Transfers | 1 | Single mention; a standard ledger property, not domain-specific vocabulary |
+| Generic Placeholder | 1 | Single mention; subsumed by Unclaimed seat |
+| Claim-Based Model | 1 | Single mention describing verification approach; covered by Public Verification Portal |
+| Interpretation Snapshot | 1 | Single mention; a cache row, not a concept needing glossary status |
+| drift indicators | 1 | Single mention; a vague output category, not a precise term |
+| pending slice | 1 | Single mention; an implementation detail of settlement |
+| Attendance Event Log | 2 | Conceptual label for what attendance_sessions already describes |
+| Diagnostic Drill-Down Metrics | 2 | A UX pattern, not a term; self-explanatory from context |
+| Class Drift | 2 | Informal name for a session-restoration problem; covered by Sticky Context |
+| Drift & Anomaly Metrics | 3 | A category label, not a precise term; covered by System Health Metrics |
+| Behavioral Interpretation | 3 | One of two interpretation axes; useful only if Structural Interpretation stays (see below) |
+
+### Removed: Zero occurrences outside this audit
+
+| Term | Justification |
+|---|---|
+| class-scoped isolation | 0 occurrences; the concept is fully expressed by class universe and class_id |
+| obligation-linked entitlements | 0 occurrences; described inline wherever entitlement_events is used |
+| Liveness / Readiness / Correctness | 0 occurrences; a standard ops taxonomy, not project-specific vocabulary |
+| Zero-Cost Perk | 0 occurrences; a one-off store behavior, not a reusable term |
+| Withdrawal Participation | 2 occurrences but purely a banking eligibility sub-rule; an implementation detail |
+
+### Kept but flagged for consolidation
+
+| Term | Suggestion |
+|---|---|
+| Structural Interpretation / Behavioral Interpretation | Consider merging into a single "Interpretation Axes" entry |
+| Core Orchestrator / Domain Guard | Could be folded into the FEAT entry as sub-patterns rather than standalone terms |
+| Operational Truth / Operational Provenance | Consider merging into a single "Operations domain semantics" entry |
+| Posted Balance Snapshot / Spendable Balance / Eligible Savings Balance | Three related balance concepts that could consolidate under a "Balance taxonomy" entry |
+| Event-Log Authority | Near-duplicate of append-only policy evolution; consider merging |
+| Idempotency Lock | Subsumed by idempotency_key; consider merging |
+| Scheduled activation infrastructure | Only 7 occurrences; borderline — keep if OPS↔FEAT boundary docs grow |
+| Axis Exclusivity | Only 2 occurrences; borderline — only meaningful if interpretation axes are retained |
+
+---
+
+## Term Count
+
+- **Original inventory:** 177 terms
+- **Removed (one-off / zero-occurrence / implementation detail):** 30 terms
+- **Cleaned table:** 147 terms
+- **Flagged for consolidation:** ~10 terms (potential further reduction to ~140)

--- a/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
+++ b/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
@@ -3,182 +3,182 @@
 > Part 1 of the documentation audit. Inventory only; no rewriting.
 > Date: 2026-06-15
 
-| Term | Definition | Usage/Context | Version | Facing |
-|---|---|---|---|---|
-| Account Lifecycle Map | The non-normative human-story map of teacher and student identity progression from provisioning through operation and recovery. | Identity onboarding and developer orientation. | v2 | dev |
-| account_balances | Planned v2 per-account checkpoint/cache table keyed by class, seat, and account type for available/current balance tracking. | Future banking/ledger rebuild design. | v2 | dev |
-| Accrual Frequency | How often savings interest is earned (daily, weekly, monthly), distinct from compounding and payout timing. | Banking policy and execution scheduling. | v2 | both |
-| Accrued Interest | Interest earned but not yet posted into spendable savings; it exists as intermediate banking state until payout. | Banking domain accrual and payout model. | v2 | both |
-| Activation Intent | The abstract timing mode attached to a policy transition that says whether a change is immediate, at the next lawful boundary, or manual. | Economic policy governance and disclosure. | v2 | both |
-| actor_public_id | Support-facing copy of a seat public ID used in sysadmin views so support workflows do not expose raw seat/student identifiers. | Support tickets, correlation packs, escalation views. | v2 | dev |
-| Aggregate Analytics Principle | Rule that analytics should describe class-level ecosystem health and drift, not rank or surveil individual students. | Economy analytics philosophy. | both | both |
-| Alignment Status | Teacher-facing indication of whether live class settings align with the selected economy policy mode and recommendations. | Economy Health and rebalance workflow. | v1 | both |
-| AnalyticsAlert | Legacy/sysadmin alert object raised from analytics snapshots when a class economy crosses health thresholds. | v1 sysadmin observability and alerting. | v1 | dev |
-| AnalyticsSnapshot | Immutable aggregate class-health snapshot captured for analytics and sysadmin alerting without exposing individual student data. | Analytics, alerting, and legacy sysadmin monitoring. | both | dev |
-| anonymous_code | HMAC-derived opaque reference displayed for free-form user reports instead of raw identity. | Support/user report workflow. | v2 | dev |
-| append-only policy evolution | Core economic governance rule that policy changes are represented as new transition lineage, never in-place mutation of active truth. | Economic policy governance and migration away from hidden delayed mutation. | v2 | dev |
-| Attendance Event Log | Conceptual append-only timeline formed by attendance sessions and hall-pass events as the authoritative attendance fact history. | Attendance domain model. | v2 | dev |
-| attendance_sessions | Canonical v2 table for tap-in/tap-out attendance facts; the successor to legacy tap_events. | Attendance tracking, payroll inputs, and temporal rules. | v2 | both |
-| Audit Event | High-integrity append-only record for security-sensitive, identity-sensitive, and money-moving side effects. | Operations domain audit trail. | v2 | dev |
-| audit_log | Operations-owned audit table that stores structured before/after records for sensitive side effects and FEAT execution traces. | Audit lineage and operational compliance. | v2 | dev |
-| available_balance | Operational balance that includes posted balance plus pending delta and is used for real-time reads and preconditions. | Ledger reads, banking UI, overdraft checks, and settlement contract. | both | both |
-| Axis Exclusivity | Interpretation rule that every metric belongs to exactly one axis—behavioral or structural—and must not blend them into one authority path. | Interpretation domain invariants. | v2 | dev |
-| balance_cache | Legacy balance cache term for the derived money cache used before the canonical ledger_balance_snapshot/account-balance direction. | v1/v1.5 ledger implementation and migration bridge. | v1 | dev |
-| Behavioral Interpretation | Interpretation axis that explains how seats behave over completed payroll cycles using domain event logs. | Interpretation/analytics meaning layer. | v2 | both |
-| block | Legacy label used for periods/sections and sometimes policy scope; v2 treats it as metadata only and forbids label-based authority. | v1 scoping model and v2 prohibition boundary. | both | both |
-| Budget Survival Test | Canonical solvency check asking whether students can still preserve a minimum weekly savings buffer after recurring costs. | Economy governance, validation, and analytics. | both | both |
-| Canonical class time | The class-local notion of current time derived from UTC plus the class timezone and used for all behavioral evaluation. | Temporal architecture and class-scoped execution. | v2 | dev |
-| Catastrophe Stability rule | Economy solvency rule testing whether a student can recover within roughly one cycle from a pair of shocks such as fines or loss. | Economic policy validation and recommendations. | both | both |
-| claim artifacts | Seat-owned verification artifacts used to prove entitlement to a rostered participant position during the claim flow. | Student seat claim and roster provisioning. | v2 | dev |
-| Claim Lifecycle | Identity flow that binds a global user to a class-local seat after verifying class-specific claim artifacts. | Identity onboarding and seat binding. | v2 | both |
-| Claim-Based Model | Public hall-pass verification model that only answers a specific student claim instead of exposing a roster or pass list. | Public hall-pass verification portal. | both | both |
-| class day | The canonical classroom day boundary defined as midnight-to-midnight in class timezone, then converted to UTC query bounds. | Temporal architecture, attendance, and daily limits. | v2 | dev |
-| Class Drift | Identity/context problem where a session restores or remains in the wrong class; sticky-context rules exist to prevent it. | Identity session restoration. | v2 | both |
-| class timezone | Immutable IANA timezone owned by the class and used to evaluate days, periods, due dates, accrual windows, and attendance boundaries. | Temporal model, interpretation, obligations, and banking. | v2 | both |
-| class universe | The isolated classroom-economy boundary represented canonically by class_id and operationalized through class-local seats. | Identity architecture and scoping law. | v2 | both |
-| class-scoped isolation | Rule that all class activity, records, and permissions remain within one resolved class boundary with no cross-class leakage. | Core invariants, request context, and domain ownership. | both | both |
-| class_economies | Legacy v1 class container model that held class identity and join code before the canonical classes/class_id v2 model. | v1 architecture and migration references. | v1 | dev |
-| class_features | Class Configuration table whose row existence per feature acts as authoritative feature enablement for a class. | Feature enablement and class policy surfaces. | v2 | dev |
-| class_id | Canonical private class-universe identifier and internal scoping boundary for all authority-sensitive v2 behavior. | Identity, policy, ledger, attendance, and isolation invariants. | both | both |
-| ClassEconomy | Legacy v1 private tenant container for a classroom economy, paired with a public join code. | v1 multi-tenancy and class identity model. | v1 | dev |
-| classes | Canonical v2 class-anchor table that defines the universe boundary and carries join code token, display name, and section metadata. | Identity and all class-wide configuration references. | v2 | dev |
-| ClassMembership | Legacy membership/bridge record linking a person to a class; v2 replaces this with seat existence as membership truth. | v1 identity and scoping model, plus migration discussions. | v1 | dev |
-| Classroom Token Hub (CTH) | The classroom economy platform whose documentation uses CTH/ Classroom Token Hub as the canonical product name. | Cross-document product identity. | both | both |
-| Classroom Wage Index (CWI) | Expected weekly income for perfect attendance; the baseline economic unit that all recommended pricing and solvency ratios are measured against. | Economy governance, analytics, policy modes, and recommendations. | both | both |
-| Collective Goal | A shared class objective or store-goal construct priced relative to CWI to encourage coordinated saving and participation. | Economy design, store catalog, and analytics. | both | both |
-| collective_goal_instance_code | Instance key that groups one or more collective-goal store items into the same progress bucket. | Store catalog and collective-goal tracking. | both | dev |
-| comfortable | The most generous policy mode, intended to lower pressure and accelerate progression relative to CWI. | Economy governance and teacher policy selection. | both | both |
-| Compound Frequency | How often accrued interest joins the future earning base; distinct from earning frequency and payout frequency. | Banking policy and accrual math. | v2 | both |
-| Compound Participation | The rule deciding whether accrued-but-unpaid interest is allowed to participate in future accrual calculations. | Banking domain semantics. | v2 | both |
-| ConsumptionIntent | Attendance-originated trigger concept for using an obligation-linked entitlement such as a rent-granted hall pass. | Attendance-to-Obligations coordination. | v2 | dev |
-| Context-First Execution | FEAT rule that a user, seat, and class context must be resolved before any domain interaction or mutation occurs. | Feature execution contract. | v2 | dev |
-| Core Orchestrator | A FEAT designated as a reusable high-integrity orchestration unit, especially for money posting/voiding and similar cross-domain actions. | Feature-execution architecture. | v2 | dev |
-| correlation pack | Immutable support snapshot that captures request-trace and error context at issue submission time. | Support diagnostics and escalation. | v2 | dev |
-| correlation_id | System-wide workflow identifier propagated across requests, FEATs, reversals, audits, jobs, and incidents to preserve causality. | Operations, ledger, FEAT, and support tracing. | both | both |
-| current_balance | Authoritative posted-only account balance used after settlement and reconciliation, distinct from available balance. | Banking/ledger settlement model. | both | both |
-| current_session_nonce | Per-login nonce stored on users that binds all requests to one current session and invalidates older sessions on next sign-in. | Identity session security. | v2 | dev |
-| default | The balanced middle policy mode used as the baseline classroom economy climate. | Economy governance and teacher settings. | both | both |
-| Diagnostic Drill-Down Metrics | Analytics metrics revealed only after interaction so a teacher can inspect context without making student ranking the default view. | Analytics and interpretation UX. | both | both |
-| display_name | Human-facing class title metadata, normally paired with section for teacher-facing class display. | Identity/class metadata and UI labels. | both | both |
-| Distributed trust | Teacher-recovery principle requiring one verifying student per active class so no single student can recover a teacher account alone. | Teacher account recovery. | v2 | both |
-| Domain Blindness | Ledger rule that money rows record operational provenance but not business meaning such as rent or store semantics. | Ledger domain architecture. | v2 | dev |
-| Domain Guard | Standardized read-only domain check that returns allowed/reason/metadata for FEAT orchestration instead of mutating or throwing business errors. | Capability and FEAT interaction pattern. | v2 | dev |
-| Domain Law | Shorthand for the codified domain authority model that says each domain owns one bounded truth and mutation boundary. | V2 restructuring and authority summary. | v2 | dev |
-| done_for_day_date | Per-seat attendance lock date used for O(1) gating; if it disagrees with the event log, attendance history remains authoritative. | Attendance state and daily lock behavior. | both | both |
-| Drift & Anomaly Metrics | Trend-oriented analytics that surface divergence from expected classroom-economy behavior instead of reporting totals alone. | Analytics and interpretation surfaces. | both | both |
-| drift indicators | Derived interpretation outputs that flag comparative movement away from expected system behavior over time. | Interpretation domain state classification. | v2 | dev |
-| Economy Balance Checker | Shared recommendation/validation engine that checks whether a class economy fits policy-mode guidance and solvency expectations. | Economy Health, rebalance preview, and recommendation APIs. | v1 | both |
-| Economy Health | Teacher-facing surface for policy mode, alignment review, recommendation visibility, and rebalance actions. | Economy feature/UI. | v1 | both |
-| economy_pending_rebalance_json | Deprecated compatibility field that stored delayed rebalance payloads before append-only policy transitions became the constitutional model. | Migration bridge from v1 delayed mutation to v2 governance. | both | dev |
-| economy_policy_alignment_status | Stored teacher-facing result showing whether current settings are aligned or misaligned with policy guidance. | Legacy feature_settings economy mode support. | v1 | both |
-| economy_policy_mode | Stored policy climate selector (tight/default/comfortable); in v2 it is an operational projection rather than independent constitutional truth. | Class configuration and economy UI. | both | both |
-| Eligible Savings Balance | The authoritative posted balance slice that actually qualifies to earn interest in a given accrual period. | Banking accrual rules and projections. | v2 | both |
-| Entitlement Balance | Derived count/value of obligation-linked perks; it is computed from events and is never stored as authoritative state. | Obligations and entitlement usage. | v2 | both |
-| entitlement_events | Append-only event stream for obligation-linked grants, consumption, and revocations such as rent-linked hall-pass quota. | Obligations domain. | v2 | dev |
-| Event-Log Authority | V2 rule that authoritative truth comes from immutable event records or explicit projections derived from them. | Core schema and domain summary. | v2 | dev |
-| Event-Log Fallback | Ledger rule that the posted transaction log can always recompute the spendable-balance cache if the cache is missing or inconsistent. | Ledger invariants and recovery behavior. | v2 | dev |
-| FEAT | Atomic feature-execution orchestration unit and the only lawful place for state mutation, money movement, binding, and cross-domain coordination. | Core execution architecture. | v2 | dev |
-| Foundational | Highest documentation authority level for system identity and non-negotiable invariants. | Documentation governance model. | both | dev |
-| Future Economic Law | Pending policy state treated as visible announced law rather than hidden backend configuration. | Economic policy transitions and disclosure. | v2 | both |
-| Generic Placeholder | Teacher-created unclaimed seat waiting for a future student claim/binding. | Roster provisioning and identity lifecycle. | v2 | both |
-| hall pass balance | Combined pass availability model where rent-granted quota is tracked separately from purchased or other pass sources. | Hall-pass and entitlement behavior. | both | both |
-| hall_pass_logs | Attendance-owned lifecycle records for hall-pass requests, approvals, departures, and returns. | Hall-pass execution history. | both | both |
-| hall_pass_settings | Class-owned configuration for queueing, pass types, and simultaneous limits. | Class configuration and hall-pass feature. | both | both |
-| hall_pass_verify_token | Legacy hall-pass public verification token retained only as a compatibility surface; newer docs prefer UUID/public-token patterns. | v1 public hall-pass verification. | both | both |
-| health_check_events | Operations events capturing liveness, readiness, or correctness checks for components and workflows. | Operational health model. | v2 | dev |
-| Hidden Deferred Mutation | Forbidden pattern where future economic changes live only in opaque delayed payloads instead of visible transition lineage. | Economic governance and FEAT compliance. | v2 | dev |
-| Idempotency Lock | Ledger/system guard enforcing uniqueness of write intent at the database level. | Ledger state classification and FEAT retry safety. | v2 | dev |
-| idempotency_key | Unique replay-protection key attached to writes so retries cannot create duplicate effects. | FEAT execution, ledger writes, obligations, and activation flows. | both | both |
-| identity rebinding | Recovery principle that restores credential access on the same identity record without creating or moving economic state. | Student and teacher account recovery. | v2 | both |
-| identity_profiles | Seat-owned display-identity table for encrypted first name and public-facing initials; not an authority or credential table. | Identity display layer. | v2 | dev |
-| incident_events | Append-only lifecycle events describing incident creation, updates, comments, and resolution. | Operations incident management. | v2 | dev |
-| incident_summary | Cache/projection of the current state of an incident, derived from its append-only event history. | Operations and status page surfaces. | v2 | dev |
-| Interest Payout | The lawful posting of accrued interest into a student’s savings balance through FEAT and ledger execution. | Banking domain and payout scheduling. | v2 | both |
-| Interpretation Snapshot | Cached materialization of a computed behavioral or structural metric window for a class. | Interpretation domain performance layer. | v2 | dev |
-| issue_categories | System-managed taxonomy used to classify student support issues. | Support domain. | v2 | both |
-| issue_resolution_actions | Append-only declaration log of support actions such as reversals or waivers, without owning the underlying money effect. | Support domain and FEAT-linked remediation. | v2 | dev |
-| issue_status_history | Append-only audit trail of every support issue status transition. | Support domain lifecycle tracking. | v2 | dev |
-| job_events | Operations event log for scheduled/background work such as invariant runs, activation jobs, retries, and failures. | Operations domain. | v2 | dev |
-| join_code | Human-facing class entry alias that resolves to class_id before any authority-sensitive action; canonical in v1, alias-only in v2. | Student claim, routing, recovery, and class selection. | both | both |
-| last_active_seat_id | Sticky-context pointer on users that restores the last resolved class-local actor context across devices and logins. | Identity session restoration. | v2 | dev |
-| ledger_balance_snapshot | Canonical v2 spendable-balance cache owned by the Ledger domain and re-derivable from posted transactions. | Ledger performance/read model. | v2 | dev |
-| ledger_transaction | Canonical immutable money-movement record used by the Ledger domain. | Ledger authority, FEAT posting, reversals, and audit. | v2 | dev |
-| Liveness / Readiness / Correctness | Three-part health model distinguishing process uptime, dependency availability, and invariant/business correctness. | Operations health semantics. | v2 | dev |
-| Mid-Period Lock | Rule that rent-item type semantics cannot change after a valid payment has occurred in the current coverage period. | Rent-linked perks and rent feature behavior. | v1 | both |
-| money velocity | Core class-level metric describing how quickly currency circulates through the classroom economy. | Analytics and interpretation. | both | both |
-| money_action_cooldown_until | Global rate-limit field on users that gates rapid financial mutations. | Identity security state and money-action safety. | v2 | dev |
-| next_boundary | Activation mode meaning a pending policy should take effect at the next lawful operational boundary rather than immediately. | Economic transition governance. | v2 | both |
-| obligation-linked entitlements | Perks whose grant/consumption is controlled by the Obligations domain because they arise from rent/assessment satisfaction rather than store purchase. | Obligations-store boundary. | v2 | both |
-| obligation_lifecycle | Derived per-assessment state row describing whether an obligation is due, overdue, paid, waived, or reversed. | Obligations domain. | v2 | dev |
-| obligation_reversal | Immutable record that nullifies a prior assessment and forces downstream interpretation to treat the obligation as non-existent. | Obligations corrections. | v2 | dev |
-| obligation_satisfaction | Immutable record of how a debt was resolved, such as payment or waiver. | Obligations domain lifecycle. | v2 | dev |
-| Operational Provenance | Ledger classification idea behind category fields such as SYSTEM/MANUAL/ADJUSTMENT; it records where a transaction came from, not its business meaning. | Ledger domain-blind design. | v2 | dev |
-| Operational Truth | Operations-domain truth about system behavior, health, incidents, jobs, and alerts—not business facts like balances or attendance. | Operations domain definition. | v2 | dev |
-| operational_events | Structured JSON operational logs with indexed trace fields outside the payload blob. | Operations observability. | v2 | dev |
-| passkey | WebAuthn-based passwordless authentication capability owned by users and optionally used by teacher/sysadmin accounts. | Identity and login architecture. | both | both |
-| payroll_fines | Class-owned fine presets that FEAT can translate into deductions but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both |
-| payroll_rewards | Class-owned reward presets that FEAT can translate into payroll credits but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both |
-| pending slice | The eligible subset of pending transactions processed during settlement rather than a full historical ledger rescan. | Banking/ledger settlement design. | v2 | dev |
-| PeriodKey | Deterministic class-calendar/policy-schedule key that creates a one-to-one mapping between a liability period and an assessment. | Obligations idempotency and period logic. | v2 | dev |
-| policy mode | Teacher-selectable economy climate (tight, default, comfortable) that shapes recommended ratios, pacing, and solvency expectations. | Economy governance and classroom configuration. | both | both |
-| policy_transitions | Append-only lineage objects describing source/target policy versions, activation mode, status, and supersession relationships. | Economic governance and class configuration. | v2 | dev |
-| policy_versions | Immutable constitutional policy records representing the active or historical economic truth for a class/domain pair. | Economic governance and class configuration. | v2 | dev |
-| Posted Balance Snapshot | The cached spendable-balance view derived from posted transactions only; authoritative for spending if recomputable from the event log. | Ledger state model. | v2 | dev |
-| Public Verification Portal | Public hall-pass verification surface that verifies one claimed student situation without exposing broader roster history. | Hall-pass public-facing feature. | both | user |
-| queue_enabled | Hall-pass configuration toggle that determines whether queued pass requests are used for a class. | Hall-pass settings and teacher controls. | both | both |
-| queue_limit | Configured maximum number of concurrent or queued hall-pass requests allowed by a class or pass type. | Hall-pass settings and request-time gating. | both | both |
-| recovery_status | Short lifecycle marker used in bridge-era student recovery to represent whether an identity is active or waiting to be reclaimed. | Student account recovery. | both | both |
-| RecoveryRequest | Teacher-recovery state object that tracks one pending/verified/expired recovery session across all represented classes. | Teacher account recovery. | v2 | both |
-| redemption_audit_logs | Store-owned append-only audit rows recording redemption requests and approval/rejection outcomes. | Store entitlement redemption history. | both | dev |
-| redemption_prompt | Teacher-facing prompt text attached to delayed store items to guide redemption handling. | Store catalog behavior. | both | both |
-| Rent Late Fee Reversal | Targeted corrective transaction used when mid-cycle rent changes incorrectly caused late fees under the locked base-rate rule. | Rent corrections and admin remediation. | v1 | both |
-| rent-linked store item | Store catalog item that is a store-facing alias of a rent/obligation-controlled benefit. | Store and obligations integration. | both | both |
-| rent_hall_passes | Legacy/bridge count of hall passes granted from rent rather than purchased, used for top-off behavior. | Rent-linked hall-pass logic. | both | both |
-| Reset code | Short teacher-visible student recovery code used for identity rebinding without altering economic state. | Student recovery flow. | both | both |
-| resume PIN | Teacher-recovery resume secret that reconnects a later browser session to DB-persisted partial recovery progress. | Teacher account recovery. | v2 | both |
-| Reversal Primacy | Obligations rule that a reversal overrides any prior satisfaction history when computing the real status of an assessment. | Obligations invariants and interpretation. | v2 | dev |
-| Roster Provisioning Contract | Identity rule that roster upload provisions a user shell, class seat, display profile, and claim artifacts without activating credentials. | Student onboarding and seat creation. | v2 | dev |
-| Scheduled activation infrastructure | Operations-side evidence model for jobs that may trigger lawful policy activation without giving OPS authority over policy truth or timing legality. | OPS ↔ FEAT ↔ economic-governance integration. | v2 | dev |
-| seat | Class-local participant position and the canonical actor identity for economic/operational activity inside one class universe. | Identity, attendance, ledger, obligations, and store. | v2 | both |
-| seat-scoped isolation | Rule that debt, money movement, entitlement usage, attendance facts, and other actor activity stay bound to one seat within one class. | Core v2 authority and domain design. | v2 | dev |
-| seat_attendance_state | Per-seat mutable attendance gate row used for tap enablement and done-for-day locking. | Attendance domain. | v2 | dev |
-| seat_id | Canonical actor identifier for class-local activity; all economic and operational records hang from it in v2. | Identity, attendance, ledger, obligations, support, and store. | both | both |
-| seats.public_id | UUID-encoded deidentified public actor identifier used in class-scoped participant navigation and sysadmin-safe references. | Identity, support, and scoped routing. | v2 | both |
-| section | Canonical metadata field for class-period labeling such as Block A or Period 1; useful for display but not authority. | Class identity and teacher-facing UI. | both | both |
-| share_class_name_with_sysadmin | Explicit teacher-consent flag controlling whether class name/context can be shown during issue escalation. | Support escalation privacy boundary. | v2 | both |
-| Signed Magnitude | Ledger rule that transaction direction is encoded by sign alone: positive credits and negative debits. | Ledger invariants and money math. | v2 | dev |
-| Single active session per seat | Attendance invariant that only one active attendance session may exist for a seat at a time. | Attendance concurrency and write-time enforcement. | v2 | dev |
-| Solvency Preservation Principle | Economic principle requiring system-recommended settings to keep ordinary fully-attending students financially viable. | Economy governance. | both | both |
-| Spendable Balance | The authoritative sum of posted ledger transactions for a seat/account context and the balance truth other domains query for solvency decisions. | Ledger derived state. | v2 | both |
-| Sticky Context | The last-active class/seat restoration mechanism used to keep users in the correct class context across sessions and devices. | Identity session handling. | v2 | both |
-| store_item_visibility | Seat-scoped visibility mapping that limits which seats may see a store item; absence of rows means visible to all class seats. | Store catalog scoping. | v2 | dev |
-| store_items | Store-owned catalog rows describing price, item behavior, inventory, collective-goal settings, and rent-link flags. | Store domain. | both | both |
-| Structural Interpretation | Interpretation axis that evaluates class configuration and economy health relative to the modeled system structure and CWI. | Interpretation/analytics meaning layer. | v2 | both |
-| Structured Operational Log | JSON log record with indexed trace fields such as timestamp, correlation_id, domain, and level separated from payload. | Operations observability. | v2 | dev |
-| Student Seat | Seat whose role is student and which acts as the earning/spending/claiming actor inside a class. | Identity and classroom economy participation. | v2 | both |
-| student-assisted recovery | Teacher-recovery pattern in which one student per active class helps verify the teacher’s identity by providing generated recovery codes. | Teacher account recovery. | v2 | both |
-| student_items | Store-held purchased or granted entitlements attached to a seat, including status, expiry, bundle, and use counters. | Store domain. | both | both |
-| student_recovery_codes | Teacher-recovery rows storing hashed six-digit codes contributed by verifying student seats. | Teacher account recovery. | v2 | dev |
-| StudentBlock | Legacy v1 student-in-class object that carried class-local state such as passes or done-for-day markers before the seat-based v2 model. | v1 identity and attendance architecture. | v1 | dev |
-| System Health Metrics | Always-visible analytics metrics representing the classroom economy’s heartbeat, such as participation rate or money velocity. | Analytics feature. | both | both |
-| tap_enabled | Teacher-controlled per-seat flag that allows or blocks future tap accumulation without erasing prior session history. | Attendance gate state. | both | both |
-| tap_events | Legacy v1 attendance event table superseded conceptually by attendance_sessions in the canonical v2 schema. | v1 attendance implementation and migration bridge. | v1 | dev |
-| Teacher Seat | Seat whose role is teacher and which owns class-scoped operational authority within one class universe. | Identity and teacher-side class administration. | v2 | both |
-| teacher_blocks | Legacy v1 table/model for teacher-to-block relationships superseded by seat/class ownership in v2. | v1 identity and class-scoping architecture. | v1 | dev |
-| teacher_public_id | Legacy canonical public teacher identifier used for public flows before the unified seat public-ID direction. | v1 teacher identity and public verification. | v1 | both |
-| teacher_public_token | Public, non-enumerable verification token used for hall-pass verification portals. | Public hall-pass verification. | both | both |
-| TemporalContext | Immutable per-request object carrying UTC timestamp, class timezone, and derived class-local time as the only approved execution-time temporal truth. | Temporal architecture and future rebuild model. | v2 | dev |
-| ticket_correlation_packs | Support-owned immutable 1:1 diagnostic snapshots tying an issue to frozen request traces and error references. | Support diagnostics. | v2 | dev |
-| tight | Most restrictive policy mode emphasizing survival, slower savings growth, and higher economic pressure. | Economy governance and teacher settings. | both | both |
-| Top-Off Logic | Rule for adding only the missing rent-granted portion of hall passes so purchased passes are preserved. | Rent-linked hall-pass benefit behavior. | both | both |
-| Unclaimed seat | Seat provisioned in a class with no bound user_id yet; it exists as a future participant position awaiting claim. | Roster provisioning and student onboarding. | v2 | both |
-| Unified identity model | V2 identity architecture where teachers, students, and sysadmins share users/seats/classes primitives instead of separate role tables. | Identity redesign. | v2 | dev |
-| user_recovery_tokens | Canonical user-owned recovery-token lifecycle rows for v2 recovery authority, distinct from short-lived bridge reset-code fields. | Student and teacher account recovery. | v2 | dev |
-| user_reports | Free-form bug/suggestion/comment records separate from the structured class issue-ticket system. | Support domain. | both | both |
-| username_lookup_hash | Deterministic hashed lookup key used to locate a user during login and recovery without storing plaintext usernames. | Identity and recovery flows. | both | dev |
-| users | Canonical global identity table that owns authentication, recovery, session security, and role law. | Identity domain and cross-class human identity. | v2 | dev |
-| visible future economic law | The disclosure principle that pending policy state must be visible to affected teachers, students, and operational domains. | Economic policy visibility. | v2 | both |
-| Waiver-Aware Paid Status | Rule that a rent coverage period counts as paid either by sufficient payment or by an active waiver that covers the due date. | Rent/obligation behavior. | v1 | both |
-| Withdrawal Participation | Banking rule that withdrawals reduce future eligible balance so interest is not paid on funds no longer represented in authoritative balance. | Banking eligibility. | v2 | both |
-| Zero-Cost Perk | Rent-linked store purchase that resolves at zero price when the seat already has the qualifying obligation-linked benefit. | Rent/store integration. | v1 | both |
-| Zero-Sum Transfers | Ledger invariant requiring all transactions in one correlated transfer group to net to zero atomically. | Ledger integrity and transfer orchestration. | v2 | dev |
+| Term | Definition | Usage/Context | Version | Facing | Frequency |
+|---|---|---|---|---|---|
+| Account Lifecycle Map | The non-normative human-story map of teacher and student identity progression from provisioning through operation and recovery. | Identity onboarding and developer orientation. | v2 | dev | 2 |
+| account_balances | Planned v2 per-account checkpoint/cache table keyed by class, seat, and account type for available/current balance tracking. | Future banking/ledger rebuild design. | v2 | dev | 7 |
+| Accrual Frequency | How often savings interest is earned (daily, weekly, monthly), distinct from compounding and payout timing. | Banking policy and execution scheduling. | v2 | both | 5 |
+| Accrued Interest | Interest earned but not yet posted into spendable savings; it exists as intermediate banking state until payout. | Banking domain accrual and payout model. | v2 | both | 14 |
+| Activation Intent | The abstract timing mode attached to a policy transition that says whether a change is immediate, at the next lawful boundary, or manual. | Economic policy governance and disclosure. | v2 | both | 14 |
+| actor_public_id | Support-facing copy of a seat public ID used in sysadmin views so support workflows do not expose raw seat/student identifiers. | Support tickets, correlation packs, escalation views. | v2 | dev | 150 |
+| Aggregate Analytics Principle | Rule that analytics should describe class-level ecosystem health and drift, not rank or surveil individual students. | Economy analytics philosophy. | both | both | 2 |
+| Alignment Status | Teacher-facing indication of whether live class settings align with the selected economy policy mode and recommendations. | Economy Health and rebalance workflow. | v1 | both | 3 |
+| AnalyticsAlert | Legacy/sysadmin alert object raised from analytics snapshots when a class economy crosses health thresholds. | v1 sysadmin observability and alerting. | v1 | dev | 57 |
+| AnalyticsSnapshot | Immutable aggregate class-health snapshot captured for analytics and sysadmin alerting without exposing individual student data. | Analytics, alerting, and legacy sysadmin monitoring. | both | dev | 55 |
+| anonymous_code | HMAC-derived opaque reference displayed for free-form user reports instead of raw identity. | Support/user report workflow. | v2 | dev | 23 |
+| append-only policy evolution | Core economic governance rule that policy changes are represented as new transition lineage, never in-place mutation of active truth. | Economic policy governance and migration away from hidden delayed mutation. | v2 | dev | 2 |
+| Attendance Event Log | Conceptual append-only timeline formed by attendance sessions and hall-pass events as the authoritative attendance fact history. | Attendance domain model. | v2 | dev | 2 |
+| attendance_sessions | Canonical v2 table for tap-in/tap-out attendance facts; the successor to legacy tap_events. | Attendance tracking, payroll inputs, and temporal rules. | v2 | both | 66 |
+| Audit Event | High-integrity append-only record for security-sensitive, identity-sensitive, and money-moving side effects. | Operations domain audit trail. | v2 | dev | 14 |
+| audit_log | Operations-owned audit table that stores structured before/after records for sensitive side effects and FEAT execution traces. | Audit lineage and operational compliance. | v2 | dev | 115 |
+| available_balance | Operational balance that includes posted balance plus pending delta and is used for real-time reads and preconditions. | Ledger reads, banking UI, overdraft checks, and settlement contract. | both | both | 43 |
+| Axis Exclusivity | Interpretation rule that every metric belongs to exactly one axis—behavioral or structural—and must not blend them into one authority path. | Interpretation domain invariants. | v2 | dev | 3 |
+| balance_cache | Legacy balance cache term for the derived money cache used before the canonical ledger_balance_snapshot/account-balance direction. | v1/v1.5 ledger implementation and migration bridge. | v1 | dev | 114 |
+| Behavioral Interpretation | Interpretation axis that explains how seats behave over completed payroll cycles using domain event logs. | Interpretation/analytics meaning layer. | v2 | both | 3 |
+| block | Legacy label used for periods/sections and sometimes policy scope; v2 treats it as metadata only and forbids label-based authority. | v1 scoping model and v2 prohibition boundary. | both | both | 8250 |
+| Budget Survival Test | Canonical solvency check asking whether students can still preserve a minimum weekly savings buffer after recurring costs. | Economy governance, validation, and analytics. | both | both | 19 |
+| Canonical class time | The class-local notion of current time derived from UTC plus the class timezone and used for all behavioral evaluation. | Temporal architecture and class-scoped execution. | v2 | dev | 6 |
+| Catastrophe Stability rule | Economy solvency rule testing whether a student can recover within roughly one cycle from a pair of shocks such as fines or loss. | Economic policy validation and recommendations. | both | both | 3 |
+| claim artifacts | Seat-owned verification artifacts used to prove entitlement to a rostered participant position during the claim flow. | Student seat claim and roster provisioning. | v2 | dev | 13 |
+| Claim Lifecycle | Identity flow that binds a global user to a class-local seat after verifying class-specific claim artifacts. | Identity onboarding and seat binding. | v2 | both | 6 |
+| Claim-Based Model | Public hall-pass verification model that only answers a specific student claim instead of exposing a roster or pass list. | Public hall-pass verification portal. | both | both | 2 |
+| class day | The canonical classroom day boundary defined as midnight-to-midnight in class timezone, then converted to UTC query bounds. | Temporal architecture, attendance, and daily limits. | v2 | dev | 4 |
+| Class Drift | Identity/context problem where a session restores or remains in the wrong class; sticky-context rules exist to prevent it. | Identity session restoration. | v2 | both | 2 |
+| class timezone | Immutable IANA timezone owned by the class and used to evaluate days, periods, due dates, accrual windows, and attendance boundaries. | Temporal model, interpretation, obligations, and banking. | v2 | both | 33 |
+| class universe | The isolated classroom-economy boundary represented canonically by class_id and operationalized through class-local seats. | Identity architecture and scoping law. | v2 | both | 33 |
+| class-scoped isolation | Rule that all class activity, records, and permissions remain within one resolved class boundary with no cross-class leakage. | Core invariants, request context, and domain ownership. | both | both | 1 |
+| class_economies | Legacy v1 class container model that held class identity and join code before the canonical classes/class_id v2 model. | v1 architecture and migration references. | v1 | dev | 420 |
+| class_features | Class Configuration table whose row existence per feature acts as authoritative feature enablement for a class. | Feature enablement and class policy surfaces. | v2 | dev | 56 |
+| class_id | Canonical private class-universe identifier and internal scoping boundary for all authority-sensitive v2 behavior. | Identity, policy, ledger, attendance, and isolation invariants. | both | both | 7791 |
+| ClassEconomy | Legacy v1 private tenant container for a classroom economy, paired with a public join code. | v1 multi-tenancy and class identity model. | v1 | dev | 887 |
+| classes | Canonical v2 class-anchor table that defines the universe boundary and carries join code token, display name, and section metadata. | Identity and all class-wide configuration references. | v2 | dev | 840 |
+| ClassMembership | Legacy membership/bridge record linking a person to a class; v2 replaces this with seat existence as membership truth. | v1 identity and scoping model, plus migration discussions. | v1 | dev | 269 |
+| Classroom Token Hub (CTH) | The classroom economy platform whose documentation uses CTH/ Classroom Token Hub as the canonical product name. | Cross-document product identity. | both | both | 11 |
+| Classroom Wage Index (CWI) | Expected weekly income for perfect attendance; the baseline economic unit that all recommended pricing and solvency ratios are measured against. | Economy governance, analytics, policy modes, and recommendations. | both | both | 16 |
+| Collective Goal | A shared class objective or store-goal construct priced relative to CWI to encourage coordinated saving and participation. | Economy design, store catalog, and analytics. | both | both | 115 |
+| collective_goal_instance_code | Instance key that groups one or more collective-goal store items into the same progress bucket. | Store catalog and collective-goal tracking. | both | dev | 95 |
+| comfortable | The most generous policy mode, intended to lower pressure and accelerate progression relative to CWI. | Economy governance and teacher policy selection. | both | both | 49 |
+| Compound Frequency | How often accrued interest joins the future earning base; distinct from earning frequency and payout frequency. | Banking policy and accrual math. | v2 | both | 10 |
+| Compound Participation | The rule deciding whether accrued-but-unpaid interest is allowed to participate in future accrual calculations. | Banking domain semantics. | v2 | both | 4 |
+| ConsumptionIntent | Attendance-originated trigger concept for using an obligation-linked entitlement such as a rent-granted hall pass. | Attendance-to-Obligations coordination. | v2 | dev | 2 |
+| Context-First Execution | FEAT rule that a user, seat, and class context must be resolved before any domain interaction or mutation occurs. | Feature execution contract. | v2 | dev | 2 |
+| Core Orchestrator | A FEAT designated as a reusable high-integrity orchestration unit, especially for money posting/voiding and similar cross-domain actions. | Feature-execution architecture. | v2 | dev | 4 |
+| correlation pack | Immutable support snapshot that captures request-trace and error context at issue submission time. | Support diagnostics and escalation. | v2 | dev | 13 |
+| correlation_id | System-wide workflow identifier propagated across requests, FEATs, reversals, audits, jobs, and incidents to preserve causality. | Operations, ledger, FEAT, and support tracing. | both | both | 1048 |
+| current_balance | Authoritative posted-only account balance used after settlement and reconciliation, distinct from available balance. | Banking/ledger settlement model. | both | both | 42 |
+| current_session_nonce | Per-login nonce stored on users that binds all requests to one current session and invalidates older sessions on next sign-in. | Identity session security. | v2 | dev | 20 |
+| default | The balanced middle policy mode used as the baseline classroom economy climate. | Economy governance and teacher settings. | both | both | 1456 |
+| Diagnostic Drill-Down Metrics | Analytics metrics revealed only after interaction so a teacher can inspect context without making student ranking the default view. | Analytics and interpretation UX. | both | both | 2 |
+| display_name | Human-facing class title metadata, normally paired with section for teacher-facing class display. | Identity/class metadata and UI labels. | both | both | 394 |
+| Distributed trust | Teacher-recovery principle requiring one verifying student per active class so no single student can recover a teacher account alone. | Teacher account recovery. | v2 | both | 4 |
+| Domain Blindness | Ledger rule that money rows record operational provenance but not business meaning such as rent or store semantics. | Ledger domain architecture. | v2 | dev | 6 |
+| Domain Guard | Standardized read-only domain check that returns allowed/reason/metadata for FEAT orchestration instead of mutating or throwing business errors. | Capability and FEAT interaction pattern. | v2 | dev | 5 |
+| Domain Law | Shorthand for the codified domain authority model that says each domain owns one bounded truth and mutation boundary. | V2 restructuring and authority summary. | v2 | dev | 2 |
+| done_for_day_date | Per-seat attendance lock date used for O(1) gating; if it disagrees with the event log, attendance history remains authoritative. | Attendance state and daily lock behavior. | both | both | 68 |
+| Drift & Anomaly Metrics | Trend-oriented analytics that surface divergence from expected classroom-economy behavior instead of reporting totals alone. | Analytics and interpretation surfaces. | both | both | 3 |
+| drift indicators | Derived interpretation outputs that flag comparative movement away from expected system behavior over time. | Interpretation domain state classification. | v2 | dev | 2 |
+| Economy Balance Checker | Shared recommendation/validation engine that checks whether a class economy fits policy-mode guidance and solvency expectations. | Economy Health, rebalance preview, and recommendation APIs. | v1 | both | 11 |
+| Economy Health | Teacher-facing surface for policy mode, alignment review, recommendation visibility, and rebalance actions. | Economy feature/UI. | v1 | both | 62 |
+| economy_pending_rebalance_json | Deprecated compatibility field that stored delayed rebalance payloads before append-only policy transitions became the constitutional model. | Migration bridge from v1 delayed mutation to v2 governance. | both | dev | 24 |
+| economy_policy_alignment_status | Stored teacher-facing result showing whether current settings are aligned or misaligned with policy guidance. | Legacy feature_settings economy mode support. | v1 | both | 7 |
+| economy_policy_mode | Stored policy climate selector (tight/default/comfortable); in v2 it is an operational projection rather than independent constitutional truth. | Class configuration and economy UI. | both | both | 129 |
+| Eligible Savings Balance | The authoritative posted balance slice that actually qualifies to earn interest in a given accrual period. | Banking accrual rules and projections. | v2 | both | 2 |
+| Entitlement Balance | Derived count/value of obligation-linked perks; it is computed from events and is never stored as authoritative state. | Obligations and entitlement usage. | v2 | both | 5 |
+| entitlement_events | Append-only event stream for obligation-linked grants, consumption, and revocations such as rent-linked hall-pass quota. | Obligations domain. | v2 | dev | 50 |
+| Event-Log Authority | V2 rule that authoritative truth comes from immutable event records or explicit projections derived from them. | Core schema and domain summary. | v2 | dev | 4 |
+| Event-Log Fallback | Ledger rule that the posted transaction log can always recompute the spendable-balance cache if the cache is missing or inconsistent. | Ledger invariants and recovery behavior. | v2 | dev | 2 |
+| FEAT | Atomic feature-execution orchestration unit and the only lawful place for state mutation, money movement, binding, and cross-domain coordination. | Core execution architecture. | v2 | dev | 9200 |
+| Foundational | Highest documentation authority level for system identity and non-negotiable invariants. | Documentation governance model. | both | dev | 93 |
+| Future Economic Law | Pending policy state treated as visible announced law rather than hidden backend configuration. | Economic policy transitions and disclosure. | v2 | both | 19 |
+| Generic Placeholder | Teacher-created unclaimed seat waiting for a future student claim/binding. | Roster provisioning and identity lifecycle. | v2 | both | 2 |
+| hall pass balance | Combined pass availability model where rent-granted quota is tracked separately from purchased or other pass sources. | Hall-pass and entitlement behavior. | both | both | 10 |
+| hall_pass_logs | Attendance-owned lifecycle records for hall-pass requests, approvals, departures, and returns. | Hall-pass execution history. | both | both | 121 |
+| hall_pass_settings | Class-owned configuration for queueing, pass types, and simultaneous limits. | Class configuration and hall-pass feature. | both | both | 139 |
+| hall_pass_verify_token | Legacy hall-pass public verification token retained only as a compatibility surface; newer docs prefer UUID/public-token patterns. | v1 public hall-pass verification. | both | both | 68 |
+| health_check_events | Operations events capturing liveness, readiness, or correctness checks for components and workflows. | Operational health model. | v2 | dev | 15 |
+| Hidden Deferred Mutation | Forbidden pattern where future economic changes live only in opaque delayed payloads instead of visible transition lineage. | Economic governance and FEAT compliance. | v2 | dev | 2 |
+| Idempotency Lock | Ledger/system guard enforcing uniqueness of write intent at the database level. | Ledger state classification and FEAT retry safety. | v2 | dev | 3 |
+| idempotency_key | Unique replay-protection key attached to writes so retries cannot create duplicate effects. | FEAT execution, ledger writes, obligations, and activation flows. | both | both | 1797 |
+| identity rebinding | Recovery principle that restores credential access on the same identity record without creating or moving economic state. | Student and teacher account recovery. | v2 | both | 6 |
+| identity_profiles | Seat-owned display-identity table for encrypted first name and public-facing initials; not an authority or credential table. | Identity display layer. | v2 | dev | 95 |
+| incident_events | Append-only lifecycle events describing incident creation, updates, comments, and resolution. | Operations incident management. | v2 | dev | 15 |
+| incident_summary | Cache/projection of the current state of an incident, derived from its append-only event history. | Operations and status page surfaces. | v2 | dev | 15 |
+| Interest Payout | The lawful posting of accrued interest into a student’s savings balance through FEAT and ledger execution. | Banking domain and payout scheduling. | v2 | both | 12 |
+| Interpretation Snapshot | Cached materialization of a computed behavioral or structural metric window for a class. | Interpretation domain performance layer. | v2 | dev | 2 |
+| issue_categories | System-managed taxonomy used to classify student support issues. | Support domain. | v2 | both | 31 |
+| issue_resolution_actions | Append-only declaration log of support actions such as reversals or waivers, without owning the underlying money effect. | Support domain and FEAT-linked remediation. | v2 | dev | 44 |
+| issue_status_history | Append-only audit trail of every support issue status transition. | Support domain lifecycle tracking. | v2 | dev | 40 |
+| job_events | Operations event log for scheduled/background work such as invariant runs, activation jobs, retries, and failures. | Operations domain. | v2 | dev | 20 |
+| join_code | Human-facing class entry alias that resolves to class_id before any authority-sensitive action; canonical in v1, alias-only in v2. | Student claim, routing, recovery, and class selection. | both | both | 6110 |
+| last_active_seat_id | Sticky-context pointer on users that restores the last resolved class-local actor context across devices and logins. | Identity session restoration. | v2 | dev | 30 |
+| ledger_balance_snapshot | Canonical v2 spendable-balance cache owned by the Ledger domain and re-derivable from posted transactions. | Ledger performance/read model. | v2 | dev | 54 |
+| ledger_transaction | Canonical immutable money-movement record used by the Ledger domain. | Ledger authority, FEAT posting, reversals, and audit. | v2 | dev | 98 |
+| Liveness / Readiness / Correctness | Three-part health model distinguishing process uptime, dependency availability, and invariant/business correctness. | Operations health semantics. | v2 | dev | 1 |
+| Mid-Period Lock | Rule that rent-item type semantics cannot change after a valid payment has occurred in the current coverage period. | Rent-linked perks and rent feature behavior. | v1 | both | 7 |
+| money velocity | Core class-level metric describing how quickly currency circulates through the classroom economy. | Analytics and interpretation. | both | both | 18 |
+| money_action_cooldown_until | Global rate-limit field on users that gates rapid financial mutations. | Identity security state and money-action safety. | v2 | dev | 30 |
+| next_boundary | Activation mode meaning a pending policy should take effect at the next lawful operational boundary rather than immediately. | Economic transition governance. | v2 | both | 4 |
+| obligation-linked entitlements | Perks whose grant/consumption is controlled by the Obligations domain because they arise from rent/assessment satisfaction rather than store purchase. | Obligations-store boundary. | v2 | both | 1 |
+| obligation_lifecycle | Derived per-assessment state row describing whether an obligation is due, overdue, paid, waived, or reversed. | Obligations domain. | v2 | dev | 44 |
+| obligation_reversal | Immutable record that nullifies a prior assessment and forces downstream interpretation to treat the obligation as non-existent. | Obligations corrections. | v2 | dev | 57 |
+| obligation_satisfaction | Immutable record of how a debt was resolved, such as payment or waiver. | Obligations domain lifecycle. | v2 | dev | 46 |
+| Operational Provenance | Ledger classification idea behind category fields such as SYSTEM/MANUAL/ADJUSTMENT; it records where a transaction came from, not its business meaning. | Ledger domain-blind design. | v2 | dev | 6 |
+| Operational Truth | Operations-domain truth about system behavior, health, incidents, jobs, and alerts—not business facts like balances or attendance. | Operations domain definition. | v2 | dev | 4 |
+| operational_events | Structured JSON operational logs with indexed trace fields outside the payload blob. | Operations observability. | v2 | dev | 21 |
+| passkey | WebAuthn-based passwordless authentication capability owned by users and optionally used by teacher/sysadmin accounts. | Identity and login architecture. | both | both | 446 |
+| payroll_fines | Class-owned fine presets that FEAT can translate into deductions but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both | 75 |
+| payroll_rewards | Class-owned reward presets that FEAT can translate into payroll credits but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both | 75 |
+| pending slice | The eligible subset of pending transactions processed during settlement rather than a full historical ledger rescan. | Banking/ledger settlement design. | v2 | dev | 2 |
+| PeriodKey | Deterministic class-calendar/policy-schedule key that creates a one-to-one mapping between a liability period and an assessment. | Obligations idempotency and period logic. | v2 | dev | 2 |
+| policy mode | Teacher-selectable economy climate (tight, default, comfortable) that shapes recommended ratios, pacing, and solvency expectations. | Economy governance and classroom configuration. | both | both | 49 |
+| policy_transitions | Append-only lineage objects describing source/target policy versions, activation mode, status, and supersession relationships. | Economic governance and class configuration. | v2 | dev | 89 |
+| policy_versions | Immutable constitutional policy records representing the active or historical economic truth for a class/domain pair. | Economic governance and class configuration. | v2 | dev | 100 |
+| Posted Balance Snapshot | The cached spendable-balance view derived from posted transactions only; authoritative for spending if recomputable from the event log. | Ledger state model. | v2 | dev | 4 |
+| Public Verification Portal | Public hall-pass verification surface that verifies one claimed student situation without exposing broader roster history. | Hall-pass public-facing feature. | both | user | 2 |
+| queue_enabled | Hall-pass configuration toggle that determines whether queued pass requests are used for a class. | Hall-pass settings and teacher controls. | both | both | 21 |
+| queue_limit | Configured maximum number of concurrent or queued hall-pass requests allowed by a class or pass type. | Hall-pass settings and request-time gating. | both | both | 38 |
+| recovery_status | Short lifecycle marker used in bridge-era student recovery to represent whether an identity is active or waiting to be reclaimed. | Student account recovery. | both | both | 71 |
+| RecoveryRequest | Teacher-recovery state object that tracks one pending/verified/expired recovery session across all represented classes. | Teacher account recovery. | v2 | both | 48 |
+| redemption_audit_logs | Store-owned append-only audit rows recording redemption requests and approval/rejection outcomes. | Store entitlement redemption history. | both | dev | 58 |
+| redemption_prompt | Teacher-facing prompt text attached to delayed store items to guide redemption handling. | Store catalog behavior. | both | both | 26 |
+| Rent Late Fee Reversal | Targeted corrective transaction used when mid-cycle rent changes incorrectly caused late fees under the locked base-rate rule. | Rent corrections and admin remediation. | v1 | both | 4 |
+| rent-linked store item | Store catalog item that is a store-facing alias of a rent/obligation-controlled benefit. | Store and obligations integration. | both | both | 5 |
+| rent_hall_passes | Legacy/bridge count of hall passes granted from rent rather than purchased, used for top-off behavior. | Rent-linked hall-pass logic. | both | both | 72 |
+| Reset code | Short teacher-visible student recovery code used for identity rebinding without altering economic state. | Student recovery flow. | both | both | 62 |
+| resume PIN | Teacher-recovery resume secret that reconnects a later browser session to DB-persisted partial recovery progress. | Teacher account recovery. | v2 | both | 13 |
+| Reversal Primacy | Obligations rule that a reversal overrides any prior satisfaction history when computing the real status of an assessment. | Obligations invariants and interpretation. | v2 | dev | 2 |
+| Roster Provisioning Contract | Identity rule that roster upload provisions a user shell, class seat, display profile, and claim artifacts without activating credentials. | Student onboarding and seat creation. | v2 | dev | 2 |
+| Scheduled activation infrastructure | Operations-side evidence model for jobs that may trigger lawful policy activation without giving OPS authority over policy truth or timing legality. | OPS ↔ FEAT ↔ economic-governance integration. | v2 | dev | 2 |
+| seat | Class-local participant position and the canonical actor identity for economic/operational activity inside one class universe. | Identity, attendance, ledger, obligations, and store. | v2 | both | 5584 |
+| seat-scoped isolation | Rule that debt, money movement, entitlement usage, attendance facts, and other actor activity stay bound to one seat within one class. | Core v2 authority and domain design. | v2 | dev | 4 |
+| seat_attendance_state | Per-seat mutable attendance gate row used for tap enablement and done-for-day locking. | Attendance domain. | v2 | dev | 53 |
+| seat_id | Canonical actor identifier for class-local activity; all economic and operational records hang from it in v2. | Identity, attendance, ledger, obligations, support, and store. | both | both | 1844 |
+| seats.public_id | UUID-encoded deidentified public actor identifier used in class-scoped participant navigation and sysadmin-safe references. | Identity, support, and scoped routing. | v2 | both | 35 |
+| section | Canonical metadata field for class-period labeling such as Block A or Period 1; useful for display but not authority. | Class identity and teacher-facing UI. | both | both | 629 |
+| share_class_name_with_sysadmin | Explicit teacher-consent flag controlling whether class name/context can be shown during issue escalation. | Support escalation privacy boundary. | v2 | both | 14 |
+| Signed Magnitude | Ledger rule that transaction direction is encoded by sign alone: positive credits and negative debits. | Ledger invariants and money math. | v2 | dev | 2 |
+| Single active session per seat | Attendance invariant that only one active attendance session may exist for a seat at a time. | Attendance concurrency and write-time enforcement. | v2 | dev | 2 |
+| Solvency Preservation Principle | Economic principle requiring system-recommended settings to keep ordinary fully-attending students financially viable. | Economy governance. | both | both | 2 |
+| Spendable Balance | The authoritative sum of posted ledger transactions for a seat/account context and the balance truth other domains query for solvency decisions. | Ledger derived state. | v2 | both | 6 |
+| Sticky Context | The last-active class/seat restoration mechanism used to keep users in the correct class context across sessions and devices. | Identity session handling. | v2 | both | 5 |
+| store_item_visibility | Seat-scoped visibility mapping that limits which seats may see a store item; absence of rows means visible to all class seats. | Store catalog scoping. | v2 | dev | 18 |
+| store_items | Store-owned catalog rows describing price, item behavior, inventory, collective-goal settings, and rent-link flags. | Store domain. | both | both | 237 |
+| Structural Interpretation | Interpretation axis that evaluates class configuration and economy health relative to the modeled system structure and CWI. | Interpretation/analytics meaning layer. | v2 | both | 4 |
+| Structured Operational Log | JSON log record with indexed trace fields such as timestamp, correlation_id, domain, and level separated from payload. | Operations observability. | v2 | dev | 2 |
+| Student Seat | Seat whose role is student and which acts as the earning/spending/claiming actor inside a class. | Identity and classroom economy participation. | v2 | both | 47 |
+| student-assisted recovery | Teacher-recovery pattern in which one student per active class helps verify the teacher’s identity by providing generated recovery codes. | Teacher account recovery. | v2 | both | 3 |
+| student_items | Store-held purchased or granted entitlements attached to a seat, including status, expiry, bundle, and use counters. | Store domain. | both | both | 151 |
+| student_recovery_codes | Teacher-recovery rows storing hashed six-digit codes contributed by verifying student seats. | Teacher account recovery. | v2 | dev | 39 |
+| StudentBlock | Legacy v1 student-in-class object that carried class-local state such as passes or done-for-day markers before the seat-based v2 model. | v1 identity and attendance architecture. | v1 | dev | 253 |
+| System Health Metrics | Always-visible analytics metrics representing the classroom economy’s heartbeat, such as participation rate or money velocity. | Analytics feature. | both | both | 19 |
+| tap_enabled | Teacher-controlled per-seat flag that allows or blocks future tap accumulation without erasing prior session history. | Attendance gate state. | both | both | 92 |
+| tap_events | Legacy v1 attendance event table superseded conceptually by attendance_sessions in the canonical v2 schema. | v1 attendance implementation and migration bridge. | v1 | dev | 179 |
+| Teacher Seat | Seat whose role is teacher and which owns class-scoped operational authority within one class universe. | Identity and teacher-side class administration. | v2 | both | 33 |
+| teacher_blocks | Legacy v1 table/model for teacher-to-block relationships superseded by seat/class ownership in v2. | v1 identity and class-scoping architecture. | v1 | dev | 258 |
+| teacher_public_id | Legacy canonical public teacher identifier used for public flows before the unified seat public-ID direction. | v1 teacher identity and public verification. | v1 | both | 133 |
+| teacher_public_token | Public, non-enumerable verification token used for hall-pass verification portals. | Public hall-pass verification. | both | both | 23 |
+| TemporalContext | Immutable per-request object carrying UTC timestamp, class timezone, and derived class-local time as the only approved execution-time temporal truth. | Temporal architecture and future rebuild model. | v2 | dev | 20 |
+| ticket_correlation_packs | Support-owned immutable 1:1 diagnostic snapshots tying an issue to frozen request traces and error references. | Support diagnostics. | v2 | dev | 17 |
+| tight | Most restrictive policy mode emphasizing survival, slower savings growth, and higher economic pressure. | Economy governance and teacher settings. | both | both | 79 |
+| Top-Off Logic | Rule for adding only the missing rent-granted portion of hall passes so purchased passes are preserved. | Rent-linked hall-pass benefit behavior. | both | both | 3 |
+| Unclaimed seat | Seat provisioned in a class with no bound user_id yet; it exists as a future participant position awaiting claim. | Roster provisioning and student onboarding. | v2 | both | 79 |
+| Unified identity model | V2 identity architecture where teachers, students, and sysadmins share users/seats/classes primitives instead of separate role tables. | Identity redesign. | v2 | dev | 5 |
+| user_recovery_tokens | Canonical user-owned recovery-token lifecycle rows for v2 recovery authority, distinct from short-lived bridge reset-code fields. | Student and teacher account recovery. | v2 | dev | 47 |
+| user_reports | Free-form bug/suggestion/comment records separate from the structured class issue-ticket system. | Support domain. | both | both | 62 |
+| username_lookup_hash | Deterministic hashed lookup key used to locate a user during login and recovery without storing plaintext usernames. | Identity and recovery flows. | both | dev | 288 |
+| users | Canonical global identity table that owns authentication, recovery, session security, and role law. | Identity domain and cross-class human identity. | v2 | dev | 535 |
+| visible future economic law | The disclosure principle that pending policy state must be visible to affected teachers, students, and operational domains. | Economic policy visibility. | v2 | both | 5 |
+| Waiver-Aware Paid Status | Rule that a rent coverage period counts as paid either by sufficient payment or by an active waiver that covers the due date. | Rent/obligation behavior. | v1 | both | 2 |
+| Withdrawal Participation | Banking rule that withdrawals reduce future eligible balance so interest is not paid on funds no longer represented in authoritative balance. | Banking eligibility. | v2 | both | 2 |
+| Zero-Cost Perk | Rent-linked store purchase that resolves at zero price when the seat already has the qualifying obligation-linked benefit. | Rent/store integration. | v1 | both | 1 |
+| Zero-Sum Transfers | Ledger invariant requiring all transactions in one correlated transfer group to net to zero atomically. | Ledger integrity and transfer orchestration. | v2 | dev | 2 |

--- a/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
+++ b/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
@@ -11,7 +11,7 @@
 | 1 | block | Definition incomplete; frequency wildly inflated (8250→~3700, many are model names like `StudentBlock`) | Rewrote definition to reflect current transitional state; corrected frequency |
 | 2 | class_economies | Marked v1-only but the Python model `ClassEconomy` is still the active class anchor (mapped to `classes` table) | Changed to "both"; clarified table-name vs model-name distinction |
 | 3 | ClassEconomy | Marked v1-only but it is the active runtime model | Changed to "both" |
-| 4 | ClassMembership | Marked v1-only but still active in routes and listed in CLAUDE.md as current scoping authority | Changed to "both" |
+| 4 | ClassMembership | Marked v1-only but still active in routes and listed in `.claude/CLAUDE.md` as current scoping authority | Changed to "both" |
 | 5 | balance_cache | Marked v1-only but `BalanceCache` model is active (backed by `ledger_balance_snapshot` table) | Changed to "both"; clarified the table rename |
 | 6 | StudentBlock | Marked v1-only but still actively used in routes for per-seat per-class state | Changed to "both" |
 | 7 | tap_events | Marked v1-only/superseded but still in active dual-write transition | Changed to "both" |

--- a/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
+++ b/docs/TRACKING/TERMINOLOGY_AUDIT_V1.md
@@ -1,0 +1,184 @@
+# Classroom Token Hub — Terminology Audit (Inventory Run)
+
+> Part 1 of the documentation audit. Inventory only; no rewriting.
+> Date: 2026-06-15
+
+| Term | Definition | Usage/Context | Version | Facing |
+|---|---|---|---|---|
+| Account Lifecycle Map | The non-normative human-story map of teacher and student identity progression from provisioning through operation and recovery. | Identity onboarding and developer orientation. | v2 | dev |
+| account_balances | Planned v2 per-account checkpoint/cache table keyed by class, seat, and account type for available/current balance tracking. | Future banking/ledger rebuild design. | v2 | dev |
+| Accrual Frequency | How often savings interest is earned (daily, weekly, monthly), distinct from compounding and payout timing. | Banking policy and execution scheduling. | v2 | both |
+| Accrued Interest | Interest earned but not yet posted into spendable savings; it exists as intermediate banking state until payout. | Banking domain accrual and payout model. | v2 | both |
+| Activation Intent | The abstract timing mode attached to a policy transition that says whether a change is immediate, at the next lawful boundary, or manual. | Economic policy governance and disclosure. | v2 | both |
+| actor_public_id | Support-facing copy of a seat public ID used in sysadmin views so support workflows do not expose raw seat/student identifiers. | Support tickets, correlation packs, escalation views. | v2 | dev |
+| Aggregate Analytics Principle | Rule that analytics should describe class-level ecosystem health and drift, not rank or surveil individual students. | Economy analytics philosophy. | both | both |
+| Alignment Status | Teacher-facing indication of whether live class settings align with the selected economy policy mode and recommendations. | Economy Health and rebalance workflow. | v1 | both |
+| AnalyticsAlert | Legacy/sysadmin alert object raised from analytics snapshots when a class economy crosses health thresholds. | v1 sysadmin observability and alerting. | v1 | dev |
+| AnalyticsSnapshot | Immutable aggregate class-health snapshot captured for analytics and sysadmin alerting without exposing individual student data. | Analytics, alerting, and legacy sysadmin monitoring. | both | dev |
+| anonymous_code | HMAC-derived opaque reference displayed for free-form user reports instead of raw identity. | Support/user report workflow. | v2 | dev |
+| append-only policy evolution | Core economic governance rule that policy changes are represented as new transition lineage, never in-place mutation of active truth. | Economic policy governance and migration away from hidden delayed mutation. | v2 | dev |
+| Attendance Event Log | Conceptual append-only timeline formed by attendance sessions and hall-pass events as the authoritative attendance fact history. | Attendance domain model. | v2 | dev |
+| attendance_sessions | Canonical v2 table for tap-in/tap-out attendance facts; the successor to legacy tap_events. | Attendance tracking, payroll inputs, and temporal rules. | v2 | both |
+| Audit Event | High-integrity append-only record for security-sensitive, identity-sensitive, and money-moving side effects. | Operations domain audit trail. | v2 | dev |
+| audit_log | Operations-owned audit table that stores structured before/after records for sensitive side effects and FEAT execution traces. | Audit lineage and operational compliance. | v2 | dev |
+| available_balance | Operational balance that includes posted balance plus pending delta and is used for real-time reads and preconditions. | Ledger reads, banking UI, overdraft checks, and settlement contract. | both | both |
+| Axis Exclusivity | Interpretation rule that every metric belongs to exactly one axis—behavioral or structural—and must not blend them into one authority path. | Interpretation domain invariants. | v2 | dev |
+| balance_cache | Legacy balance cache term for the derived money cache used before the canonical ledger_balance_snapshot/account-balance direction. | v1/v1.5 ledger implementation and migration bridge. | v1 | dev |
+| Behavioral Interpretation | Interpretation axis that explains how seats behave over completed payroll cycles using domain event logs. | Interpretation/analytics meaning layer. | v2 | both |
+| block | Legacy label used for periods/sections and sometimes policy scope; v2 treats it as metadata only and forbids label-based authority. | v1 scoping model and v2 prohibition boundary. | both | both |
+| Budget Survival Test | Canonical solvency check asking whether students can still preserve a minimum weekly savings buffer after recurring costs. | Economy governance, validation, and analytics. | both | both |
+| Canonical class time | The class-local notion of current time derived from UTC plus the class timezone and used for all behavioral evaluation. | Temporal architecture and class-scoped execution. | v2 | dev |
+| Catastrophe Stability rule | Economy solvency rule testing whether a student can recover within roughly one cycle from a pair of shocks such as fines or loss. | Economic policy validation and recommendations. | both | both |
+| claim artifacts | Seat-owned verification artifacts used to prove entitlement to a rostered participant position during the claim flow. | Student seat claim and roster provisioning. | v2 | dev |
+| Claim Lifecycle | Identity flow that binds a global user to a class-local seat after verifying class-specific claim artifacts. | Identity onboarding and seat binding. | v2 | both |
+| Claim-Based Model | Public hall-pass verification model that only answers a specific student claim instead of exposing a roster or pass list. | Public hall-pass verification portal. | both | both |
+| class day | The canonical classroom day boundary defined as midnight-to-midnight in class timezone, then converted to UTC query bounds. | Temporal architecture, attendance, and daily limits. | v2 | dev |
+| Class Drift | Identity/context problem where a session restores or remains in the wrong class; sticky-context rules exist to prevent it. | Identity session restoration. | v2 | both |
+| class timezone | Immutable IANA timezone owned by the class and used to evaluate days, periods, due dates, accrual windows, and attendance boundaries. | Temporal model, interpretation, obligations, and banking. | v2 | both |
+| class universe | The isolated classroom-economy boundary represented canonically by class_id and operationalized through class-local seats. | Identity architecture and scoping law. | v2 | both |
+| class-scoped isolation | Rule that all class activity, records, and permissions remain within one resolved class boundary with no cross-class leakage. | Core invariants, request context, and domain ownership. | both | both |
+| class_economies | Legacy v1 class container model that held class identity and join code before the canonical classes/class_id v2 model. | v1 architecture and migration references. | v1 | dev |
+| class_features | Class Configuration table whose row existence per feature acts as authoritative feature enablement for a class. | Feature enablement and class policy surfaces. | v2 | dev |
+| class_id | Canonical private class-universe identifier and internal scoping boundary for all authority-sensitive v2 behavior. | Identity, policy, ledger, attendance, and isolation invariants. | both | both |
+| ClassEconomy | Legacy v1 private tenant container for a classroom economy, paired with a public join code. | v1 multi-tenancy and class identity model. | v1 | dev |
+| classes | Canonical v2 class-anchor table that defines the universe boundary and carries join code token, display name, and section metadata. | Identity and all class-wide configuration references. | v2 | dev |
+| ClassMembership | Legacy membership/bridge record linking a person to a class; v2 replaces this with seat existence as membership truth. | v1 identity and scoping model, plus migration discussions. | v1 | dev |
+| Classroom Token Hub (CTH) | The classroom economy platform whose documentation uses CTH/ Classroom Token Hub as the canonical product name. | Cross-document product identity. | both | both |
+| Classroom Wage Index (CWI) | Expected weekly income for perfect attendance; the baseline economic unit that all recommended pricing and solvency ratios are measured against. | Economy governance, analytics, policy modes, and recommendations. | both | both |
+| Collective Goal | A shared class objective or store-goal construct priced relative to CWI to encourage coordinated saving and participation. | Economy design, store catalog, and analytics. | both | both |
+| collective_goal_instance_code | Instance key that groups one or more collective-goal store items into the same progress bucket. | Store catalog and collective-goal tracking. | both | dev |
+| comfortable | The most generous policy mode, intended to lower pressure and accelerate progression relative to CWI. | Economy governance and teacher policy selection. | both | both |
+| Compound Frequency | How often accrued interest joins the future earning base; distinct from earning frequency and payout frequency. | Banking policy and accrual math. | v2 | both |
+| Compound Participation | The rule deciding whether accrued-but-unpaid interest is allowed to participate in future accrual calculations. | Banking domain semantics. | v2 | both |
+| ConsumptionIntent | Attendance-originated trigger concept for using an obligation-linked entitlement such as a rent-granted hall pass. | Attendance-to-Obligations coordination. | v2 | dev |
+| Context-First Execution | FEAT rule that a user, seat, and class context must be resolved before any domain interaction or mutation occurs. | Feature execution contract. | v2 | dev |
+| Core Orchestrator | A FEAT designated as a reusable high-integrity orchestration unit, especially for money posting/voiding and similar cross-domain actions. | Feature-execution architecture. | v2 | dev |
+| correlation pack | Immutable support snapshot that captures request-trace and error context at issue submission time. | Support diagnostics and escalation. | v2 | dev |
+| correlation_id | System-wide workflow identifier propagated across requests, FEATs, reversals, audits, jobs, and incidents to preserve causality. | Operations, ledger, FEAT, and support tracing. | both | both |
+| current_balance | Authoritative posted-only account balance used after settlement and reconciliation, distinct from available balance. | Banking/ledger settlement model. | both | both |
+| current_session_nonce | Per-login nonce stored on users that binds all requests to one current session and invalidates older sessions on next sign-in. | Identity session security. | v2 | dev |
+| default | The balanced middle policy mode used as the baseline classroom economy climate. | Economy governance and teacher settings. | both | both |
+| Diagnostic Drill-Down Metrics | Analytics metrics revealed only after interaction so a teacher can inspect context without making student ranking the default view. | Analytics and interpretation UX. | both | both |
+| display_name | Human-facing class title metadata, normally paired with section for teacher-facing class display. | Identity/class metadata and UI labels. | both | both |
+| Distributed trust | Teacher-recovery principle requiring one verifying student per active class so no single student can recover a teacher account alone. | Teacher account recovery. | v2 | both |
+| Domain Blindness | Ledger rule that money rows record operational provenance but not business meaning such as rent or store semantics. | Ledger domain architecture. | v2 | dev |
+| Domain Guard | Standardized read-only domain check that returns allowed/reason/metadata for FEAT orchestration instead of mutating or throwing business errors. | Capability and FEAT interaction pattern. | v2 | dev |
+| Domain Law | Shorthand for the codified domain authority model that says each domain owns one bounded truth and mutation boundary. | V2 restructuring and authority summary. | v2 | dev |
+| done_for_day_date | Per-seat attendance lock date used for O(1) gating; if it disagrees with the event log, attendance history remains authoritative. | Attendance state and daily lock behavior. | both | both |
+| Drift & Anomaly Metrics | Trend-oriented analytics that surface divergence from expected classroom-economy behavior instead of reporting totals alone. | Analytics and interpretation surfaces. | both | both |
+| drift indicators | Derived interpretation outputs that flag comparative movement away from expected system behavior over time. | Interpretation domain state classification. | v2 | dev |
+| Economy Balance Checker | Shared recommendation/validation engine that checks whether a class economy fits policy-mode guidance and solvency expectations. | Economy Health, rebalance preview, and recommendation APIs. | v1 | both |
+| Economy Health | Teacher-facing surface for policy mode, alignment review, recommendation visibility, and rebalance actions. | Economy feature/UI. | v1 | both |
+| economy_pending_rebalance_json | Deprecated compatibility field that stored delayed rebalance payloads before append-only policy transitions became the constitutional model. | Migration bridge from v1 delayed mutation to v2 governance. | both | dev |
+| economy_policy_alignment_status | Stored teacher-facing result showing whether current settings are aligned or misaligned with policy guidance. | Legacy feature_settings economy mode support. | v1 | both |
+| economy_policy_mode | Stored policy climate selector (tight/default/comfortable); in v2 it is an operational projection rather than independent constitutional truth. | Class configuration and economy UI. | both | both |
+| Eligible Savings Balance | The authoritative posted balance slice that actually qualifies to earn interest in a given accrual period. | Banking accrual rules and projections. | v2 | both |
+| Entitlement Balance | Derived count/value of obligation-linked perks; it is computed from events and is never stored as authoritative state. | Obligations and entitlement usage. | v2 | both |
+| entitlement_events | Append-only event stream for obligation-linked grants, consumption, and revocations such as rent-linked hall-pass quota. | Obligations domain. | v2 | dev |
+| Event-Log Authority | V2 rule that authoritative truth comes from immutable event records or explicit projections derived from them. | Core schema and domain summary. | v2 | dev |
+| Event-Log Fallback | Ledger rule that the posted transaction log can always recompute the spendable-balance cache if the cache is missing or inconsistent. | Ledger invariants and recovery behavior. | v2 | dev |
+| FEAT | Atomic feature-execution orchestration unit and the only lawful place for state mutation, money movement, binding, and cross-domain coordination. | Core execution architecture. | v2 | dev |
+| Foundational | Highest documentation authority level for system identity and non-negotiable invariants. | Documentation governance model. | both | dev |
+| Future Economic Law | Pending policy state treated as visible announced law rather than hidden backend configuration. | Economic policy transitions and disclosure. | v2 | both |
+| Generic Placeholder | Teacher-created unclaimed seat waiting for a future student claim/binding. | Roster provisioning and identity lifecycle. | v2 | both |
+| hall pass balance | Combined pass availability model where rent-granted quota is tracked separately from purchased or other pass sources. | Hall-pass and entitlement behavior. | both | both |
+| hall_pass_logs | Attendance-owned lifecycle records for hall-pass requests, approvals, departures, and returns. | Hall-pass execution history. | both | both |
+| hall_pass_settings | Class-owned configuration for queueing, pass types, and simultaneous limits. | Class configuration and hall-pass feature. | both | both |
+| hall_pass_verify_token | Legacy hall-pass public verification token retained only as a compatibility surface; newer docs prefer UUID/public-token patterns. | v1 public hall-pass verification. | both | both |
+| health_check_events | Operations events capturing liveness, readiness, or correctness checks for components and workflows. | Operational health model. | v2 | dev |
+| Hidden Deferred Mutation | Forbidden pattern where future economic changes live only in opaque delayed payloads instead of visible transition lineage. | Economic governance and FEAT compliance. | v2 | dev |
+| Idempotency Lock | Ledger/system guard enforcing uniqueness of write intent at the database level. | Ledger state classification and FEAT retry safety. | v2 | dev |
+| idempotency_key | Unique replay-protection key attached to writes so retries cannot create duplicate effects. | FEAT execution, ledger writes, obligations, and activation flows. | both | both |
+| identity rebinding | Recovery principle that restores credential access on the same identity record without creating or moving economic state. | Student and teacher account recovery. | v2 | both |
+| identity_profiles | Seat-owned display-identity table for encrypted first name and public-facing initials; not an authority or credential table. | Identity display layer. | v2 | dev |
+| incident_events | Append-only lifecycle events describing incident creation, updates, comments, and resolution. | Operations incident management. | v2 | dev |
+| incident_summary | Cache/projection of the current state of an incident, derived from its append-only event history. | Operations and status page surfaces. | v2 | dev |
+| Interest Payout | The lawful posting of accrued interest into a student’s savings balance through FEAT and ledger execution. | Banking domain and payout scheduling. | v2 | both |
+| Interpretation Snapshot | Cached materialization of a computed behavioral or structural metric window for a class. | Interpretation domain performance layer. | v2 | dev |
+| issue_categories | System-managed taxonomy used to classify student support issues. | Support domain. | v2 | both |
+| issue_resolution_actions | Append-only declaration log of support actions such as reversals or waivers, without owning the underlying money effect. | Support domain and FEAT-linked remediation. | v2 | dev |
+| issue_status_history | Append-only audit trail of every support issue status transition. | Support domain lifecycle tracking. | v2 | dev |
+| job_events | Operations event log for scheduled/background work such as invariant runs, activation jobs, retries, and failures. | Operations domain. | v2 | dev |
+| join_code | Human-facing class entry alias that resolves to class_id before any authority-sensitive action; canonical in v1, alias-only in v2. | Student claim, routing, recovery, and class selection. | both | both |
+| last_active_seat_id | Sticky-context pointer on users that restores the last resolved class-local actor context across devices and logins. | Identity session restoration. | v2 | dev |
+| ledger_balance_snapshot | Canonical v2 spendable-balance cache owned by the Ledger domain and re-derivable from posted transactions. | Ledger performance/read model. | v2 | dev |
+| ledger_transaction | Canonical immutable money-movement record used by the Ledger domain. | Ledger authority, FEAT posting, reversals, and audit. | v2 | dev |
+| Liveness / Readiness / Correctness | Three-part health model distinguishing process uptime, dependency availability, and invariant/business correctness. | Operations health semantics. | v2 | dev |
+| Mid-Period Lock | Rule that rent-item type semantics cannot change after a valid payment has occurred in the current coverage period. | Rent-linked perks and rent feature behavior. | v1 | both |
+| money velocity | Core class-level metric describing how quickly currency circulates through the classroom economy. | Analytics and interpretation. | both | both |
+| money_action_cooldown_until | Global rate-limit field on users that gates rapid financial mutations. | Identity security state and money-action safety. | v2 | dev |
+| next_boundary | Activation mode meaning a pending policy should take effect at the next lawful operational boundary rather than immediately. | Economic transition governance. | v2 | both |
+| obligation-linked entitlements | Perks whose grant/consumption is controlled by the Obligations domain because they arise from rent/assessment satisfaction rather than store purchase. | Obligations-store boundary. | v2 | both |
+| obligation_lifecycle | Derived per-assessment state row describing whether an obligation is due, overdue, paid, waived, or reversed. | Obligations domain. | v2 | dev |
+| obligation_reversal | Immutable record that nullifies a prior assessment and forces downstream interpretation to treat the obligation as non-existent. | Obligations corrections. | v2 | dev |
+| obligation_satisfaction | Immutable record of how a debt was resolved, such as payment or waiver. | Obligations domain lifecycle. | v2 | dev |
+| Operational Provenance | Ledger classification idea behind category fields such as SYSTEM/MANUAL/ADJUSTMENT; it records where a transaction came from, not its business meaning. | Ledger domain-blind design. | v2 | dev |
+| Operational Truth | Operations-domain truth about system behavior, health, incidents, jobs, and alerts—not business facts like balances or attendance. | Operations domain definition. | v2 | dev |
+| operational_events | Structured JSON operational logs with indexed trace fields outside the payload blob. | Operations observability. | v2 | dev |
+| passkey | WebAuthn-based passwordless authentication capability owned by users and optionally used by teacher/sysadmin accounts. | Identity and login architecture. | both | both |
+| payroll_fines | Class-owned fine presets that FEAT can translate into deductions but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both |
+| payroll_rewards | Class-owned reward presets that FEAT can translate into payroll credits but that do not create ledger entries by themselves. | Class configuration for payroll. | v2 | both |
+| pending slice | The eligible subset of pending transactions processed during settlement rather than a full historical ledger rescan. | Banking/ledger settlement design. | v2 | dev |
+| PeriodKey | Deterministic class-calendar/policy-schedule key that creates a one-to-one mapping between a liability period and an assessment. | Obligations idempotency and period logic. | v2 | dev |
+| policy mode | Teacher-selectable economy climate (tight, default, comfortable) that shapes recommended ratios, pacing, and solvency expectations. | Economy governance and classroom configuration. | both | both |
+| policy_transitions | Append-only lineage objects describing source/target policy versions, activation mode, status, and supersession relationships. | Economic governance and class configuration. | v2 | dev |
+| policy_versions | Immutable constitutional policy records representing the active or historical economic truth for a class/domain pair. | Economic governance and class configuration. | v2 | dev |
+| Posted Balance Snapshot | The cached spendable-balance view derived from posted transactions only; authoritative for spending if recomputable from the event log. | Ledger state model. | v2 | dev |
+| Public Verification Portal | Public hall-pass verification surface that verifies one claimed student situation without exposing broader roster history. | Hall-pass public-facing feature. | both | user |
+| queue_enabled | Hall-pass configuration toggle that determines whether queued pass requests are used for a class. | Hall-pass settings and teacher controls. | both | both |
+| queue_limit | Configured maximum number of concurrent or queued hall-pass requests allowed by a class or pass type. | Hall-pass settings and request-time gating. | both | both |
+| recovery_status | Short lifecycle marker used in bridge-era student recovery to represent whether an identity is active or waiting to be reclaimed. | Student account recovery. | both | both |
+| RecoveryRequest | Teacher-recovery state object that tracks one pending/verified/expired recovery session across all represented classes. | Teacher account recovery. | v2 | both |
+| redemption_audit_logs | Store-owned append-only audit rows recording redemption requests and approval/rejection outcomes. | Store entitlement redemption history. | both | dev |
+| redemption_prompt | Teacher-facing prompt text attached to delayed store items to guide redemption handling. | Store catalog behavior. | both | both |
+| Rent Late Fee Reversal | Targeted corrective transaction used when mid-cycle rent changes incorrectly caused late fees under the locked base-rate rule. | Rent corrections and admin remediation. | v1 | both |
+| rent-linked store item | Store catalog item that is a store-facing alias of a rent/obligation-controlled benefit. | Store and obligations integration. | both | both |
+| rent_hall_passes | Legacy/bridge count of hall passes granted from rent rather than purchased, used for top-off behavior. | Rent-linked hall-pass logic. | both | both |
+| Reset code | Short teacher-visible student recovery code used for identity rebinding without altering economic state. | Student recovery flow. | both | both |
+| resume PIN | Teacher-recovery resume secret that reconnects a later browser session to DB-persisted partial recovery progress. | Teacher account recovery. | v2 | both |
+| Reversal Primacy | Obligations rule that a reversal overrides any prior satisfaction history when computing the real status of an assessment. | Obligations invariants and interpretation. | v2 | dev |
+| Roster Provisioning Contract | Identity rule that roster upload provisions a user shell, class seat, display profile, and claim artifacts without activating credentials. | Student onboarding and seat creation. | v2 | dev |
+| Scheduled activation infrastructure | Operations-side evidence model for jobs that may trigger lawful policy activation without giving OPS authority over policy truth or timing legality. | OPS ↔ FEAT ↔ economic-governance integration. | v2 | dev |
+| seat | Class-local participant position and the canonical actor identity for economic/operational activity inside one class universe. | Identity, attendance, ledger, obligations, and store. | v2 | both |
+| seat-scoped isolation | Rule that debt, money movement, entitlement usage, attendance facts, and other actor activity stay bound to one seat within one class. | Core v2 authority and domain design. | v2 | dev |
+| seat_attendance_state | Per-seat mutable attendance gate row used for tap enablement and done-for-day locking. | Attendance domain. | v2 | dev |
+| seat_id | Canonical actor identifier for class-local activity; all economic and operational records hang from it in v2. | Identity, attendance, ledger, obligations, support, and store. | both | both |
+| seats.public_id | UUID-encoded deidentified public actor identifier used in class-scoped participant navigation and sysadmin-safe references. | Identity, support, and scoped routing. | v2 | both |
+| section | Canonical metadata field for class-period labeling such as Block A or Period 1; useful for display but not authority. | Class identity and teacher-facing UI. | both | both |
+| share_class_name_with_sysadmin | Explicit teacher-consent flag controlling whether class name/context can be shown during issue escalation. | Support escalation privacy boundary. | v2 | both |
+| Signed Magnitude | Ledger rule that transaction direction is encoded by sign alone: positive credits and negative debits. | Ledger invariants and money math. | v2 | dev |
+| Single active session per seat | Attendance invariant that only one active attendance session may exist for a seat at a time. | Attendance concurrency and write-time enforcement. | v2 | dev |
+| Solvency Preservation Principle | Economic principle requiring system-recommended settings to keep ordinary fully-attending students financially viable. | Economy governance. | both | both |
+| Spendable Balance | The authoritative sum of posted ledger transactions for a seat/account context and the balance truth other domains query for solvency decisions. | Ledger derived state. | v2 | both |
+| Sticky Context | The last-active class/seat restoration mechanism used to keep users in the correct class context across sessions and devices. | Identity session handling. | v2 | both |
+| store_item_visibility | Seat-scoped visibility mapping that limits which seats may see a store item; absence of rows means visible to all class seats. | Store catalog scoping. | v2 | dev |
+| store_items | Store-owned catalog rows describing price, item behavior, inventory, collective-goal settings, and rent-link flags. | Store domain. | both | both |
+| Structural Interpretation | Interpretation axis that evaluates class configuration and economy health relative to the modeled system structure and CWI. | Interpretation/analytics meaning layer. | v2 | both |
+| Structured Operational Log | JSON log record with indexed trace fields such as timestamp, correlation_id, domain, and level separated from payload. | Operations observability. | v2 | dev |
+| Student Seat | Seat whose role is student and which acts as the earning/spending/claiming actor inside a class. | Identity and classroom economy participation. | v2 | both |
+| student-assisted recovery | Teacher-recovery pattern in which one student per active class helps verify the teacher’s identity by providing generated recovery codes. | Teacher account recovery. | v2 | both |
+| student_items | Store-held purchased or granted entitlements attached to a seat, including status, expiry, bundle, and use counters. | Store domain. | both | both |
+| student_recovery_codes | Teacher-recovery rows storing hashed six-digit codes contributed by verifying student seats. | Teacher account recovery. | v2 | dev |
+| StudentBlock | Legacy v1 student-in-class object that carried class-local state such as passes or done-for-day markers before the seat-based v2 model. | v1 identity and attendance architecture. | v1 | dev |
+| System Health Metrics | Always-visible analytics metrics representing the classroom economy’s heartbeat, such as participation rate or money velocity. | Analytics feature. | both | both |
+| tap_enabled | Teacher-controlled per-seat flag that allows or blocks future tap accumulation without erasing prior session history. | Attendance gate state. | both | both |
+| tap_events | Legacy v1 attendance event table superseded conceptually by attendance_sessions in the canonical v2 schema. | v1 attendance implementation and migration bridge. | v1 | dev |
+| Teacher Seat | Seat whose role is teacher and which owns class-scoped operational authority within one class universe. | Identity and teacher-side class administration. | v2 | both |
+| teacher_blocks | Legacy v1 table/model for teacher-to-block relationships superseded by seat/class ownership in v2. | v1 identity and class-scoping architecture. | v1 | dev |
+| teacher_public_id | Legacy canonical public teacher identifier used for public flows before the unified seat public-ID direction. | v1 teacher identity and public verification. | v1 | both |
+| teacher_public_token | Public, non-enumerable verification token used for hall-pass verification portals. | Public hall-pass verification. | both | both |
+| TemporalContext | Immutable per-request object carrying UTC timestamp, class timezone, and derived class-local time as the only approved execution-time temporal truth. | Temporal architecture and future rebuild model. | v2 | dev |
+| ticket_correlation_packs | Support-owned immutable 1:1 diagnostic snapshots tying an issue to frozen request traces and error references. | Support diagnostics. | v2 | dev |
+| tight | Most restrictive policy mode emphasizing survival, slower savings growth, and higher economic pressure. | Economy governance and teacher settings. | both | both |
+| Top-Off Logic | Rule for adding only the missing rent-granted portion of hall passes so purchased passes are preserved. | Rent-linked hall-pass benefit behavior. | both | both |
+| Unclaimed seat | Seat provisioned in a class with no bound user_id yet; it exists as a future participant position awaiting claim. | Roster provisioning and student onboarding. | v2 | both |
+| Unified identity model | V2 identity architecture where teachers, students, and sysadmins share users/seats/classes primitives instead of separate role tables. | Identity redesign. | v2 | dev |
+| user_recovery_tokens | Canonical user-owned recovery-token lifecycle rows for v2 recovery authority, distinct from short-lived bridge reset-code fields. | Student and teacher account recovery. | v2 | dev |
+| user_reports | Free-form bug/suggestion/comment records separate from the structured class issue-ticket system. | Support domain. | both | both |
+| username_lookup_hash | Deterministic hashed lookup key used to locate a user during login and recovery without storing plaintext usernames. | Identity and recovery flows. | both | dev |
+| users | Canonical global identity table that owns authentication, recovery, session security, and role law. | Identity domain and cross-class human identity. | v2 | dev |
+| visible future economic law | The disclosure principle that pending policy state must be visible to affected teachers, students, and operational domains. | Economic policy visibility. | v2 | both |
+| Waiver-Aware Paid Status | Rule that a rent coverage period counts as paid either by sufficient payment or by an active waiver that covers the due date. | Rent/obligation behavior. | v1 | both |
+| Withdrawal Participation | Banking rule that withdrawals reduce future eligible balance so interest is not paid on funds no longer represented in authoritative balance. | Banking eligibility. | v2 | both |
+| Zero-Cost Perk | Rent-linked store purchase that resolves at zero price when the seat already has the qualifying obligation-linked benefit. | Rent/store integration. | v1 | both |
+| Zero-Sum Transfers | Ledger invariant requiring all transactions in one correlated transfer group to net to zero atomically. | Ledger integrity and transfer orchestration. | v2 | dev |


### PR DESCRIPTION
## Summary

- Completes Part 1 terminology audit: inventoried 177 terms across the codebase and docs, corrected 13 accuracy errors (wrong version labels, inflated frequencies, incomplete definitions), and classified all terms through a governance review
- Creates the `REF` (Reference) namespace with `TERM` (Terminology) functional area
- Adds **REF-TERM-001**: normative developer-facing vocabulary (82 terms after merging and pruning)
- Adds **REF-TERM-002**: normative user-facing vocabulary (~35 terms in plain language, grouped by functional area)
- Registers both documents in `docs/README.md` and `SOP-DOC-002` documentation index

## Key decisions

- **30 terms removed** from glossary (one-off doc terms, zero-occurrence terms, implementation details)
- **18 terms merged** into parent concepts (e.g., balance taxonomy consolidated under Spendable Balance; actor_public_id merged into seats.public_id)
- **22 terms moved to schema glossary** (field/table names without independent architectural meaning)
- **10 terms moved to feature specs** (behavioral rules specific to one feature)
- **7 terms removed entirely** (legacy names being replaced, premature concepts, derivable model names)

## Test plan

- [x] Verify REF-TERM-001 and REF-TERM-002 follow existing doc header conventions (reference number, version, authority level)
- [x] Verify docs/README.md correctly lists the new REFERENCE namespace
- [x] Verify SOP-DOC-002 index links resolve to the new files
- [ ] Review: no term in REF-TERM-002 (user-facing) uses developer jargon without plain-language explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)