### PR TITLE
chore: consolidate safe Dependabot updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 
-alembic==1.18.4
+alembic==1.18.5
 beautifulsoup4==4.15.0
 bcrypt==5.0.0
 bleach==6.4.0
 blinker==1.9.0
-click==8.4.1
+click==8.4.2
 exceptiongroup==1.3.1
 Flask==3.1.3
 Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 # Upgraded to 26.5.0 in PR #1203 after comprehensive v2.0 compatibility testing
 gevent==26.5.0
-greenlet==3.5.2
+greenlet==3.5.3
 gunicorn==26.0.0
 iniconfig==2.3.0
 itsdangerous==2.2.0
@@ -49,7 +49,7 @@ Flask-WTF==1.3.0
 python-dotenv==1.2.2
 
 qrcode[pil]==8.2
-APScheduler==3.11.2
+APScheduler==3.11.3
 # TODO: [DEPENDABOT PR #648] Flask-Limiter 4.x introduces breaking changes:
 # - API changes for default_limits and decorator syntax
 # - See https://flask-limiter.readthedocs.io/en/stable/changelog.html
@@ -58,10 +58,10 @@ Flask-Limiter==3.5.0
 redis==7.4.0
 passwordless==2.0.0
 requests==2.34.2
-opentelemetry-api==1.42.1
-opentelemetry-sdk==1.42.1
-opentelemetry-exporter-otlp-proto-http==1.42.1
-opentelemetry-semantic-conventions==0.63b1
-opentelemetry-instrumentation-flask==0.63b1
-opentelemetry-instrumentation-requests==0.63b1
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-api==1.43.0
+opentelemetry-sdk==1.43.0
+opentelemetry-exporter-otlp-proto-http==1.43.0
+opentelemetry-semantic-conventions==0.64b0
+opentelemetry-instrumentation-flask==0.64b0
+opentelemetry-instrumentation-requests==0.64b0
+opentelemetry-instrumentation-sqlalchemy==0.64b0


### PR DESCRIPTION
Consolidates the safe Dependabot updates into one PR against `codex/v2.0`.

Included:
- `alembic` 1.18.4 -> 1.18.5
- `click` 8.4.1 -> 8.4.2
- `greenlet` 3.5.2 -> 3.5.3
- `APScheduler` 3.11.2 -> 3.11.3
- OpenTelemetry packages aligned to `1.43.0` / `0.64b0`

Excluded from this consolidation:
- `redis` 8.0.1
- GitHub Actions major bumps for checkout/cache/configure-pages/deploy-pages/upload-pages-artifact

Validation performed:
- `git diff --check`
- Final diff is `requirements.txt` only.
