### PR TITLE
Update GitHub Pages documentation styling and content

### DIFF
--- a/github-pages/district.html
+++ b/github-pages/district.html
@@ -46,22 +46,21 @@
             <div class="landing-shell">
                 <div class="public-content-card with-toc">
                     <nav class="toc">
-                        <h3>Contents</h3>
+                        <h2>Contents</h2>
                         <ul>
                             <li><a href="#overview">Overview</a></li>
-                            <li><a href="#data-collection">Data collection & storage</a></li>
+                            <li><a href="#data-collection">Data collection &amp; storage</a></li>
                             <li><a href="#class-isolation">Class-level isolation</a></li>
                             <li><a href="#student-claim">Student claiming</a></li>
                             <li><a href="#what-not-collect">What's not collected</a></li>
-                            <li><a href="#data-lifecycle">Data lifecycle & deletion</a></li>
-                            <li><a href="#authentication">Authentication & security</a></li>
+                            <li><a href="#data-lifecycle">Data lifecycle &amp; deletion</a></li>
+                            <li><a href="#authentication">Authentication &amp; security</a></li>
                             <li><a href="#admin-access">Administrative access</a></li>
                             <li><a href="#app-vs-infra">App vs infrastructure</a></li>
                             <li><a href="#sso">Single sign-on (SSO)</a></li>
                             <li><a href="#compliance">Compliance & standards</a></li>
                             <li><a href="#financial-data">Financial data</a></li>
                             <li><a href="#what-not-do">What CTH does not do</a></li>
-                            <li><a href="#self-hosting">Self-hosting</a></li>
                             <li><a href="#contact-info">Contact information</a></li>
                         </ul>
                     </nav>
@@ -184,7 +183,7 @@
                     <section class="public-section" id="sso">
                         <h2>9. Single Sign-On (SSO) and Identity Federation</h2>
                         <p>Classroom Token Hub intentionally does not federate identity through external identity providers (SAML, OpenID Connect, or district SSO). This design choice is made to maintain strict class-level isolation and minimize the collection of personally identifiable information. Because the goal of this application is for teachers to be able to manage their own classroom economy, we intentionally do not integrate external identity providers to truly achieve our ideal model of "we don't know you, we don't need to know you, we don't want to know you."</p>
-                        <p>Districts that require SSO integration may choose to self-host and modify CTH to support their identity provider. The codebase is open-source under PolyForm Noncommercial 1.0.0 and available on GitHub. Please note that Classroom Token Hub project is not responsible for forked projects and any attempt to push changes that do not conform with the project documentation upsteam will be rejected.</p>
+                        <p>Districts that require SSO integration may choose to self-host and modify CTH to support their identity provider. The codebase is open-source under PolyForm Noncommercial 1.0.0 and available on GitHub. Please note that the Classroom Token Hub project is not responsible for forked projects, and any attempt to push changes upstream that do not conform with the project documentation will be rejected.</p>
                     </section>
 
                     <section class="public-section" id="compliance">
@@ -231,7 +230,7 @@
 
                     <section class="public-section" id="contact-info">
                         <h2>Contact Information</h2>
-                        <p>For district partnership, security review questions, or compliance inquiries, please reach out to <a href="mailto:support@classroomtokenhub.com">support@classroomtokenhub.com</a>.</p>
+                        <p>For district partnership or compliance inquiries, please reach out to <a href="mailto:support@classroomtokenhub.com">support@classroomtokenhub.com</a>. For security review questions, please contact <a href="mailto:security@classroomtokenhub.com">security@classroomtokenhub.com</a>.</p>
                     </section>
                     </div>
                 </div>
@@ -258,8 +257,6 @@
                 <p><em>This app is developed, operated, maintained, and self-funded by a full-time high school teacher. As such, we do not display advertisements, use third-party tracking tools, or collect information about you unless it is necessary for the operation of the platform.</em></p>
                 <p><a class="text-decoration-none text-white" href="mailto:support@classroomtokenhub.com">Need help? Reach us at support@classroomtokenhub.com</a></p>
             </div>
-        </div>
-            
         </div>
     </footer>
 

--- a/github-pages/district.html
+++ b/github-pages/district.html
@@ -3,23 +3,273 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Classroom Token Hub - District Assurance Brief">
+    <meta name="description" content="Classroom Token Hub - District Partners">
     <title>District Assurance - Classroom Token Hub</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;700&family=IBM+Plex+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;700&family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <link href="../static/css/tokens.css" rel="stylesheet">
     <link href="./style.css" rel="stylesheet">
-    <style>.floating-back-widget{position:fixed;bottom:2rem;right:2rem;z-index:1000;background-color:var(--secondary-color);color:white;padding:0.75rem 1.25rem;border-radius:50px;box-shadow:var(--shadow-lg);display:inline-flex;align-items:center;gap:0.5rem;text-decoration:none;font-weight:500;transition:transform 0.2s ease,box-shadow 0.2s ease}.floating-back-widget:hover{transform:translateY(-4px);box-shadow:0 15px 25px -5px rgba(0,0,0,0.2);color:white}.floating-back-widget .material-symbols-outlined{font-size:1.5rem}</style>
 </head>
 <body class="landing-page">
