### PR TITLE
docs: correct README inaccuracies and tag v1 legacy onboarding code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ New code must route writes through FEATs; legacy routes that commit directly are
 - **Account Recovery** — Student-assisted teacher recovery flow
 
 ### For System Admins
-- **Admin Portal** — Review error logs and broadcast announcements
+- **Admin Portal** — Teacher overview, support tickets, error/event logs, broadcast announcements
+  > **v2 direction:** Invite-code gating replaced by open teacher self-signup; sysadmin role shifts to operational oversight.
 
 ### Platform
 - **Multi-Tenant** — Full class-period isolation; shared students across teachers

--- a/README.md
+++ b/README.md
@@ -54,22 +54,21 @@ New code must route writes through FEATs; legacy routes that commit directly are
 - **Classroom Store** — Virtual and physical items with bundles, expirations, and redemption tracking
 - **Rent & Fees** — Recurring rent with waivers, late fees, and immutable policy versioning
 - **Insurance** — Policies, enrollments, and claims with canonical obligation lifecycle
-- **Analytics** — CWI analysis, participation tracking, system health metrics
+- **Analytics** — Aggregate class metrics: participation rate, money velocity, spending/hoarding behavior, budget survivability; weekly and monthly views
 - **Hall Passes** — Time-limited passes with automatic tracking
 
 ### For Students
 - **Portal** — View balances, transaction history, store, and attendance
-- **Transfers** — Send tokens to other students in the same class
+- **Account Transfers** — Move funds between checking and savings accounts
 - **Account Recovery** — Student-assisted teacher recovery flow
 
 ### For System Admins
-- **Admin Portal** — Manage teachers, review error logs, broadcast announcements
-- **2FA Reset** — Reset teacher TOTP when locked out
+- **Admin Portal** — Review error logs and broadcast announcements
 
 ### Platform
 - **Multi-Tenant** — Full class-period isolation; shared students across teachers
 - **Progressive Web App** — Installable on mobile with offline fallback
-- **Accessibility** — WCAG 2.1 AA design guidelines, keyboard navigation, ARIA labels, screen reader support
+- **Accessibility** — WCAG 2.1 AA design guidelines, keyboard navigation, ARIA labels, screen reader support. Automated testing uses axe-core; no formal certification.
 - **Security** — PII encryption at rest, TOTP 2FA for admins, CSRF protection, salted+peppered credential hashing, Cloudflare Turnstile bot protection, post-claim PII deletion
 
 ---
@@ -199,7 +198,7 @@ python scripts/seed_dummy_students.py   # Seed test data
 ## Documentation
 
 - **[Architecture Foundation](docs/ARCHITECTURE/ARC-CORE-000_Architecture_Foundation.md)** — System design and domain boundaries
-- **[Authority Model](docs/INV-CORE-001_Authority_Model.md)** — INV → DOM → FEAT enforcement hierarchy
+- **[Authority Model](docs/INVARIANT/CORE/INV-CORE-001_CAPABILITY_BASED_ARCHITECTURE_AND_AUTHORITY_MODEL.md)** — INV → DOM → FEAT enforcement hierarchy
 - **[Domain Specs](docs/DOMAIN/)** — Per-domain authority contracts
 - **[FEAT Contracts](docs/FEATURE-EXECUTION/)** — Execution layer specifications
 - **[API Reference](docs/ARCHITECTURE/OPERATIONS/ARC-OPS-005_Api_Reference.md)** — REST API documentation

--- a/app/models.py
+++ b/app/models.py
@@ -579,6 +579,7 @@ class Student(db.Model):
 
 
 class AdminInviteCode(db.Model):
+    # V1 LEGACY — replaced in v2 by open teacher signup (Turnstile-gated form → TOTP → passkey → done)
     __tablename__ = 'teacher_invite_codes'
     id = db.Column(db.Integer, primary_key=True)
     code = db.Column(db.String(255), unique=True, nullable=False)

