### PR TITLE
fix(deps): bump docs-site @babel/core to 7.29.6

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -275,17 +275,17 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+      "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
+        "@babel/generator": "^7.29.6",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
+        "@babel/helpers": "^7.29.2",
+        "@babel/parser": "^7.29.3",
         "@babel/template": "^7.28.6",
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^19.0.0"
   },
   "overrides": {
+    "@babel/core": "7.29.6",
     "serialize-javascript": ">=7.0.5",
     "uuid": ">=11.1.1"
   }


### PR DESCRIPTION
Separate docs-site security fix for Dependabot alert #31.

Changes:
- add a docs-site override for `@babel/core` 7.29.6
- regenerate `docs-site/package-lock.json`

This keeps the Babel file-read remediation isolated from the js-yaml alert and from the Python dependency bundle.