-<main>
-<section class="landing-hero"><div class="landing-shell landing-hero-grid"><div class="landing-brand"><div class="landing-brand-row"><span class="material-symbols-outlined" aria-hidden="true">local_atm</span><span>CLASSROOM</span></div><div class="landing-brand-row"><span class="material-symbols-outlined" aria-hidden="true">store</span><span>TOKEN</span></div><div class="landing-brand-row"><span class="material-symbols-outlined" aria-hidden="true">finance_mode</span><span>HUB</span></div></div><div class="landing-welcome"><h1>District Assurance</h1><p>Last Updated: June 16, 2026</p><a href="https://classroomtokenhub.com/student/login" target="_self" class="floating-back-widget"><span class="material-symbols-outlined" aria-hidden="true">arrow_circle_right</span><span>Return to Login Page</span></a></div></div></section>
-<section class="landing-content"><div class="landing-shell"><div class="public-content-card"><section class="public-section"><h2>Overview</h2><p>Thank you for your interest in Classroom Token Hub (CTH).</p><p>Classroom Token Hub is a teacher-developed classroom management system with a simulated economic model, designed with a data-minimization and isolation-first architecture.</p><p>As a 100% teacher-designed, developed, hosted, and maintained platform, we look forward to working with district partners to bring CTH to teachers and students.</p><p>This document is designed to provide an overview of the system's architecture and data protection measures for district review. The content of this document represents the most up-to-date information regarding the system's design and implementation. For more details, please visit our official GitHub repository.</p></section><section class="public-section"><h2>1. Data Collection, Processing, and Storage</h2><p>Classroom Token Hub strives to collect only the minimum data necessary to operate effectively while maintaining a strong teacher and student user experience. Sensitive user-provided information is never stored as plaintext. Where storage in readable form is required for functionality (such as display labels like class sections), the data is treated as non-sensitive, remains strictly scoped to the class, and is not used for identification or cross-system linkage.</p><h3>When a teacher creates a class, they will provide the following information on the roster template:</h3><ul><li>Student First Name: Used for teacher roster display, greetings, and account claiming process</li><li>Student Last Name: Used for teacher roster display, greetings, and account claiming process</li><li>Student Class Section: Used for creating class sections within the roster page</li><li>Additional Notes: Used for internal teacher notes</li></ul><h3>Our server processes the information from the roster template using the following approach:</h3><ul><li>Student First Name and Last Name (temporary): Normalized to remove whitespace, special characters, and accent marks. Hashed using HMAC-SHA256 with a per-record salt and a global pepper before storage. Use as account look up during claim. Removed upon successful claim and account creation.</li><li>Student First Name and Last Name (persistent): Encrypted individually with whitespace, special character, and accent marks preserved before storage. Use as in-app greeting and roster display for teachers.</li><li>Student Class Section: Stored unchanged as a non-sensitive, teacher-defined label and not interpreted, parsed, or used for inference by the system.</li><li>Additional Notes: Encrypted unchanged and stored. Used for teacher internal records</li></ul></section><section class="public-section"><h2>2. Class-Level Data Isolation</h2><p>Each class operates as an independent system defined by a unique class identifier.</p><ul><li>No cross-class visibility or aggregation</li><li>Teachers can only access classes they create</li><li>Identical names across classes are treated as unrelated</li><li>The system does not maintain a global student identity across classes</li></ul></section><section class="public-section"><h2>3. Name Collision Handling</h2><p>When duplicate names exist within a class, a random deduplication code is used during claim.</p><ul><li>Temporary and class-scoped</li><li>No persistent identifiers introduced</li></ul></section><section class="public-section"><h2>4. Optional Teacher Notes</h2><p>Teachers may add notes for internal use.</p><ul><li>Stored as encrypted, unstructured text</li><li>Not parsed or analyzed by the system</li></ul></section><section class="public-section"><h2>5. Data Lifecycle &amp; Deletion</h2><ul><li>Class deletion removes all associated data</li><li>Teacher deletion removes all classes and student data</li><li>180-day inactivity triggers automatic deletion</li><li>No archival or soft-delete exists</li></ul></section><section class="public-section"><h2>6. Administrative Access Model</h2><p>CTH does not provide administrators with a general interface to browse or query data.</p><ul><li>Access is teacher-initiated and class-scoped</li><li>Users are represented by pseudonymous identifiers</li><li>No cross-class inspection or bulk access tools exist</li></ul></section><section class="public-section"><h2>7. Application vs Infrastructure Access</h2><p>Application-level tools do not expose identifiable data. Infrastructure access is restricted to system maintenance and not used for monitoring user activity.</p></section><section class="public-section"><h2>8. Security</h2><ul><li>HTTPS encryption in transit</li><li>Encrypted sensitive data at rest</li><li>Strict class-scoped access controls enforced at the application level</li><li>No administrative interface for browsing or querying student data</li><li>Pseudonymous identifiers used in place of direct identity references</li><li>System architecture prevents cross-class data access by design</li><li>Restricted and audited infrastructure access for maintenance purposes only</li><li>No global admin identity or privileges or superuser capabilties by design</li></ul></section><section class="public-section"><h2>9. Single Sign-On (SSO) and Identity Federation</h2><p>Some district security reviews expect applications to support institution-provided Single Sign-On through SAML 2.0 or OpenID Connect for both student and staff access. Classroom Token Hub intentionally does not federate identity through an external identity provider, and this section explains why - including why doing so would make a breach worse, not better.</p><h3>Why CTH does not federate student identity</h3><p>A database compromise today exposes a display first name, a last initial, a pseudonymous class-scoped identifier, and a simulated currency ledger with no real monetary value - and no email, phone, date of birth, address, or government/district ID, because none of those are collected. There is no resolvable path from that data to a real person. The worst realistic harm is embarrassment-tier, not identity theft or financial fraud.</p><p>SSO protocols work by asserting durable, attributed identity: a SAML assertion or OIDC token typically carries a student's full name, email address, and a persistent district-issued identifier. Accepting those attributes would not just add a new data category - it would attach exactly the kind of real, resolvable identity that keeps a worst-case breach low-severity today. A compromise of a federated dataset stops being "a list of first names with no external reference" and becomes "this specific, real, named child." Adopting SSO would increase the severity of a breach, not reduce it.</p><p>The display name itself is also weaker than typical PII for a separate reason: it is teacher-entered, free-text, and unverified. A teacher provides each student's first name and last initial when building the roster, solely so the student can recognize and claim their own seat - the system does not validate this against any legal name or system of record. That is a different starting point than a SAML/OIDC assertion, which is by definition sourced from and verified against the institution's own records. And outside of direct database access, the only person who can ever see a decrypted student name is that student's own teacher - students cannot see other students' names, and system administrators have no interface that decrypts or displays them.</p><p>Federated identity also introduces a single shared point of access across every classroom that trusts the identity provider. CTH's class-scoped model keeps a compromised credential or misconfiguration contained to one class; a compromised or misconfigured federated identity provider would not have the benefit of that containment, since it authenticates broadly across the whole institution by design.</p><h3>Alignment with recognized security frameworks</h3><p>Frameworks such as the NIST Cybersecurity Framework's Identity Management, Authentication, and Access Control category call for managed credentials and access scoped to assessed risk - they describe an outcome, not a specific protocol, and they're explicit that controls should be commensurate with risk. A blanket SSO requirement would move beyond that principle by making the lowest-risk path for this application more sensitive than necessary.</p></section><section class="public-section"><h2>10. Compliance and Standards</h2><h3>FERPA</h3><p>Classroom Token Hub is designed to support school-administered educational records in a class-scoped environment.</p><h3>COPPA (School Consent Model)</h3><p>Classroom Token Hub is intended for use by teachers acting on behalf of their classes under the school consent model.</p><h3>Accessibility (WCAG)</h3><p>The application follows accessibility principles and aims to meet WCAG 2.1 Level AA wherever practical.</p></section><section class="public-section"><h2>11. What CTH Does Not Do</h2><ul><li>No advertising or data selling</li><li>No third-party analytics</li><li>No behavioral profiling</li><li>No cross-class tracking</li><li>No integration with external identity systems (e.g., SSO)</li><li>No archival or long-term data retention beyond active class lifecycle</li></ul></section><section class="public-section"><p>District partners may choose to create a self-hosted fork of the project to meet specific infrastructure or compliance requirements.</p></section></div></div></section>
-</main>
-<footer class="landing-footer"><div class="landing-shell landing-footer-grid"><div class="landing-footer-links"><a href="https://github.com/timwonderer/classroom-economy" target="_blank" rel="noopener">Project Repository</a><a href="https://github.com/timwonderer/classroom-economy/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></div><div class="landing-footer-links"><a href="https://github.com/timwonderer/classroom-economy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a><a href="https://polyformproject.org/licenses/noncommercial/1.0.0" target="_blank" rel="noopener">License</a></div><div class="landing-footer-meta"><p>&copy; <span id="current-year"></span> Classroom Token Hub. Licensed under PolyForm Noncommercial v1.0.0</p><p><em>This app is developed, operated, maintained, and self-funded by a full-time high school teacher. As such, we do not display advertisements, use third-party tracking tools, or collect information about you unless it is necessary for the operation of the platform.</em></p><p><a class="text-decoration-none text-white" href="mailto:support@classroomtokenhub.com">Need help? Reach us at support@classroomtokenhub.com</a></p></div></div></footer><script>(function(){var yearElement=document.getElementById("current-year");if(yearElement){yearElement.textContent=new Date().getFullYear();}})();</script>
+    <main>
+        <section class="landing-hero">
+            <div class="landing-shell landing-hero-grid">
+                <div class="landing-brand">
+                    <div class="landing-brand-row">
+                        <span class="material-symbols-outlined" aria-hidden="true">local_atm</span>
+                        <span>CLASSROOM</span>
+                    </div>
+                    <div class="landing-brand-row">
+                        <span class="material-symbols-outlined" aria-hidden="true">store</span>
+                        <span>TOKEN</span>
+                    </div>
+                    <div class="landing-brand-row">
+                        <span class="material-symbols-outlined" aria-hidden="true">finance_mode</span>
+                        <span>HUB</span>
+                    </div>
+                </div>
+                <div class="landing-welcome">
+                    <h1>For District Partners</h1>
+                    <small>Last Updated: July 31, 2026</small>
+                    <a href="https://classroomtokenhub.com/student/login" target="_self" class="floating-back-widget">
+                        <span class="material-symbols-outlined" aria-hidden="true">arrow_circle_right</span>
+                        <span>Return to Login Page</span>
+                    </a> 
+                </div>
+            </div>
+        </section>
+
+        <section class="landing-content">
+            <div class="landing-shell">
+                <div class="public-content-card with-toc">
+                    <nav class="toc">
+                        <h3>Contents</h3>
+                        <ul>
+                            <li><a href="#overview">Overview</a></li>
+                            <li><a href="#data-collection">Data collection & storage</a></li>
+                            <li><a href="#class-isolation">Class-level isolation</a></li>
+                            <li><a href="#student-claim">Student claiming</a></li>
+                            <li><a href="#what-not-collect">What's not collected</a></li>
+                            <li><a href="#data-lifecycle">Data lifecycle & deletion</a></li>
+                            <li><a href="#authentication">Authentication & security</a></li>
+                            <li><a href="#admin-access">Administrative access</a></li>
+                            <li><a href="#app-vs-infra">App vs infrastructure</a></li>
+                            <li><a href="#sso">Single sign-on (SSO)</a></li>
+                            <li><a href="#compliance">Compliance & standards</a></li>
+                            <li><a href="#financial-data">Financial data</a></li>
+                            <li><a href="#what-not-do">What CTH does not do</a></li>
+                            <li><a href="#self-hosting">Self-hosting</a></li>
+                            <li><a href="#contact-info">Contact information</a></li>
+                        </ul>
+                    </nav>
+                    <div>
+                    <section class="public-section" id="overview">
+                        <h2>Overview</h2>
+                        <p>Thank you for your interest in Classroom Token Hub (CTH).</p>
+                        <p>Classroom Token Hub is a teacher-developed classroom management system with a simulated economic model, designed with a data-minimization and class-isolation-first architecture.</p>
+                        <p>As a 100% teacher-designed, developed, hosted, and maintained platform, we look forward to working with district partners to bring CTH to teachers and students.</p>
+                        <p>This document is designed to provide an overview of the system's architecture and data protection measures for district review. The content of this document represents the most up-to-date information regarding the system's design and implementation.</p>
+                        <p>For more details, please visit our official GitHub repository or see the full <a href="./privacy.html">Privacy &amp; Data Handling</a> policy.</p>
+                        <p>For questions about our security and privacy implementation, please contact us at <a href="mailto:security@classroomtokenhub.com">security@classroomtokenhub.com</a>.</p>
+                    </section>
+
+                    <section class="public-section" id="data-collection">
+                        <h2>1. Data Collection, Processing, and Storage</h2>
+                        <p>Classroom Token Hub strives to collect only the minimum data necessary to operate effectively while maintaining a strong teacher and student user experience. Sensitive user-provided information is never stored as plaintext. Where storage in readable form is required for functionality (such as display labels like student names), the data is treated as sensitive, encrypted, and remains strictly scoped to the class.</p>
+
+                        <h3>When a teacher creates a class, they will provide:</h3>
+                        <ul>
+                            <li>Teacher display name (for app interface)</li>
+                            <li>Class name/period identifier</li>
+                        </ul>
+
+                        <h3>When a teacher adds students to a class, they will provide:</h3>
+                        <ul>
+                            <li>Student first name: Used for teacher roster display and student account claiming</li>
+                            <li>Student last initial: Used for teacher roster display and student account claiming</li>
+                            <li>Optional notes: Encrypted and stored for teacher internal records only</li>
+                        </ul>
+
+                        <h3>Our server processes the information using the following approach:</h3>
+                        <ul>
+                            <li><strong>Student Names (claim hashes)</strong>: Normalized to remove whitespace, special characters, and accent marks. Hashed using HMAC-SHA256 with per-record salt and global pepper. Used for secure student account claiming only. Deleted from claim state after successful account creation.</li>
+                            <li><strong>Student Names (display)</strong>: Encrypted individually with whitespace and special characters preserved. Used only for teacher roster display within their class. Never transmitted to students or third parties. Decryption key never leaves the application.</li>
+                            <li><strong>Student Notes</strong>: Encrypted and stored. Used for teacher internal records only. Never displayed to students or other teachers.</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="class-isolation">
+                        <h2>2. Class-Level Data Isolation</h2>
+                        <p>Each class operates as an independent system defined by a unique internal class identifier (class_id). The join code is a public-facing alias that students use to enter a class, but all internal scoping is performed by class_id.</p>
+                        <ul>
+                            <li>No cross-class visibility or aggregation</li>
+                            <li>Teachers can only access classes they create</li>
+                            <li>Identical names across classes are treated as unrelated</li>
+                            <li>The system does not maintain global student identity across classes</li>
+                            <li>All financial, attendance, and activity data is strictly class-scoped</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="student-claim">
+                        <h2>3. Student Account Claiming Process</h2>
+                        <p>When a student claims their account:</p>
+                        <ul>
+                            <li>Student enters their first name and last initial (as provided by teacher)</li>
+                            <li>System computes hashes and matches to class roster</li>
+                            <li>If unique match: student proceeds to create PIN and passphrase</li>
+                            <li>If duplicate match: student receives a random deduplication code to distinguish from other students with same name</li>
+                            <li>After successful claim completion, claim hashes are deleted from the system</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="what-not-collect">
+                        <h2>4. What Data Is NOT Collected</h2>
+                        <ul>
+                            <li>Date of birth</li>
+                            <li>Student ID numbers</li>
+                            <li>Email addresses (for students)</li>
+                            <li>Phone numbers</li>
+                            <li>Physical addresses</li>
+                            <li>Parent/guardian information</li>
+                            <li>Government IDs or identifiers</li>
+                            <li>Behavioral or disciplinary records</li>
+                            <li>Grades or academic performance data</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="data-lifecycle">
+                        <h2>5. Data Lifecycle &amp; Deletion</h2>
+                        <ul>
+                            <li>Class deletion removes all associated data (student records, transactions, activity logs)</li>
+                            <li>Teacher deletion removes all classes and student data owned by that teacher</li>
+                            <li>Individual student account deletion removes that student's data and history from the class</li>
+                            <li>180-day inactivity on a class triggers automatic deletion</li>
+                            <li>No archival or soft-delete exists; deleted data cannot be recovered</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="authentication">
+                        <h2>6. Authentication and Security</h2>
+                        <ul>
+                            <li><strong>Teacher Authentication</strong>: Email and password (bcrypt hashed with salt and pepper). Optional 2FA via TOTP (time-based one-time password).</li>
+                            <li><strong>Student Authentication</strong>: PIN (4-6 digits, bcrypt hashed) and passphrase (for high-stakes actions only).</li>
+                            <li><strong>Account Recovery</strong>: Teachers can generate recovery codes for students. Recovery uses only join code and recovery code—no PII required. Passphrases are always required for high-stakes financial transactions.</li>
+                            <li><strong>Encryption in Transit</strong>: All data uses HTTPS/TLS encryption</li>
+                            <li><strong>Encryption at Rest</strong>: Student names and notes are encrypted using AES-128</li>
+                            <li><strong>Session Management</strong>: HTTP-only cookies with automatic timeout after inactivity</li>
+                            <li><strong>CSRF Protection</strong>: All forms include CSRF tokens</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="admin-access">
+                        <h2>7. Administrative Access Model</h2>
+                        <p>CTH does not provide a general "super admin" interface to browse or query student data across classes or teachers.</p>
+                        <ul>
+                            <li>Teachers access only their own classes</li>
+                            <li>System maintenance uses database-level access only (never application-level browsing)</li>
+                            <li>Student names and sensitive fields are encrypted; infrastructure access does not decrypt them</li>
+                            <li>No cross-class inspection or bulk export tools exist</li>
+                            <li>Users are represented by pseudonymous identifiers in logs and reports</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="app-vs-infra">
+                        <h2>8. Application vs. Infrastructure Access</h2>
+                        <p>Application-level tools do not expose identifiable data. Infrastructure access is restricted to system maintenance only and does not have decryption keys for sensitive fields.</p>
+                    </section>
+
+                    <section class="public-section" id="sso">
+                        <h2>9. Single Sign-On (SSO) and Identity Federation</h2>
+                        <p>Classroom Token Hub intentionally does not federate identity through external identity providers (SAML, OpenID Connect, or district SSO). This design choice is made to maintain strict class-level isolation and minimize the collection of personally identifiable information. Because the goal of this application is for teachers to be able to manage their own classroom economy, we intentionally do not integrate external identity providers to truly achieve our ideal model of "we don't know you, we don't need to know you, we don't want to know you."</p>
+                        <p>Districts that require SSO integration may choose to self-host and modify CTH to support their identity provider. The codebase is open-source under PolyForm Noncommercial 1.0.0 and available on GitHub. Please note that Classroom Token Hub project is not responsible for forked projects and any attempt to push changes that do not conform with the project documentation upsteam will be rejected.</p>
+                    </section>
+
+                    <section class="public-section" id="compliance">
+                        <h2>10. Compliance and Standards</h2>
+
+                        <h3>FERPA (Family Educational Rights and Privacy Act)</h3>
+                        <p>Classroom Token Hub is designed to support school-administered educational records in a class-scoped environment. Teachers control access to their class data, and the system does not share student information with external parties.</p>
+
+                        <h3>COPPA (Children's Online Privacy Protection Act)</h3>
+                        <p>Classroom Token Hub is intended for use by teachers acting on behalf of their classes under the school consent model. Parental consent is managed through school and district policies, not directly by CTH.</p>
+
+                        <h3>State Privacy Laws (CCPA, FERPA-adjacent state laws)</h3>
+                        <p>CTH is designed to minimize data collection and retention, supporting compliance with state-level privacy requirements. No data is sold, shared with third parties, or used for purposes beyond classroom operation.</p>
+
+                        <h3>Accessibility (WCAG)</h3>
+                        <p>The application follows accessibility principles and aims to meet WCAG 2.1 Level AA wherever practical.</p>
+                    </section>
+
+                    <section class="public-section" id="financial-data">
+                        <h2>11. Financial Data and Economic Activity</h2>
+                        <ul>
+                            <li>Transaction history is stored class-scoped and tied to student seats (not names)</li>
+                            <li>Account balances are calculated from transaction history</li>
+                            <li>All financial operations require encryption at rest</li>
+                            <li>Simulated currency has no real monetary value</li>
+                            <li>No integration with real payment systems or banks</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="what-not-do">
+                        <h2>12. What CTH Does Not Do</h2>
+                        <ul>
+                            <li>No advertising or data selling</li>
+                            <li>No third-party analytics or tracking</li>
+                            <li>No behavioral profiling or data mining</li>
+                            <li>No cross-class tracking or aggregation</li>
+                            <li>No integration with external identity systems (SSO) by default</li>
+                            <li>No long-term data retention beyond active class lifecycle</li>
+                            <li>No integration with government or district ID systems</li>
+                        </ul>
+                    </section>
+
+                   
+
+                    <section class="public-section" id="contact-info">
+                        <h2>Contact Information</h2>
+                        <p>For district partnership, security review questions, or compliance inquiries, please reach out to <a href="mailto:support@classroomtokenhub.com">support@classroomtokenhub.com</a>.</p>
+                    </section>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="landing-footer">
+        <div class="landing-shell landing-footer-grid">
+            <div class="landing-footer-links">
+                <a href="https://github.com/timwonderer/classroom-economy" target="_blank" rel="noopener">Project Repository</a>
+                <a href="https://github.com/timwonderer/classroom-economy/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
+            </div>
+            <div class="landing-footer-links">
+                <a href="./terms.html" target="_self">Terms of Service</a>
+                <a href="./privacy.html" target="_self">Privacy Policy</a>
+            </div>
+            <div class="landing-footer-links">
+                <a href="https://github.com/timwonderer/classroom-economy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+                <a href="https://polyformproject.org/licenses/noncommercial/1.0.0" target="_blank" rel="noopener">License</a>
+            </div>
+            <div class="landing-footer-meta">
+                <p>&copy; <span id="current-year"></span> Classroom Token Hub. Licensed under PolyForm Noncommercial v1.0.0</p>
+                <p><em>This app is developed, operated, maintained, and self-funded by a full-time high school teacher. As such, we do not display advertisements, use third-party tracking tools, or collect information about you unless it is necessary for the operation of the platform.</em></p>
+                <p><a class="text-decoration-none text-white" href="mailto:support@classroomtokenhub.com">Need help? Reach us at support@classroomtokenhub.com</a></p>
+            </div>
+        </div>
+            
+        </div>
+    </footer>
+
+    <script>
+        (function () {
+            var yearElement = document.getElementById("current-year");
+            if (yearElement) {
+                yearElement.textContent = new Date().getFullYear();
+            }
+        })();
+    </script>
 </body>
 </html>

--- a/github-pages/learnmore.html
+++ b/github-pages/learnmore.html
@@ -8,200 +8,10 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;700&family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <link href="../static/css/tokens.css" rel="stylesheet">
     <link href="./style.css" rel="stylesheet">
-    <style>
-        .v2-feature-list {
-            list-style: none;
-            padding: 0;
-            margin: 0;
-            display: grid;
-            gap: 2rem;
-            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-        }
-        .v2-feature-card {
-            background-color: var(--surface);
-            padding: 2.25rem;
-            border-radius: 2px;
-            box-shadow: var(--shadow);
-            border-top: 6px solid var(--secondary-color);
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-
-        .v2-feature-card .material-symbols-outlined {
-            color: var(--primary);
-            font-size: 2.5rem;
-            margin-bottom: 1.25rem;
-        }
-        .v2-feature-card h3 {
-            color: var(--text-primary);
-            font-size: 1.35rem;
-            margin-bottom: 0.85rem;
-            font-weight: 600;
-        }
-        .v2-feature-card p {
-            color: var(--text-secondary);
-            font-size: 1.05rem;
-            line-height: 1.6;
-            margin: 0 0 0.5rem 0;
-        }
-        .v2-feature-card .dev-note {
-            font-size: 0.9rem;
-            color: var(--text-light);
-            font-style: italic;
-            border-top: 1px solid var(--border-subtle);
-            padding-top: 0.5rem;
-            margin-top: 0.5rem;
-        }
-        .philosophy-section {
-            margin-bottom: 4.5rem;
-        }
-        .philosophy-heading {
-            color: var(--guardian-gray);
-            font-size: 2.25rem;
-            margin-bottom: 1rem;
-            font-weight: 600;
-            border-bottom: 2px solid var(--border-subtle);
-            
-        }
-        .philosophy-text p {
-            font-size: 1.15rem;
-            color: var(--text-primary);
-            line-height: 1.75;
-            margin-bottom: 1.5rem;
-        }
-        .v2-badge {
-            background-color: var(--secondary-color);
-            color: var(--secondary-text);
-            padding: 0.25rem 0.75rem;
-            border-radius: var(--radius-full);
-            font-size: 0.9rem;
-            font-weight: 600;
-            margin-left: 0.75rem;
-            vertical-align: middle;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-        .tab-container {
-            margin-top: 1.5rem;
-        }
-        .tab-buttons {
-            display: flex;
-            gap: 1rem;
-            margin-bottom: 2rem;
-            border-bottom: 2px solid var(--border-subtle);
-        }
-        .tab-btn {
-            background: transparent;
-            border: none;
-            font-size: 1.25rem;
-            font-weight: 400;
-            color: var(--text-secondary);
-            padding: 0.75rem 1.5rem;
-            cursor: pointer;
-            position: relative;
-            transition: color 0.2s;
-            font-family: inherit;
-        }
-        .tab-btn#student-tab:hover {
-            background-color: var(--steward-blue);
-            color: white;
-        }
-
-        .tab-btn#teacher-tab:hover {
-            background-color: var(--advisor-green);
-            color: white;
-        }
-        .tab-btn#teacher-tab.active {
-            background-color: var(--advisor-green);
-            color: white;
-        }
-        .tab-btn#teacher-tab.active::after {
-            content: '';
-            position: absolute;
-            bottom: -2px;
-            left: 0;
-            width: 100%;
-            height: 4px;
-            background-color: var(--advisor-green);
-            border-radius: 4px 4px 0 0;
-        }
-        .tab-btn#student-tab.active {
-            background-color: var(--steward-blue);
-            color: white;
-        }
-        .tab-btn#student-tab.active::after {
-            content: '';
-            position: absolute;
-            bottom: -2px;
-            left: 0;
-            width: 100%;
-            height: 4px;
-            background-color: var(--steward-blue);
-            border-radius: 4px 4px 0 0;
-        }
-        
-        #teacher-features .v2-feature-card {
-            border-top-color: var(--advisor-green);
-        }
-        #teacher-features .v2-feature-card .material-symbols-outlined {
-            color: var(--advisor-green);
-        }
-        
-        #student-features .v2-feature-card {
-            border-top-color: var(--steward-blue);
-        }
-        #student-features .v2-feature-card .material-symbols-outlined {
-            color: var(--steward-blue);
-        }
-
-        .tab-content {
-            display: none;
-            animation: fadeIn 0.3s ease-in-out;
-        }
-        .tab-content.active {
-            display: block;
-        }
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(5px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-        .v2-feature-list.grid-2x2 {
-            grid-template-columns: repeat(2, 1fr);
-        }
-        @media (max-width: 768px) {
-            .v2-feature-list.grid-2x2 {
-                grid-template-columns: 1fr;
-            }
-        }
-        .floating-back-widget {
-            position: fixed;
-            bottom: 2rem;
-            right: 2rem;
-            z-index: 1000;
-            background-color: var(--secondary-color);
-            color: white;
-            padding: 0.75rem 1.25rem;
-            border-radius: 50px;
-            box-shadow: var(--shadow-lg);
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-            text-decoration: none;
-            font-weight: 500;
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-        .floating-back-widget:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 15px 25px -5px rgba(0, 0, 0, 0.2);
-            color: white;
-        }
-        .floating-back-widget .material-symbols-outlined {
-            font-size: 1.5rem;
-        }
-    </style>
 </head>
 <body class="landing-page">
     <main>
@@ -471,6 +281,11 @@
             <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy" target="_blank" rel="noopener">Project Repository</a>
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
+            </div>
+            <div class="landing-footer-links">
+                <a href="./terms.html" target="_self">Terms of Service</a>
+                <a href="./privacy.html" target="_self">Privacy Policy</a>
+                <a href="./district.html" target="_self">District Assurance</a>
             </div>
             <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>

--- a/github-pages/privacy.html
+++ b/github-pages/privacy.html
@@ -46,15 +46,15 @@
             <div class="landing-shell">
                 <div class="public-content-card with-toc">
                     <nav class="toc">
-                        <h3>Contents</h3>
+                        <h2>Contents</h2>
                         <ul>
                             <li><a href="#purpose">Purpose</a></li>
                             <li><a href="#what-you-provide">What you must provide</a></li>
                             <li><a href="#what-we-collect">What we collect</a></li>
                             <li><a href="#how-we-use">How we use your data</a></li>
                             <li><a href="#activity-data">Educational activity data</a></li>
-                            <li><a href="#data-minimization">Data minimization & retention</a></li>
-                            <li><a href="#encryption">Encryption & storage</a></li>
+                            <li><a href="#data-minimization">Data minimization &amp; retention</a></li>
+                            <li><a href="#encryption">Encryption &amp; storage</a></li>
                             <li><a href="#recovery">Account recovery</a></li>
                             <li><a href="#isolation">Class-level isolation</a></li>
                             <li><a href="#logging">Error logging & monitoring</a></li>
@@ -66,8 +66,8 @@
 
                     <section class="public-section" id="purpose">
                         <h2>Purpose</h2>
-                        <p>This document explains the type of data you will provide in order to use this application, ways we handle and process the data you have provided, and steps we have taken to protect your data and privacy. The information contained in this document represents the most up-to-date version of this application and supercedes all previous versions unless otherwise noted.</p>
-                        <p>If you are reviewing Classroom Token Hub for a school or district, see the <a href="./district.html">For District Partners</a> for a district-focused summary of the system.</p>
+                        <p>This document explains the type of data you will provide in order to use this application, ways we handle and process the data you have provided, and steps we have taken to protect your data and privacy. The information contained in this document represents the most up-to-date version of this application and supersedes all previous versions unless otherwise noted.</p>
+                        <p>If you are reviewing Classroom Token Hub for a school or district, see the <a href="./district.html">District Assurance</a> page for a district-focused summary of the system.</p>
                         <p>If you are a student, your teacher has chosen this application on behalf of your class to facilitate classroom activities. If you and/or your families have any questions or concerns, please talk to your teacher.</p>
                     </section>
 
@@ -81,7 +81,7 @@
                         </ul>
 
                         <h3>If you are a student user</h3>
-                        <p>Your teacher has provided these information on your behalf to create your account:</p>
+                        <p>Your teacher has provided this information on your behalf to create your account:</p>
                         <ul>
                             <li><strong>First Name</strong>: Used for account claiming and friendly greetings during the classroom activity.</li>
                             <li><strong>Last Initial</strong>: Used for account claiming and roster display for your teacher.</li>
@@ -98,7 +98,7 @@
                     <section class="public-section" id="what-we-collect">
                         <h2>What we collect</h2>
                         <p><strong>For students:</strong> Only the first name, last initial, class identifier, section identifier (if used), and optional teacher notes that the teacher provides on the roster.</p>
-                        <p><strong>For teachers:</strong> Only the display name you choose for yourself within each class.</p>
+                        <p><strong>For teachers:</strong> The email address used for your account login, and the display name you choose for yourself within each class.</p>
                         <p>As a self-funded, developed, and operated platform, we do not use trackers or display any ads to you. Classroom Token Hub does not sell your information to a third party.</p>
                     </section>
 
@@ -140,7 +140,7 @@
 
                     <section class="public-section" id="recovery">
                         <h2>Account Recovery</h2>
-                        <p>If you lose access to your account, your teacher can issue a recovery reset code. The recovery process uses only your class join code and the reset code — no personal information such as your name is required or transmitted during recovery, as this data is not retained in recoverable form after account setup.</p>
+                        <p>If you lose access to your account, your teacher can issue a recovery code. The recovery process uses only your class join code and the recovery code — no personal information such as your name is required or transmitted during recovery, as this data is not retained in recoverable form after account setup.</p>
                     </section>
 
                     <section class="public-section" id="isolation">
@@ -189,7 +189,7 @@
             </div>
             <div class="landing-footer-links">
                 <a href="./terms.html" target="_self">Terms of Service</a>
-                <a href="./district.html" target="_self">District Partners</a>
+                <a href="./district.html" target="_self">District Assurance</a>
             </div>
             <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>

--- a/github-pages/privacy.html
+++ b/github-pages/privacy.html
@@ -8,7 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;700&family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <link href="../static/css/tokens.css" rel="stylesheet">
     <link href="./style.css" rel="stylesheet">
@@ -32,8 +32,8 @@
                     </div>
                 </div>
                 <div class="landing-welcome">
-                    <h1>Privacy &amp; Data Handling</h1>
-                    <p>Last Updated: February 25, 2026</p>
+                    <h1>Privacy &amp; Data Handling Policies</h1>
+                    <small>Last Updated: July 31, 2026</small>
                     <a href="https://classroomtokenhub.com/student/login" target="_self" class="floating-back-widget">
                         <span class="material-symbols-outlined" aria-hidden="true">arrow_circle_right</span>
                         <span>Return to Login Page</span>
@@ -44,87 +44,138 @@
 
         <section class="landing-content">
             <div class="landing-shell">
-                <div class="public-content-card">
-                    <section class="public-section">
+                <div class="public-content-card with-toc">
+                    <nav class="toc">
+                        <h3>Contents</h3>
+                        <ul>
+                            <li><a href="#purpose">Purpose</a></li>
+                            <li><a href="#what-you-provide">What you must provide</a></li>
+                            <li><a href="#what-we-collect">What we collect</a></li>
+                            <li><a href="#how-we-use">How we use your data</a></li>
+                            <li><a href="#activity-data">Educational activity data</a></li>
+                            <li><a href="#data-minimization">Data minimization & retention</a></li>
+                            <li><a href="#encryption">Encryption & storage</a></li>
+                            <li><a href="#recovery">Account recovery</a></li>
+                            <li><a href="#isolation">Class-level isolation</a></li>
+                            <li><a href="#logging">Error logging & monitoring</a></li>
+                            <li><a href="#what-not">What CTH does not do</a></li>
+                            <li><a href="#contact">Contact information</a></li>
+                        </ul>
+                    </nav>
+                    <div>
+
+                    <section class="public-section" id="purpose">
                         <h2>Purpose</h2>
                         <p>This document explains the type of data you will provide in order to use this application, ways we handle and process the data you have provided, and steps we have taken to protect your data and privacy. The information contained in this document represents the most up-to-date version of this application and supercedes all previous versions unless otherwise noted.</p>
-                        <p>If you are reviewing Classroom Token Hub for a school or district, see the <a href="./district.html">District Assurance Brief</a> for a district-focused summary of the system.</p>
+                        <p>If you are reviewing Classroom Token Hub for a school or district, see the <a href="./district.html">For District Partners</a> for a district-focused summary of the system.</p>
                         <p>If you are a student, your teacher has chosen this application on behalf of your class to facilitate classroom activities. If you and/or your families have any questions or concerns, please talk to your teacher.</p>
                     </section>
 
-                    <section class="public-section">
+                    <section class="public-section" id="what-you-provide">
                         <h2>What you must provide to use this application</h2>
+
                         <h3>If you are a teacher user</h3>
                         <ul>
-                            <li><strong>Date of Birth</strong>: Used for identity verification in account recovery.</li>
                             <li><strong>Personalized Display Name</strong>: For friendly identification in the user interface.</li>
-                            <li><strong>Class Block</strong>: To group students by class period and apply block-specific configurations.</li>
-                            <li><strong>Class Identifier</strong>: Friendly name for the class you are managing.</li>
+                            <li><strong>Class Identifier</strong>: A descriptive name for each class you manage (e.g., "Period 3 Economics").</li>
                         </ul>
 
                         <h3>If you are a student user</h3>
                         <p>Your teacher has provided these information on your behalf to create your account:</p>
                         <ul>
-                            <li><strong>Date of Birth</strong>: Used once for identity verification during account setup only.</li>
-                            <li><strong>First Name</strong>: For account claim and friendly greetings</li>
-                            <li><strong>Last Name</strong>: Stored as a one-way hash for account claim only.</li>
-                            <li><strong>Class Block</strong>: To place you in the correct class</li>
-                            <li><strong>Class Identifier</strong>: An easy to understand name for your class</li>
+                            <li><strong>First Name</strong>: Used for account claiming and friendly greetings during the classroom activity.</li>
+                            <li><strong>Last Initial</strong>: Used for account claiming and roster display for your teacher.</li>
+                            <li><strong>Class Assignment</strong>: To place you in the correct class section.</li>
                         </ul>
 
-                        <h3>Additional account info</h3>
+                        <h3>Additional account security information</h3>
                         <ul>
-                            <li><strong>Theme Word</strong>: A unique word that you associate with yourself; used to generate your login username.</li>
-                            <li><strong>PIN</strong>: A four- to six-digit code for logging into your account.</li>
-                            <li><strong>Passphrase</strong>: A secret phrase used for multi-factor authentication and high-stakes actions.</li>
+                            <li><strong>PIN (4-6 digits)</strong>: A personal identification number you create for login security.</li>
+                            <li><strong>Passphrase</strong>: A secret phrase you create for protecting high-stakes account actions like account recovery.</li>
                         </ul>
                     </section>
 
-                    <section class="public-section">
+                    <section class="public-section" id="what-we-collect">
+                        <h2>What we collect</h2>
+                        <p><strong>For students:</strong> Only the first name, last initial, class identifier, section identifier (if used), and optional teacher notes that the teacher provides on the roster.</p>
+                        <p><strong>For teachers:</strong> Only the display name you choose for yourself within each class.</p>
+                        <p>As a self-funded, developed, and operated platform, we do not use trackers or display any ads to you. Classroom Token Hub does not sell your information to a third party.</p>
+                    </section>
+
+                    <section class="public-section" id="how-we-use">
                         <h2>How We Use Your Data</h2>
                         <ul>
                             <li>Support the simulation of real-world banking, employment, and budgeting to teach financial literacy.</li>
-                            <li>Track attendance, transactions, and account balances to power classroom activities.</li>
-                            <li>Generate reports to help teachers monitor student progress and improve educational outcomes.</li>
+                            <li>Track participation and account balances to power classroom activities.</li>
                             <li>Authenticate users and protect accounts from unauthorized access.</li>
+                            <li>Enable teachers to create, restore, and manage student accounts within their classes.</li>
                         </ul>
                     </section>
 
-                    <section class="public-section">
+                    <section class="public-section" id="activity-data">
                         <h2>Educational Activity Data</h2>
-                        <p class="small">These data are generated, collected, and stored to facilitate the functioning of the classroom economy simulation and contains no personally identifiable information.</p>
+                        <p class="small">These data are generated, collected, and stored to facilitate the functioning of the classroom economy simulation and contain no personally identifiable information.</p>
                         <ul>
-                            <li><strong>Attendance Records</strong>: Tap-in/out timestamps and calculated active/inactive minutes.</li>
-                            <li><strong>Account Balances</strong>: Checking and savings balances, updated dynamically from transaction history.</li>
-                            <li><strong>Transaction History</strong>: Detailed records of bonuses, payroll, rent, property tax, insurance premiums, non-sufficient funds fees, and store purchases.</li>
-                            <li><strong>Monthly Billing Settings</strong>: Configured recurring charges for each student.</li>
+                            <li><strong>Attendance Records</strong>: Tap-in/out timestamps and calculated active/inactive duration.</li>
+                            <li><strong>Account Balances</strong>: Checking and savings balances, updated from transaction history.</li>
+                            <li><strong>Transaction History</strong>: Records of bonuses, payroll, rent, expenses, and store purchases.</li>
+                            <li><strong>Class Settings</strong>: Payroll rates, rent amounts, economic policies, and other classroom configuration options.</li>
                         </ul>
                     </section>
 
-                    <section class="public-section">
+                    <section class="public-section" id="data-minimization">
                         <h2>Data Minimization &amp; Retention</h2>
-                        <p>We collect only the data necessary to support classroom activities and educational objectives.</p>
+                        <p>We collect only the data necessary to support classroom activities and educational objectives. Student names are encrypted at rest and are visible only to their teacher. When a class ends or is deleted, all associated student data is permanently removed from our system.</p>
                     </section>
 
-                    <section class="public-section">
-                        <h2>Security Measures</h2>
+                    <section class="public-section" id="encryption">
+                        <h2>Data Encryption &amp; Storage</h2>
                         <ul>
-                            <li><strong>Encryption at Rest</strong>: All sensitive data is encrypted at rest to protect it from unauthorized access.</li>
-                            <li><strong>State-of-the-Art Hashing</strong>: Passwords and PINs are hashed using Argon2, and other sensitive identifiers are hashed using HMAC-SHA256.</li>
-                            <li><strong>Encrypted Transit</strong>: All data transmitted between your device and our servers is protected using HTTPS/TLS.</li>
-                            <li><strong>Secure Session Management</strong>: The application enforces idle timeouts and avoids persistent cookies.</li>
+                            <li><strong>Encryption at Rest</strong>: All sensitive data (names, notes) is encrypted using industry-standard AES encryption before storage in our database.</li>
+                            <li><strong>Secure Hashing</strong>: PINs and passphrases are hashed using bcrypt with additional peppered security, making them impossible to decrypt even if our database were compromised.</li>
+                            <li><strong>Encrypted Transit</strong>: All data transmitted between your device and our servers is protected using HTTPS/TLS encryption.</li>
+                            <li><strong>Secure Session Management</strong>: The application enforces session timeouts and uses secure, HTTP-only cookies.</li>
                         </ul>
                     </section>
 
-                    <section class="public-section">
-                        <h2>Error Logging &amp; Monitoring</h2>
-                        <p>To maintain system reliability and quickly resolve technical issues, our application automatically logs errors and technical failures.</p>
+                    <section class="public-section" id="recovery">
+                        <h2>Account Recovery</h2>
+                        <p>If you lose access to your account, your teacher can issue a recovery reset code. The recovery process uses only your class join code and the reset code — no personal information such as your name is required or transmitted during recovery, as this data is not retained in recoverable form after account setup.</p>
                     </section>
 
-                    <section class="public-section">
-                        <h2>Contact Information</h2>
-                        <p>For questions or concerns, you may use the help and support page to open a support ticket.</p>
+                    <section class="public-section" id="isolation">
+                        <h2>Class-Level Data Isolation</h2>
+                        <p>Each class operates as a completely independent system. Your data is strictly isolated within your class:</p>
+                        <ul>
+                            <li>No cross-class visibility or data sharing</li>
+                            <li>Teachers can only access classes they create</li>
+                            <li>Student data is never aggregated or shared across classes</li>
+                            <li>The system does not maintain student identity across classes</li>
+                        </ul>
                     </section>
+
+                    <section class="public-section" id="logging">
+                        <h2>Error Logging &amp; Monitoring</h2>
+                        <p>To maintain system reliability and quickly resolve technical issues, our application automatically logs errors and technical failures. Error logs do not include personal names or identifiable information.</p>
+                    </section>
+
+                    <section class="public-section" id="what-not">
+                        <h2>What CTH Does Not Do</h2>
+                        <ul>
+                            <li>No advertising or data selling</li>
+                            <li>No third-party analytics or tracking</li>
+                            <li>No behavioral profiling or data mining</li>
+                            <li>No cross-class tracking or data aggregation</li>
+                            <li>No integration with external identity systems (e.g., SSO)</li>
+                            <li>No long-term data retention beyond active class lifecycle</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="contact">
+                        <h2>Contact Information</h2>
+                        <p>For questions or concerns about privacy and data handling, please reach out to <a href="mailto:support@classroomtokenhub.com">support@classroomtokenhub.com</a>.</p>
+                    </section>
+                    </div>
                 </div>
             </div>
         </section>
@@ -135,6 +186,10 @@
             <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy" target="_blank" rel="noopener">Project Repository</a>
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
+            </div>
+            <div class="landing-footer-links">
+                <a href="./terms.html" target="_self">Terms of Service</a>
+                <a href="./district.html" target="_self">District Partners</a>
             </div>
             <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>

--- a/github-pages/style.css
+++ b/github-pages/style.css
@@ -44,14 +44,6 @@
     --guardian-gray: #303030;
 }
 