--- a/app/routes/system_admin.py
+++ b/app/routes/system_admin.py
@@ -833,10 +833,8 @@ def test_error_503():
 @system_admin_required
 def manage_admins():
     """
-    View and manage all admin (teacher) accounts.
-    Shows admin details, student counts per teacher, signup date, and last login.
-    
-    Note: System admins see teacher info and student counts only, not individual student details.
+    V1 LEGACY — admin account management (no nav link in layout_system_admin.html).
+    v2 replaces with DOM-IDEN/DOM-OPS compliant sysadmin audit (Wave 11 item 3).
     """
     # Get all admins with student counts
     admins = Admin.query.order_by(db.func.coalesce(Admin.teacher_public_id, ''), Admin.id.asc()).all()
@@ -865,8 +863,8 @@ def manage_admins():
 @system_admin_required
 def reset_teacher_totp(admin_id):
     """
-    Reset a teacher's TOTP secret and return the new setup details (JSON).
-    This allows recovery of lost accounts.
+    V1 LEGACY — only accessible via manage_admins (no nav link).
+    v2 teacher TOTP is owned by User model; recovery uses student-assisted flow.
     """
     admin = db.get_or_404(Admin, admin_id)
 
@@ -992,8 +990,8 @@ def delete_admin(admin_id):
 @system_admin_required
 def manage_teachers():
     """
-    Unified teacher management page: invite codes + teacher overview with stats.
-    Merges the old manage_teachers and teacher_overview into a single page.
+    V1 LEGACY — invite-code based teacher management.
+    v2 replaces this with open teacher signup (Turnstile-gated form → TOTP → passkey → done).
     """
     # Handle invite code form submission
     form = SystemAdminInviteForm()

--- a/app/routes/system_admin.py
+++ b/app/routes/system_admin.py
@@ -864,7 +864,8 @@ def manage_admins():
 def reset_teacher_totp(admin_id):
     """
     V1 LEGACY — only accessible via manage_admins (no nav link).
-    v2 teacher TOTP is owned by User model; recovery uses student-assisted flow.
+    v2 teacher TOTP is owned by User model. Student-assisted teacher recovery
+    (app/routes/recovery.py) is the canonical account recovery method.
     """
     admin = db.get_or_404(Admin, admin_id)
 

--- a/docs/TRACKING/V2_Full_compliance_migration_plan.md
+++ b/docs/TRACKING/V2_Full_compliance_migration_plan.md
@@ -2172,15 +2172,16 @@ Constraint:
    - Test `pg_dump` + `pg_restore` against canonical 44-table schema
    - Document in `docs/operations/Deployment_Guide.md`
 
-2. **Teacher onboarding (replaces v1 invite codes)** — open self-signup flow:
+2. **Teacher onboarding (replaces v1 invite codes)** — planned open self-signup flow:
    - Turnstile-gated registration form: username → setup TOTP → optional passkey → done
-   - `AdminInviteCode` / `teacher_invite_codes` table dropped; `user_invite_tokens` no longer used for teacher gating
-   - On first sign-in, teacher lands on a **class-creation page** (the only page that does not require class context):
+   - `AdminInviteCode` / `teacher_invite_codes` table to be dropped; `user_invite_tokens` no longer used for teacher gating
+   - On first sign-in, teacher to be routed to a **class-creation page** (the only page that does not require class context):
      - Download CSV template → fill → upload to create new class
-     - This is the **only** entry point for new class creation
+     - This will be the **only** entry point for new class creation
      - Creates a new `class_id` with user-supplied `display_name` and `section`
      - `display_name` and `section` are display metadata only, never used as reference keys
      - Duplicate `display_name` / `section` across classes is acceptable — each upload creates a distinct `class_id`
+   - **Status:** Not yet implemented. `AdminInviteCode` and related routes remain in codebase as v1 legacy.
 
 3. **Sysadmin audit** — system admin routes reviewed for DOM-IDEN/DOM-OPS compliance; phantom scope access (INV-ARC-011) eliminated
 