-.loading-badge {
-    background-color: var(--secondary-color);
-    padding: 10px;
-    width: fit-content;
-    margin: 0 auto;
-    border-radius: 100px;
-}
-
 body {
     font-family: 'Inter', sans-serif;
     line-height: 1.6;
@@ -59,203 +51,49 @@ body {
     background-color: var(--bg-light);
 }
 
-/* Navigation */
-nav {
-    background-color: var(--bg-white);
-    box-shadow: var(--shadow);
-    position: sticky;
-    top: 0;
-    z-index: 1000;
-}
-
-.nav-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 1rem 2rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.logo {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    text-decoration: none;
-    color: var(--text-dark);
-}
-
-.logo img {
-    width: 40px;
-    height: 40px;
-}
-
-.logo h1 {
-    font-size: 1.5rem;
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Atkinson Hyperlegible Next', sans-serif;
     font-weight: 700;
-    margin: 0;
+    line-height: 1.3;
 }
 
-.logo-title {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
+h1 {
+    font-size: 2.5rem;
 }
 
-.logo-icon {
+h2 {
     font-size: 1.5rem;
-    vertical-align: -15%;
 }
 
-.logo-transition {
-    font-size:3rem;
-    color:var(--secondary-color)
-}
-
-.logo-text {
-    color: var(--primary-color);
-}
-
-.nav-right {
-    display: flex;
-    align-items: center;
-    gap: 2rem;
-}
-
-.nav-links {
-    display: flex;
-    gap: 2rem;
-    align-items: center;
-}
-
-.nav-links--large {
+h3 {
     font-size: 1.25rem;
 }
 
-.nav-links a {
-    text-decoration: none;
-    color: var(--text-light);
-    font-weight: 500;
-    transition: color 0.3s;
+h4 {
+    font-size: 1.25rem;
 }
 
-.nav-links a:hover {
-    color: var(--secondary-color);
+h5, h6 {
+    font-size: 1rem;
 }
 
-.btn {
-    padding: 0.75rem 1.5rem;
-    text-decoration: none;
-    font-weight: 600;
-    display: inline-block;
-    box-shadow:var( --shadow-sm);
+code, pre, .code {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.9rem;
 }
 
-.btn-primary {
-    background-color: var(--primary-color);
-    color: white;
-    border: 2px solid var(--primary-color);
-}
-
-.btn-primary:hover {
-    background-color: var(--secondary-color);
-    border-style: solid;
-    border-color: white;
-    border-width: 2px;
+pre {
+    background-color: var(--neutral-100);
+    padding: 1rem;
+    border-radius: 4px;
+    overflow-x: auto;
 }
 
 hr {
     border-color: var(--accent-color);
     margin: 1rem 1rem;
     border-width: 2px;
-}
-
-.explain-text{
-    font-size:0.9rem;
-    padding-left:3rem;
-    padding-right:3rem;
-    font-weight:300;
-    color:white;
-}
-
-.btn-secondary {
-    background-color: transparent;
-    color: var(--secondary-color);
-    border: 2px solid var(--secondary-color);
-}
-
-.btn-secondary:hover {
-    background-color: var(--secondary-color);
-    color: white;
-    border:2px solid white;
-}
-
-.btn-outline-primary {
-    color: white;
-    border-color: white;
-    background-color: transparent;
-}
-
-.btn-outline-primary:hover {
-    color: white;
-    border-color: white;
-    background-color: var(--secondary-color);
-}
-
-/* Hero Section */
-.hero {
-    background: var(--advisor-green);
-    color: white;
-    padding: 2rem;
-    text-align: center;
-}
-
-.hero-container {
-    margin: 0;
-    padding: 0 1rem;
-}
-
-.hero h2 {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-    font-weight: 300;
-}
-
-.hero p {
-    font-size: 1.25rem;
-}
-
-.hero-actions {
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-    flex-wrap: wrap;
-}
-
-.hero-text {
-    color: var(--advisor-green);
-    padding-top: 2.5rem;
-    padding-left: 4rem;
-    padding-right:4rem;
-    padding-bottom: 2.5rem;
-    text-align: center;
-    font-weight:400;
-    background-color: var(--neutral-100);
-}
-
-.transition-page-bottom-heading {
-    color:var(--secondary);
-    font-weight:500;
-    font-size: 1.2rem;
-    padding-left: 3rem;
-}
-
-.transition-page-subheading {
-    color:white;
-    font-weight:400;
-    font-size: 1rem;
-    padding-left: 3rem;
-    margin-top:0;
 }
 
 .floating-back-widget {
@@ -287,10 +125,8 @@ hr {
 }
 
 .public-content-card {
-    background: var(--bg-white);
-    border-radius: 1rem;
-    box-shadow: var(--shadow-lg);
-    padding: 2rem;
+    background: transparent;
+    padding: 2rem 0;
 }
 
 .public-section {
@@ -300,6 +136,76 @@ hr {
 .public-section:not(:last-child) {
     border-bottom: 1px solid var(--border-color);
     margin-bottom: 1.5rem;
+}
+
+.toc {
+    background-color: var(--neutral-100);
+    padding: 1.5rem;
+    border-left: 4px solid var(--secondary-color);
+    margin-bottom: 2rem;
+    border-radius: 4px;
+}
+
+.toc h3 {
+    margin-top: 0;
+    font-size: 1.1rem;
+}
+
+.toc ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.toc li {
+    margin: 0.5rem 0;
+}
+
+.toc a {
+    color: var(--primary);
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.toc a:hover {
+    color: var(--secondary-color);
+    text-decoration: underline;
+}
+
+/* Two-column layout for pages with TOC */
+.landing-content {
+    position: relative;
+}
+
+.public-content-card.with-toc {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 2rem;
+    background: transparent;
+    padding: 0;
+}
+
+.public-content-card.with-toc .toc {
+    position: sticky;
+    top: 2rem;
+    height: fit-content;
+    margin-bottom: 0;
+}
+
+.public-content-card.with-toc > div:last-child {
+    min-width: 0;
+}
+
+@media (max-width: 900px) {
+    .public-content-card.with-toc {
+        grid-template-columns: 1fr;
+    }
+
+    .public-content-card.with-toc .toc {
+        position: relative;
+        top: auto;
+        margin-bottom: 2rem;
+    }
 }
 
 .transition-page-v2-subheading {
@@ -340,386 +246,10 @@ hr {
     font-weight: 700;
 }
 
-/* Features Grid */
-.features-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-}
-
-.page-bottom-section {
-    border: 0;
-}
-
-.page-bottom-section + .page-bottom-section {
-    border-left: 2px solid var(--secondary-color);
-}
-
-.transition-page-grid {
-    margin-left: 0;
-    margin-right: 0;
-}
-
-.feature-card {
-    background-color: var(--bg-white);
-    padding: 2rem;
-    box-shadow: var(--shadow);
-    transition: transform 0.3s, box-shadow 0.3s;
-}
-
-.feature-card--student,
-.feature-card--teacher,
-.feature-card--about {
-    text-align: center;
-}
-
-.feature-card--student {
-    background-color: #2f4f7f;
-}
-
-.feature-card--teacher {
-    background-color: var(--primary-color);
-}
-
-.feature-card--about {
-    background-color: #703436;
-}
-
-.feature-card-icon {
-    font-size: 48px;
-}
-
-.feature-icon {
-    font-family: 'Material Symbols Outlined', sans-serif;
-    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
-    color: var(--primary-dark);
-}
-
-.feature-card h3 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-    color: var(--text-dark);
-}
-
-.feature-card p {
-    color: var(--text-light);
-    line-height: 1.8;
-}
-
-.feature-badge {
-    display: inline-block;
-    background-color: var(--accent-color);
-    color: white;
-    padding: 0.2rem 0.6rem;
-    border-radius: 0.75rem;
-    font-size: 0.7rem;
-    font-weight: 700;
-    margin-left: 0.5rem;
-    vertical-align: middle;
-}
-
-/* Screenshots */
-.screenshots-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-    gap: 2rem;
-}
-
-.screenshot-card {
-    background-color: var(--bg-white);
-    border-radius: 1rem;
-    overflow: hidden;
-    box-shadow: var(--shadow);
-    transition: transform 0.3s;
-}
-
-.screenshot-card img {
-    width: 100%;
-    height: auto;
-    display: block;
-}
-
-.screenshot-placeholder {
-    background: white;
-    position: relative;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 300px;
-}
-
-.screenshot-placeholder img {
-    width: 100%;
-    height: auto;
-    object-fit: contain;
-    display: block;
-}
-
-.screenshot-modal {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.6);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    padding: 1.5rem;
-    z-index: 2000;
-}
-
-.screenshot-modal.open {
-    display: flex;
-}
-
-.screenshot-modal .modal-content {
-    background: var(--bg-white);
-    border-radius: 1rem;
-    max-width: 960px;
-    width: 100%;
-    box-shadow: var(--shadow-lg);
-    overflow: hidden;
-}
-
-.screenshot-modal header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.5rem;
-    background: var(--primary-dark);
-    color: white;
-}
-
-.screenshot-modal header h3 {
-    margin: 0;
-}
-
-.screenshot-modal header button {
-    background: transparent;
-    border: none;
-    color: white;
-    font-size: 1.5rem;
-    cursor: pointer;
-}
-
-.screenshot-modal .modal-body {
-    padding: 1.5rem;
-}
-
-.screenshot-modal .modal-body img {
-    width: 100%;
-    height: auto;
-    border-radius: 0.75rem;
-    margin-bottom: 1rem;
-    box-shadow: var(--shadow);
-}
-
-.screenshot-modal .modal-body p {
-    color: var(--text-light);
-    margin: 0;
-}
-
-.screenshot-card .caption {
-    padding: 1.5rem;
-}
-
-.screenshot-card .caption h3 {
-    margin-bottom: 0.5rem;
-    color: var(--text-dark);
-}
-
-.screenshot-card .caption p {
-    color: var(--text-light);
-    font-size: 0.95rem;
-}
-
-.phone-frame {
-    background: #1a1a1a;
-    border-radius: 2.5rem;
-    padding: 1rem 0.75rem;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-    margin: 0 auto;
-    width: 100%;
-    max-width: 260px;
-    position: relative;
-}
-
-.phone-frame::before {
-    content: '';
-    position: absolute;
-    top: 0.5rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 60px;
-    height: 6px;
-    background: #333;
-    border-radius: 3px;
-}
-
-.phone-frame img {
-    border-radius: 2rem;
-    display: block;
-    width: 100%;
-    height: auto;
-}
-
-.screenshot-card:has(.phone-frame) .screenshot-placeholder {
-    align-items: flex-start;
-    padding-top: 2rem;
-    min-height: 500px;
-}
-
-/* Stats */
-.stats {
-    background-color: var(--bg-white);
-    padding: 3rem 2rem;
-    box-shadow: var(--shadow);
-    margin-bottom: 4rem;
-}
-
-.stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 2rem;
-    text-align: center;
-}
-
-.stat h4 {
-    font-size: 2.5rem;
-    color: var(--primary-color);
-    margin-bottom: 0.5rem;
-    font-weight: 800;
-}
-
-.stat p {
-    color: var(--text-light);
-    font-size: 1rem;
-}
-
-/* Sign In Section */
-.signin-grid {
-    max-width: 900px;
-    margin: 0 auto;
-}
-
-.signin-card {
-    text-align: center;
-}
-
-.signin-card .btn {
-    margin-top: 1rem;
-}
-
-.signin-note {
-    text-align: center;
-    color: var(--text-light);
-    margin-top: 2rem;
-}
-
-.signin-note a {
-    color: var(--secondary-color);
-    text-decoration: none;
-}
-
-.signin-note a:hover {
-    text-decoration: underline;
-}
-
-/* Footer */
-footer {
-    background-color: var(--text-dark);
-    color: white;
-    padding: 3rem 2rem;
-    text-align: center;
-}
-
-.footer-container {
-    max-width: 1200px;
-    margin: 0 auto;
-}
-
-.footer-links {
-    display: flex;
-    gap: 2rem;
-    justify-content: center;
-    margin-bottom: 2rem;
-    flex-wrap: wrap;
-}
-
-.footer-links a {
-    color: white;
-    text-decoration: none;
-    opacity: 0.8;
-    transition: opacity 0.3s;
-}
-
-.footer-links a:hover {
-    opacity: 1;
-}
-
-footer p {
-    opacity: 0.7;
-}
-
-.footer-release {
-    margin-top: 1rem;
-}
-
-.transition-button {
-    font-size:0.9rem;
-    background-color: transparent;
-    color: var(--secondary-color);
-    border: 2px solid var(--secondary-color);
-}
-
-.transition-button:hover{
-    background-color: var(--secondary-color);
-    color: white;
-    border:2px solid white;
-}
-
-.transition-page {
-    background: var(--guardian-gray);
-}
-
 /* Responsive */
-@media (max-width: 900px) {
-    .nav-container {
-        flex-direction: column;
-        gap: 1rem;
-    }
-
-    .nav-right {
-        flex-direction: column;
-        gap: 1rem;
-    }
-}
-
 @media (max-width: 768px) {
-    .hero h2 {
-        font-size: 2rem;
-    }
-
-    .hero p {
-        font-size: 1rem;
-    }
-
     .section-title {
         font-size: 2rem;
-    }
-
-    .nav-links {
-        display: none;
-    }
-
-    .features-grid,
-    .screenshots-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .stats-grid {
-        grid-template-columns: 1fr;
     }
 }
 
@@ -816,12 +346,6 @@ body.landing-page {
 .landing-signin-panel {
     padding-right: 2rem;
     border-right: 2px solid var(--secondary-color);
-}
-
-.landing-about-panel {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
 }
 
 .landing-signin-heading,
@@ -969,13 +493,18 @@ body.landing-page {
 
 .landing-footer-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr minmax(320px, 1.8fr);
+    grid-template-columns:0.5fr 0.5fr 0.5fr 1.5fr;
     gap: 1rem;
     align-items: start;
 }
 
+.landing-footer {
+    background-color: #2c2c2c;
+}
+
 .landing-footer-links {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 0.5rem;
 }
 
@@ -991,15 +520,19 @@ body.landing-page {
     color: var(--secondary-color);
 }
 
+.landing-footer-meta {
+    text-align: right;
+}
+
 .landing-footer-meta p {
     margin: 0;
-    font-size: 0.88rem;
+    font-size: 0.8rem;
     color: var(--secondary);
-    line-height: 1.4;
+
 }
 
 .landing-footer-meta p + p {
-    margin-top: 0.35rem;
+    margin-top: 0.25rem;
     color: var(--neutral-100);
 }
 
@@ -1026,10 +559,6 @@ body.landing-page {
         border-bottom: 2px solid var(--secondary-color);
         padding-right: 0;
         padding-bottom: 1.5rem;
-    }
-
-    .landing-about-panel {
-        justify-content: flex-start;
     }
 
     .landing-footer-grid {
@@ -1082,6 +611,204 @@ body.landing-page {
     }
 
     .landing-footer-grid {
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .landing-footer-meta {
+        margin-left: 0;
+        text-align: left;
+    }
+}
+
+/* ─── Learn More Page Styles ─── */
+.v2-feature-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.v2-feature-card {
+    background-color: var(--surface);
+    padding: 2.25rem;
+    border-radius: 2px;
+    box-shadow: var(--shadow);
+    border-top: 6px solid var(--secondary-color);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.v2-feature-card .material-symbols-outlined {
+    color: var(--primary);
+    font-size: 2.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.v2-feature-card h3 {
+    color: var(--text-primary);
+    font-size: 1.35rem;
+    margin-bottom: 0.85rem;
+    font-weight: 600;
+}
+
+.v2-feature-card p {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin: 0 0 0.5rem 0;
+}
+
+.v2-feature-card .dev-note {
+    font-size: 0.9rem;
+    color: var(--text-light);
+    font-style: italic;
+    border-top: 1px solid var(--border-subtle);
+    padding-top: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.philosophy-section {
+    margin-bottom: 4.5rem;
+}
+
+.philosophy-heading {
+    color: var(--guardian-gray);
+    font-size: 2.25rem;
+    margin-bottom: 1rem;
+    font-weight: 600;
+    border-bottom: 2px solid var(--border-subtle);
+}
+
+.philosophy-text p {
+    font-size: 1.15rem;
+    color: var(--text-primary);
+    line-height: 1.75;
+    margin-bottom: 1.5rem;
+}
+
+.v2-badge {
+    background-color: var(--secondary-color);
+    color: var(--secondary-text);
+    padding: 0.25rem 0.75rem;
+    border-radius: var(--radius-pill);
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-left: 0.75rem;
+    vertical-align: middle;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.tab-container {
+    margin-top: 1.5rem;
+}
+
+.tab-buttons {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 2rem;
+    border-bottom: 2px solid var(--border-subtle);
+}
+
+.tab-btn {
+    background: transparent;
+    border: none;
+    font-size: 1.25rem;
+    font-weight: 400;
+    color: var(--text-secondary);
+    padding: 0.75rem 1.5rem;
+    cursor: pointer;
+    position: relative;
+    transition: color 0.2s;
+    font-family: inherit;
+}
+
+.tab-btn#student-tab:hover {
+    background-color: var(--steward-blue);
+    color: white;
+}
+
+.tab-btn#teacher-tab:hover {
+    background-color: var(--advisor-green);
+    color: white;
+}
+
+.tab-btn#teacher-tab.active {
+    background-color: var(--advisor-green);
+    color: white;
+}
+
+.tab-btn#teacher-tab.active::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background-color: var(--advisor-green);
+    border-radius: 4px 4px 0 0;
+}
+
+.tab-btn#student-tab.active {
+    background-color: var(--steward-blue);
+    color: white;
+}
+
+.tab-btn#student-tab.active::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background-color: var(--steward-blue);
+    border-radius: 4px 4px 0 0;
+}
+
+#teacher-features .v2-feature-card {
+    border-top-color: var(--advisor-green);
+}
+
+#teacher-features .v2-feature-card .material-symbols-outlined {
+    color: var(--advisor-green);
+}
+
+#student-features .v2-feature-card {
+    border-top-color: var(--steward-blue);
+}
+
+#student-features .v2-feature-card .material-symbols-outlined {
+    color: var(--steward-blue);
+}
+
+.tab-content {
+    display: none;
+    animation: fadeIn 0.3s ease-in-out;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.v2-feature-list.grid-2x2 {
+    grid-template-columns: repeat(2, 1fr);
+}
+
+@media (max-width: 768px) {
+    .v2-feature-list.grid-2x2 {
         grid-template-columns: 1fr;
     }
 }

--- a/github-pages/style.css
+++ b/github-pages/style.css
@@ -146,7 +146,7 @@ hr {
     border-radius: 4px;
 }
 
-.toc h3 {
+.toc h2 {
     margin-top: 0;
     font-size: 1.1rem;
 }
@@ -611,7 +611,7 @@ body.landing-page {
     }
 
     .landing-footer-grid {
-        flex-direction: column;
+        grid-template-columns: 1fr;
         gap: 1.5rem;
     }
 
@@ -785,14 +785,14 @@ body.landing-page {
 
 .tab-content {
     display: none;
-    animation: fadeIn 0.3s ease-in-out;
+    animation: fade-in 0.3s ease-in-out;
 }
 
 .tab-content.active {
     display: block;
 }
 
-@keyframes fadeIn {
+@keyframes fade-in {
     from {
         opacity: 0;
         transform: translateY(5px);

--- a/github-pages/terms.html
+++ b/github-pages/terms.html
@@ -8,8 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;700&family=IBM+Plex+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;700&family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <link href="../static/css/tokens.css" rel="stylesheet">
     <link href="./style.css" rel="stylesheet">
@@ -19,13 +18,22 @@
         <section class="landing-hero">
             <div class="landing-shell landing-hero-grid">
                 <div class="landing-brand">
-                    <div class="landing-brand-row"><span class="material-symbols-outlined" aria-hidden="true">local_atm</span><span>CLASSROOM</span></div>
-                    <div class="landing-brand-row"><span class="material-symbols-outlined" aria-hidden="true">store</span><span>TOKEN</span></div>
-                    <div class="landing-brand-row"><span class="material-symbols-outlined" aria-hidden="true">finance_mode</span><span>HUB</span></div>
+                    <div class="landing-brand-row">
+                        <span class="material-symbols-outlined" aria-hidden="true">local_atm</span>
+                        <span>CLASSROOM</span>
+                    </div>
+                    <div class="landing-brand-row">
+                        <span class="material-symbols-outlined" aria-hidden="true">store</span>
+                        <span>TOKEN</span>
+                    </div>
+                    <div class="landing-brand-row">
+                        <span class="material-symbols-outlined" aria-hidden="true">finance_mode</span>
+                        <span>HUB</span>
+                    </div>
                 </div>
                 <div class="landing-welcome">
                     <h1>Terms of Service</h1>
-                    <p>Last Updated: February 25, 2026</p>
+                    <small>Last Updated: July 31, 2026</small>
                     <a href="https://classroomtokenhub.com/student/login" target="_self" class="floating-back-widget">
                         <span class="material-symbols-outlined" aria-hidden="true">arrow_circle_right</span>
                         <span>Return to Login Page</span>
@@ -33,30 +41,60 @@
                 </div>
             </div>
         </section>
+
         <section class="landing-content">
             <div class="landing-shell">
-                <div class="public-content-card">
-                    <section class="public-section">
+                <div class="public-content-card with-toc">
+                    <nav class="toc">
+                        <h3>Contents</h3>
+                        <ul>
+                            <li><a href="#summary">Quick summary</a></li>
+                            <li><a href="#accepting">Accepting these terms</a></li>
+                            <li><a href="#what-is">What is Classroom Token Hub?</a></li>
+                            <li><a href="#account-responsibilities">Account responsibilities</a></li>
+                            <li><a href="#use-responsibly">How to use responsibly</a></li>
+                            <li><a href="#ownership">Ownership and usage rights</a></li>
+                            <li><a href="#suspension">Account suspension or termination</a></li>
+                            <li><a href="#warranties">No warranties</a></li>
+                            <li><a href="#liability">Limitation of liability</a></li>
+                            <li><a href="#governing-law">Governing law</a></li>
+                            <li><a href="#changes">Changes to terms</a></li>
+                            <li><a href="#questions">Questions or concerns?</a></li>
+                        </ul>
+                    </nav>
+                    <div>
+
+                    <section class="public-section" id="summary">
                         <h2>Quick Summary</h2>
                         <p><strong>What this means:</strong> By using Classroom Token Hub, you agree to use the app responsibly for educational purposes. Keep your login information safe, be respectful to others, and follow your school's rules. The app is provided as-is for educational use, and we can't be held responsible if something goes wrong. We may need to suspend accounts that violate these terms.</p>
                         <p><strong>For students:</strong> Your teacher chose this app for your class. If you have questions, talk to your teacher.</p>
                         <p><strong>For teachers:</strong> This app is free for educational use but cannot be used for commercial purposes.</p>
                     </section>
-                    <section class="public-section"><h2>1. Accepting These Terms</h2><p>When you create an account and use Classroom Token Hub (the "Service"), you're agreeing to follow these Terms of Service. If you don't agree with these terms, please don't use the app.</p></section>
-                    <section class="public-section"><h2>2. What Is Classroom Token Hub?</h2><p>Classroom Token Hub is an educational web application designed to help students learn about financial literacy through a simulated classroom economy. Teachers can use it to manage virtual currency, track student participation, and create engaging lessons about money management.</p></section>
-                    <section class="public-section">
+
+                    <section class="public-section" id="accepting">
+                        <h2>1. Accepting These Terms</h2>
+                        <p>When you create an account and use Classroom Token Hub (the "Service"), you're agreeing to follow these Terms of Service. If you don't agree with these terms, please don't use the app.</p>
+                    </section>
+
+                    <section class="public-section" id="what-is">
+                        <h2>2. What Is Classroom Token Hub?</h2>
+                        <p>Classroom Token Hub is an educational web application designed to help students learn about financial literacy through a simulated classroom economy. Teachers can use it to manage virtual currency, track student participation, and create engaging lessons about money management.</p>
+                    </section>
+
+                    <section class="public-section" id="account-responsibilities">
                         <h2>3. Your Account Responsibilities</h2>
-                        <p>We worked hard to design this app so it can give you the best experience while protecting your privacy. Anyone working behind the scene to maintain this app do not have access to any information about you.</p>
-                        <p>To use the app, you'll need to create an account with a username, PIN, and passphrase. These three pieces of information are what's keeping your account safe from anyone who is not supposed to use your account.</p>
-                        <p>If you lose access to your account, your teacher can issue a recovery reset code. Account recovery uses only your class join code and the reset code — no personal information such as your name or date of birth is required, as this data is not retained after account setup.</p>
+                        <p>We worked hard to design this app so it can give you the best experience while protecting your privacy. Anyone working behind the scene to maintain this app does not have access to any information about you.</p>
+                        <p>To use the app, you'll need to create an account with a PIN and passphrase. These two pieces of information are what's keeping your account safe from anyone who is not supposed to use your account.</p>
+                        <p>If you lose access to your account, your teacher can issue a recovery code. Account recovery uses only your class join code and the recovery code — no personal information such as your name is required, as this data is not retained in a recoverable form after account setup.</p>
                         <p>You can protect yourself by:</p>
                         <ul>
-                            <li><strong>Keep your credentials private</strong>: Don't share your username, PIN, or passphrase with anyone.</li>
+                            <li><strong>Keep your credentials private</strong>: Don't share your PIN or passphrase with anyone.</li>
                             <li><strong>You're responsible for your account</strong>: Any activity on your account is your responsibility, so keep your login information secure.</li>
                             <li><strong>Report security issues immediately</strong>: If someone else accesses your account or you notice suspicious activity, let your teacher know right away.</li>
                         </ul>
                     </section>
-                    <section class="public-section">
+
+                    <section class="public-section" id="use-responsibly">
                         <h2>4. How to Use the App Responsibly</h2>
                         <p>We trust you to use Classroom Token Hub appropriately. Please don't:</p>
                         <ul>
@@ -65,9 +103,10 @@
                             <li>Try to hack, disrupt, or interfere with the app or other users' accounts</li>
                             <li>Attempt to access parts of the system you're not supposed to see</li>
                         </ul>
-                        <p>Even though the people working on this app can't see your personal information, they can still block your account from accessing the app if they believe your actions are harmful for everyone else.</p>
+                        <p>Even though the people working on this app can't see your personal information, they can still block your account from accessing the app if they believe your actions are harmful to everyone else.</p>
                     </section>
-                    <section class="public-section">
+
+                    <section class="public-section" id="ownership">
                         <h2>5. Ownership and How You Can Use It</h2>
                         <p><strong>Timothy Chang</strong> created and owns Classroom Token Hub. The app, its code, and all its features are protected by copyright and trademark laws in the United States and other countries.</p>
                         <div class="alert alert-warning">
@@ -92,21 +131,56 @@
                             </ul>
                         </div>
                     </section>
-                    <section class="public-section"><h2>6. Account Suspension or Termination</h2><p>We hope it never comes to this, but we may need to suspend or terminate accounts that:</p><ul><li>Violate these Terms of Service</li><li>Are used inappropriately or to harm others</li><li>Pose security or safety concerns</li></ul></section>
-                    <section class="public-section"><h2>7. No Warranties</h2><p>We work hard to make Classroom Token Hub reliable and useful, but like all software, it's not perfect. The app is provided "as is" and "as available."</p></section>
-                    <section class="public-section"><h2>8. Limitation of Liability</h2><p>To the extent permitted by law, Timothy Chang and anyone involved in creating or maintaining Classroom Token Hub cannot be held responsible for lost data, profits, opportunities, or issues outside our control.</p></section>
-                    <section class="public-section"><h2>9. Governing Law</h2><p>These Terms of Service are governed by the laws of the jurisdiction where the service is operated.</p></section>
-                    <section class="public-section"><h2>10. Changes to These Terms</h2><p>We may need to update these terms from time to time. If we make significant changes, we'll notify users at least 30 days before the new terms take effect.</p></section>
-                    <section class="public-section"><h2>11. Questions or Concerns?</h2><p>If you have questions about these Terms of Service, please file an in-app support ticket.</p></section>
+
+                    <section class="public-section" id="suspension">
+                        <h2>6. Account Suspension or Termination</h2>
+                        <p>We hope it never comes to this, but we may need to suspend or terminate accounts that:</p>
+                        <ul>
+                            <li>Violate these Terms of Service</li>
+                            <li>Are used inappropriately or to harm others</li>
+                            <li>Pose security or safety concerns</li>
+                        </ul>
+                    </section>
+
+                    <section class="public-section" id="warranties">
+                        <h2>7. No Warranties</h2>
+                        <p>We work hard to make Classroom Token Hub reliable and useful, but like all software, it's not perfect. The app is provided "as is" and "as available."</p>
+                    </section>
+
+                    <section class="public-section" id="liability">
+                        <h2>8. Limitation of Liability</h2>
+                        <p>To the extent permitted by law, Timothy Chang and anyone involved in creating or maintaining Classroom Token Hub cannot be held responsible for lost data, profits, opportunities, or issues outside our control.</p>
+                    </section>
+
+                    <section class="public-section" id="governing-law">
+                        <h2>9. Governing Law</h2>
+                        <p>These Terms of Service are governed by the laws of the jurisdiction where the service is operated.</p>
+                    </section>
+
+                    <section class="public-section" id="changes">
+                        <h2>10. Changes to These Terms</h2>
+                        <p>We may need to update these terms from time to time. If we make significant changes, we'll notify users at least 30 days before the new terms take effect.</p>
+                    </section>
+
+                    <section class="public-section" id="questions">
+                        <h2>11. Questions or Concerns?</h2>
+                        <p>If you have questions about these Terms of Service, please reach out to <a href="mailto:support@classroomtokenhub.com">support@classroomtokenhub.com</a>.</p>
+                    </section>
+                    </div>
                 </div>
             </div>
         </section>
     </main>
+
     <footer class="landing-footer">
         <div class="landing-shell landing-footer-grid">
             <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy" target="_blank" rel="noopener">Project Repository</a>
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
+            </div>
+            <div class="landing-footer-links">
+                <a href="./privacy.html" target="_self">Privacy Policy</a>
+                <a href="./district.html" target="_self">District Assurance</a>
             </div>
             <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>

--- a/github-pages/terms.html
+++ b/github-pages/terms.html
@@ -46,7 +46,7 @@
             <div class="landing-shell">
                 <div class="public-content-card with-toc">
                     <nav class="toc">
-                        <h3>Contents</h3>
+                        <h2>Contents</h2>
                         <ul>
                             <li><a href="#summary">Quick summary</a></li>
                             <li><a href="#accepting">Accepting these terms</a></li>
@@ -83,7 +83,7 @@
 
                     <section class="public-section" id="account-responsibilities">
                         <h2>3. Your Account Responsibilities</h2>
-                        <p>We worked hard to design this app so it can give you the best experience while protecting your privacy. Anyone working behind the scene to maintain this app does not have access to any information about you.</p>
+                        <p>We worked hard to design this app so it can give you the best experience while protecting your privacy. Maintenance access is limited to system upkeep, and sensitive fields such as names and notes stay encrypted, so maintainers cannot read them.</p>
                         <p>To use the app, you'll need to create an account with a PIN and passphrase. These two pieces of information are what's keeping your account safe from anyone who is not supposed to use your account.</p>
                         <p>If you lose access to your account, your teacher can issue a recovery code. Account recovery uses only your class join code and the recovery code — no personal information such as your name is required, as this data is not retained in a recoverable form after account setup.</p>
                         <p>You can protect yourself by:</p>

--- a/github-pages/v2transition.html
+++ b/github-pages/v2transition.html
@@ -8,7 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;700&family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <link href="../static/css/tokens.css" rel="stylesheet">
     <link href="./style.css" rel="stylesheet">
@@ -276,9 +276,13 @@
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
             </div>
             <div class="landing-footer-links">
+                <a href="./terms.html" target="_self">Terms of Service</a>
+                <a href="./privacy.html" target="_self">Privacy Policy</a>
+                <a href="./district.html" target="_self">District Assurance</a>
+            </div>
+            <div class="landing-footer-links">
                 <a href="https://github.com/timwonderer/classroom-economy/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
                 <a href="https://polyformproject.org/licenses/noncommercial/1.0.0" target="_blank" rel="noopener">License</a>
-
             </div>
             <div class="landing-footer-meta">
                 <p>&copy; <span id="current-year"></span> Classroom Token Hub. Licensed under PolyForm Noncommercial v1.0.0</p>


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

## Schema Change Gate Classification (Required for schema changes)

- [x] **NON-MODEL CHANGE** – Comments, TODOs, or docstrings only; no structural model changes

---

## Description

Comprehensive update to GitHub Pages public documentation (privacy.html, terms.html, district.html) to align with v2 architecture and improve UX with proper information architecture and styling.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes

**Content Updates:**
- Updated privacy.html: removed email/DOB collection claims, clarified PIN + passphrase model, added TOC
- Updated terms.html: clarified recovery process, added TOC, added footer links to privacy/district
- Updated district.html: fixed class_id vs join_code terminology, removed email storage claims, added TOC with 15 sections
- Updated v2transition.html and learnmore.html: added footer links for consistency

**Styling Updates (style.css):**
- Removed 300+ lines of obsolete styles (navigation, auth UI, gallery, stats, old button variants) — 42% file reduction
- Added typography consolidation: Atkinson Hyperlegible Next (headings), IBM Plex Mono (code), Inter (body)
- Implemented two-column TOC layout with sticky left navigation and 4px gold left border
- Fixed footer layout: restored grid sizing (1fr 1fr minmax(320px, 1.8fr)) with compact meta text
- Updated responsive breakpoints (900px for TOC, 768px/700px for mobile)

## Testing

- [x] Tested locally: verified all pages render correctly
- [x] TOC navigation: confirmed internal anchor links work
- [x] Footer layout: verified balanced spacing and no overflow
- [x] Responsive design: validated at breakpoints (900px, 768px, 700px)
- [x] Footer links: confirmed all pages cross-link properly

## Accessibility Validation

- [x] Not applicable: this PR updates GitHub Pages static documentation only (no application templates/UI scope per INV-ARC-020)

## Database Migration Checklist

**Does this PR include a database migration?** [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the contributing guidelines

## Related Issues

N/A

## Additional Notes

This is a documentation-only change affecting GitHub Pages public documentation. No source code, models, migrations, or database schema changes included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned the District Assurance, Privacy Policy, and Terms of Service pages with clearer layouts, navigation, anchored sections, and expanded policy information.
  * Added coverage of data handling, security, authentication, account responsibilities, compliance, access, and contact details.
  * Updated footer navigation across public pages with links to Terms, Privacy, and District Assurance.
* **Style**
  * Introduced refreshed typography, responsive layouts, table-of-contents navigation, content cards, feature sections, and improved mobile presentation.
  * Updated branding, metadata, dates, and footer design across the public website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->