--- a/docs/TRACKING/V2_Full_compliance_migration_plan.md
+++ b/docs/TRACKING/V2_Full_compliance_migration_plan.md
@@ -2172,7 +2172,15 @@ Constraint:
    - Test `pg_dump` + `pg_restore` against canonical 44-table schema
    - Document in `docs/operations/Deployment_Guide.md`
 
-2. **Operator sign-off flow** — teacher onboarding gate using `user_invite_tokens` (from Wave 3)
+2. **Teacher onboarding (replaces v1 invite codes)** — open self-signup flow:
+   - Turnstile-gated registration form: username → setup TOTP → optional passkey → done
+   - `AdminInviteCode` / `teacher_invite_codes` table dropped; `user_invite_tokens` no longer used for teacher gating
+   - On first sign-in, teacher lands on a **class-creation page** (the only page that does not require class context):
+     - Download CSV template → fill → upload to create new class
+     - This is the **only** entry point for new class creation
+     - Creates a new `class_id` with user-supplied `display_name` and `section`
+     - `display_name` and `section` are display metadata only, never used as reference keys
+     - Duplicate `display_name` / `section` across classes is acceptable — each upload creates a distinct `class_id`
 
 3. **Sysadmin audit** — system admin routes reviewed for DOM-IDEN/DOM-OPS compliance; phantom scope access (INV-ARC-011) eliminated
 


### PR DESCRIPTION
## Schema Change Gate Classification

- [x] **NON-MODEL CHANGE** – Comments, TODOs, or docstrings only; no structural model changes

## Summary

- **README corrections**: Fixed 6 inaccurate claims in the most public-facing document, introduced by the previous Copilot documentation audit PR
- **Legacy code tagging**: Marked v1 invite-code and admin management code with deprecation notes
- **Tracking update**: Replaced Wave 11 invite-code onboarding spec with the v2 open teacher signup flow (planned, not yet implemented)

## What changed

### README.md
- **Analytics**: Removed false claims of "CWI analysis" and "system health metrics"; replaced with actual teacher-facing metrics (participation rate, money velocity, spending/hoarding behavior, budget survivability; weekly/monthly views)
- **Student Transfers**: Changed from "Send tokens to other students" (invariant violation — no peer-to-peer transfer exists) to "Move funds between checking and savings accounts"
- **System Admin**: Listed actual nav-accessible features (teacher overview, support tickets, error/event logs, announcements); added v2 direction note about invite-code removal and sysadmin role shift
- **Accessibility**: Added explicit note that axe-core is used for automated testing only; no formal WCAG certification
- **Authority Model link**: Pointed to canonical v2 path (`docs/INVARIANT/CORE/`) instead of root-level legacy copy

### Code tagging (app/models.py, app/routes/system_admin.py)
- `AdminInviteCode` model tagged as v1 legacy with v2 replacement note
- `manage_teachers`, `manage_admins`, `reset_teacher_totp` routes tagged as v1 legacy with v2 replacement context

### Tracking (V2_Full_compliance_migration_plan.md)
- Wave 11 item 2: Replaced "operator sign-off flow using `user_invite_tokens`" with v2 teacher onboarding spec (planned):
  - Turnstile-gated signup form → TOTP setup → optional passkey → done
  - First sign-in routes to class-creation page (only page without class context)
  - Template download → upload creates new `class_id` with `display_name`/`section` as display-only metadata
  - Duplicate `display_name`/`section` acceptable — each upload creates distinct `class_id`
  - Explicitly noted as not yet implemented

## Test plan

- [ ] Verify all README documentation links resolve (no 404s)
- [ ] Verify README feature descriptions match actual product behavior
- [ ] Verify legacy tags in code match docstring format conventions
- [ ] Verify Wave 11 tracking update is consistent with v2 architecture specs

**Note:** Schema gate requires the NON-MODEL CHANGE classification (PR #TBD) to land on codex/v2.0 first. The only change to `app/models.py` is a comment on `AdminInviteCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)