### PR TITLE
PR 5b: Add entitlement lifecycle FEATs and rewire api.py routes to delegate (bundled slice)

### DIFF
--- a/app/feats/entitlement_lifecycle_feat.py
+++ b/app/feats/entitlement_lifecycle_feat.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+from datetime import datetime
+
+from app.extensions import db
+from app.feats.base import requires_feat_context
+from app.models import PendingAction
+
+
+@requires_feat_context("FEAT-STOR-002")
+def execute_use_item_immediate(
+    *,
+    entitlement_id: str,
+    class_id: str,
+    target_seat_id: int,
+    product_id: int,
+    entitlement_type: str,
+    acquisition_type: str,
+    item_type: str,
+    details: str | None,
+    correlation_id: str | None = None,
+    idempotency_key: str | None = None,
+) -> None:
+    """Execute immediate item consumption."""
+    from app.services.inventory_service import consume_entitlement
+
+    consume_entitlement(
+        entitlement_id=entitlement_id,
+        class_id=class_id,
+        target_seat_id=target_seat_id,
+        actor_seat_id=target_seat_id,
+        product_id=product_id,
+        entitlement_type=entitlement_type,
+        acquisition_type=acquisition_type,
+        correlation_id=correlation_id or f"immediate_use_{entitlement_id}",
+        payload={
+            "outcome": "APPROVED",
+            "source": "api.use_item",
+            "item_type": item_type,
+            "details": details,
+        },
+    )
+
+
+@requires_feat_context("FEAT-STOR-002")
+def execute_use_item_request(
+    *,
+    class_id: str,
+    seat_id: int,
+    entitlement_id: str,
+    action_payload: dict[str, Any],
+    correlation_id: str | None = None,
+    idempotency_key: str | None = None,
+) -> None:
+    """Create a pending action for item use request."""
+    import uuid
+    pending_action = PendingAction(
+        class_id=class_id,
+        seat_id=seat_id,
+        entitlement_id=entitlement_id,
+        correlation_id=correlation_id or f"pending_{entitlement_id}_{uuid.uuid4().hex}",
+        authoritative_feat="FEAT-STOR-002",
+        payload=action_payload,
+    )
+    db.session.add(pending_action)
+
+
+@requires_feat_context("FEAT-STOR-002")
+def execute_approve_redemption(
+    *,
+    entitlement: Any,
+    store_item: Any,
+    pending_action: PendingAction,
+    ctx: Any,
+    correlation_id: str | None = None,
+    idempotency_key: str | None = None,
+) -> None:
+    """Execute approval of a pending redemption."""
+    from app.feats.prod import record_hall_pass_log
+    from app.services.inventory_service import consume_entitlement
+
+    if store_item.item_type == 'hall_pass':
+        record_hall_pass_log(
+            ctx=ctx,
+            requested_by_seat_id=entitlement.target_seat_id,
+            approved_by_seat_id=ctx.seat_id,
+            destination=str((pending_action.payload or {}).get("destination") or "Hall Pass"),
+            reason=str((pending_action.payload or {}).get("details") or ""),
+            idempotency_key=pending_action.correlation_id,
+        )
+    else:
+        consume_entitlement(
+            entitlement_id=entitlement.entitlement_id,
+            class_id=entitlement.class_id,
+            target_seat_id=entitlement.target_seat_id,
+            actor_seat_id=ctx.seat_id,
+            product_id=entitlement.product_id,
+            entitlement_type=entitlement.entitlement_type,
+            acquisition_type=entitlement.acquisition_type,
+            correlation_id=pending_action.correlation_id,
+            payload={
+                "outcome": "APPROVED",
+                "source": "api.approve_redemption",
+                "item_type": store_item.item_type,
+                "details": (pending_action.payload or {}).get("details") or None,
+            },
+        )
+    db.session.delete(pending_action)
+
+
+@requires_feat_context("FEAT-STOR-002")
+def execute_reject_redemption(
+    *,
+    pending_action: PendingAction,
+    correlation_id: str | None = None,
+    idempotency_key: str | None = None,
+) -> None:
+    """Execute rejection of a pending redemption (delete pending action without consumption)."""
+    db.session.delete(pending_action)

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -56,7 +56,7 @@ from app.routes.student import (
     _is_student_coverage_period_paid,
 )
 from app.services.context_resolver import resolve_canonical_context, ContextResolutionError
-from app.feats.base import FEATContext
+from app.feats.base import feat_shell, FEATContext
 from app.feats.store_purchase_feat import execute_store_purchase
 from app.feats.ledger_resolution_feat import build_intended_ledger_plan, resolve_intended_ledger_plan, apply_resolved_ledger_plan
 from app.services import store_service
@@ -1023,6 +1023,7 @@ def hall_pass_settings():
 
 @api_bp.route('/hall-pass/settings', methods=['POST'])
 @admin_required
+@feat_shell("FEAT-SETTINGS-001")
 def update_hall_pass_settings():
     """Update hall pass queue settings (admin only)."""
     context = getattr(g, "canonical_context", None)
@@ -1040,7 +1041,6 @@ def update_hall_pass_settings():
             queue_limit=data.get("queue_limit") if "queue_limit" in data else None,
             updated_at=utc_now(),
         )
-        db.session.commit()
     except ValueError as exc:
         _log_api_client_error("update_hall_pass_settings", exc, extra=f"class_id={class_id}")
         return jsonify({"status": "error", "message": "Hall pass settings are invalid."}), 400
@@ -1238,6 +1238,7 @@ def get_hall_pass_setup():
 
 @api_bp.route('/hall-pass/setup', methods=['POST'])
 @admin_required
+@feat_shell("FEAT-SETTINGS-001")
 def save_hall_pass_setup():
     """Save teacher's hall pass configuration"""
     user_id = g.canonical_context.user_id
@@ -1304,7 +1305,6 @@ def save_hall_pass_setup():
             pass_types=pass_types,
             updated_at=utc_now(),
         )
-        db.session.commit()
 
         return jsonify({
             "status": "success",
@@ -1321,6 +1321,7 @@ def save_hall_pass_setup():
 
 @api_bp.route('/hall-pass/verify-token/rotate', methods=['POST'])
 @admin_required
+@feat_shell("FEAT-SETTINGS-001")
 def rotate_hall_pass_verify_token():
     """
     Rotate the teacher's hall pass public verification token.
@@ -1333,7 +1334,6 @@ def rotate_hall_pass_verify_token():
 
     try:
         token = feat_rotate_teacher_hall_pass_verify_token(user_id=user_id)
-        db.session.commit()
     except LookupError as exc:
         _log_api_client_error("rotate_hall_pass_verify_token", exc, extra=f"user_id={user_id}")
         return jsonify({"status": "error", "message": "Hall pass verification settings were not found."}), 404

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -474,7 +474,6 @@ def use_item():
             details=details,
             idempotency_key=f"feat:stor:use_imm:{entitlement.entitlement_id}",
         )
-        db.session.commit()
         return jsonify({"status": "success", "message": f"You used {store_item.name}."})
 
     if store_item.item_type == 'hall_pass':
@@ -503,7 +502,6 @@ def use_item():
         action_payload=action_payload,
         idempotency_key=f"feat:stor:use_req:{entitlement.entitlement_id}",
     )
-    db.session.commit()
     return jsonify({"status": "success", "message": f"You have requested to use {store_item.name}. Awaiting admin approval."})
 
 
@@ -560,7 +558,6 @@ def approve_redemption():
             ctx=ctx,
             idempotency_key=f"feat:stor:appr_req:{entitlement.entitlement_id}",
         )
-        db.session.commit()
     except (SQLAlchemyError, ValueError) as e:
         current_app.logger.info(
             "Redemption approval failed for entitlement %s: %s",
@@ -612,7 +609,6 @@ def reject_redemption():
             pending_action=pending_action,
             idempotency_key=f"feat:stor:rej_req:{entitlement.entitlement_id}",
         )
-        db.session.commit()
     except (SQLAlchemyError, ValueError) as e:
         current_app.logger.info(
             "Redemption rejection failed for entitlement %s: %s",

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -41,7 +41,7 @@ from app.auth import (
 )
 from app.access import AccessScopeDenied, resolve_scope
 from app.services.context_resolver import ContextResolutionError, resolve_canonical_context
-from app.feats.base import feat_shell
+
 from app.feats.attendance import (
     rotate_teacher_hall_pass_verify_token as feat_rotate_teacher_hall_pass_verify_token,
     save_hall_pass_setup_config as feat_save_hall_pass_setup_config,
@@ -417,7 +417,6 @@ def purchase_item():
 
 @api_bp.route('/use-item', methods=['POST'])
 @login_required
-@feat_shell("FEAT-STOR-002")
 def use_item():
     context = getattr(g, "canonical_context", None)
     if not context:
@@ -463,22 +462,19 @@ def use_item():
         terminal = _entitlement_terminal_event(entitlement.entitlement_id)
         if terminal:
             return jsonify({"status": "error", "message": "This item is not available for redemption."}), 400
-        consume_entitlement(
+        from app.feats.entitlement_lifecycle_feat import execute_use_item_immediate
+        execute_use_item_immediate(
             entitlement_id=entitlement.entitlement_id,
             class_id=entitlement.class_id,
             target_seat_id=entitlement.target_seat_id,
-            actor_seat_id=entitlement.target_seat_id,
             product_id=entitlement.product_id,
             entitlement_type=entitlement.entitlement_type,
             acquisition_type=entitlement.acquisition_type,
-            correlation_id=f"immediate_use_{entitlement.entitlement_id}",
-            payload={
-                "outcome": "APPROVED",
-                "source": "api.use_item",
-                "item_type": store_item.item_type,
-                "details": details or None,
-            },
+            item_type=store_item.item_type,
+            details=details,
+            idempotency_key=f"feat:stor:use_imm:{entitlement.entitlement_id}",
         )
+        db.session.commit()
         return jsonify({"status": "success", "message": f"You used {store_item.name}."})
 
     if store_item.item_type == 'hall_pass':
@@ -499,21 +495,20 @@ def use_item():
             "details": details or None,
         }
 
-    pending_action = PendingAction(
+    from app.feats.entitlement_lifecycle_feat import execute_use_item_request
+    execute_use_item_request(
         class_id=entitlement.class_id,
         seat_id=student.id,
         entitlement_id=entitlement.entitlement_id,
-        correlation_id=f"pending_{entitlement.entitlement_id}_{uuid.uuid4().hex}",
-        authoritative_feat="FEAT-STOR-002",
-        payload=action_payload,
+        action_payload=action_payload,
+        idempotency_key=f"feat:stor:use_req:{entitlement.entitlement_id}",
     )
-    db.session.add(pending_action)
+    db.session.commit()
     return jsonify({"status": "success", "message": f"You have requested to use {store_item.name}. Awaiting admin approval."})
 
 
 @api_bp.route('/approve-redemption', methods=['POST'])
 @admin_required
-@feat_shell("FEAT-STOR-002")
 def approve_redemption():
     """
     Approve a pending redemption request.
@@ -557,33 +552,15 @@ def approve_redemption():
             return jsonify({"status": "error", "message": "Redemption request is no longer pending and cannot be approved."}), 409
 
         ctx = g.canonical_context
-        if store_item.item_type == 'hall_pass':
-            record_hall_pass_log(
-                ctx=ctx,
-                requested_by_seat_id=entitlement.target_seat_id,
-                approved_by_seat_id=ctx.seat_id,
-                destination=str((pending_action.payload or {}).get("destination") or "Hall Pass"),
-                reason=str((pending_action.payload or {}).get("details") or ""),
-                idempotency_key=pending_action.correlation_id,
-            )
-        else:
-            consume_entitlement(
-                entitlement_id=entitlement.entitlement_id,
-                class_id=entitlement.class_id,
-                target_seat_id=entitlement.target_seat_id,
-                actor_seat_id=ctx.seat_id,
-                product_id=entitlement.product_id,
-                entitlement_type=entitlement.entitlement_type,
-                acquisition_type=entitlement.acquisition_type,
-                correlation_id=pending_action.correlation_id,
-                payload={
-                    "outcome": "APPROVED",
-                    "source": "api.approve_redemption",
-                    "item_type": store_item.item_type,
-                    "details": (pending_action.payload or {}).get("details") or None,
-                },
-            )
-        db.session.delete(pending_action)
+        from app.feats.entitlement_lifecycle_feat import execute_approve_redemption
+        execute_approve_redemption(
+            entitlement=entitlement,
+            store_item=store_item,
+            pending_action=pending_action,
+            ctx=ctx,
+            idempotency_key=f"feat:stor:appr_req:{entitlement.entitlement_id}",
+        )
+        db.session.commit()
     except (SQLAlchemyError, ValueError) as e:
         current_app.logger.info(
             "Redemption approval failed for entitlement %s: %s",
@@ -600,7 +577,6 @@ def approve_redemption():
 
 @api_bp.route('/reject-redemption', methods=['POST'])
 @admin_required
-@feat_shell("FEAT-STOR-002")
 def reject_redemption():
     """Reject a pending redemption request without terminating the entitlement."""
     data = request.get_json(silent=True) or {}
@@ -631,7 +607,12 @@ def reject_redemption():
         if not pending_action:
             return jsonify({"status": "error", "message": "Redemption request could not be rejected in its current state."}), 409
 
-        db.session.delete(pending_action)
+        from app.feats.entitlement_lifecycle_feat import execute_reject_redemption
+        execute_reject_redemption(
+            pending_action=pending_action,
+            idempotency_key=f"feat:stor:rej_req:{entitlement.entitlement_id}",
+        )
+        db.session.commit()
     except (SQLAlchemyError, ValueError) as e:
         current_app.logger.info(
             "Redemption rejection failed for entitlement %s: %s",
@@ -1046,7 +1027,6 @@ def hall_pass_settings():
 
 @api_bp.route('/hall-pass/settings', methods=['POST'])
 @admin_required
-@feat_shell("FEAT-SETTINGS-001")
 def update_hall_pass_settings():
     """Update hall pass queue settings (admin only)."""
     context = getattr(g, "canonical_context", None)
@@ -1064,6 +1044,7 @@ def update_hall_pass_settings():
             queue_limit=data.get("queue_limit") if "queue_limit" in data else None,
             updated_at=utc_now(),
         )
+        db.session.commit()
     except ValueError as exc:
         _log_api_client_error("update_hall_pass_settings", exc, extra=f"class_id={class_id}")
         return jsonify({"status": "error", "message": "Hall pass settings are invalid."}), 400
@@ -1261,7 +1242,6 @@ def get_hall_pass_setup():
 
 @api_bp.route('/hall-pass/setup', methods=['POST'])
 @admin_required
-@feat_shell("FEAT-SETTINGS-001")
 def save_hall_pass_setup():
     """Save teacher's hall pass configuration"""
     user_id = g.canonical_context.user_id
@@ -1328,6 +1308,7 @@ def save_hall_pass_setup():
             pass_types=pass_types,
             updated_at=utc_now(),
         )
+        db.session.commit()
 
         return jsonify({
             "status": "success",
@@ -1344,7 +1325,6 @@ def save_hall_pass_setup():
 
 @api_bp.route('/hall-pass/verify-token/rotate', methods=['POST'])
 @admin_required
-@feat_shell("FEAT-SETTINGS-001")
 def rotate_hall_pass_verify_token():
     """
     Rotate the teacher's hall pass public verification token.
@@ -1357,6 +1337,7 @@ def rotate_hall_pass_verify_token():
 
     try:
         token = feat_rotate_teacher_hall_pass_verify_token(user_id=user_id)
+        db.session.commit()
     except LookupError as exc:
         _log_api_client_error("rotate_hall_pass_verify_token", exc, extra=f"user_id={user_id}")
         return jsonify({"status": "error", "message": "Hall pass verification settings were not found."}), 404


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Schema Change Gate Classification (Required for schema changes)

- [x] **EXPAND** – Additive, backward-compatible (no removals)
- [ ] **CONTRACT (CODE ONLY)** – Model attribute removal, DB schema unchanged
- [ ] **CONTRACT (DATABASE)** – Destructive migration only
- [ ] **NON-MODEL CHANGE** – Comments, TODOs, or docstrings only; no structural model changes

## Description

**PR 5b of the FEAT-context-correction stack.** Bundled slice — extracts the entitlement redemption/approval lifecycle FEAT functions PLUS their `app/routes/api.py` route callers as one coherent unit. Both files byte-for-byte equivalent to `feat-context-correction` (verified per file).

### Why bundled

Unlike PRs 2-5 which were pure decorator swaps, this slice is a **route→FEAT delegation refactor**. The four new FEAT functions in `entitlement_lifecycle_feat.py` are only meaningful with their corresponding route caller updates in `api.py`. Landing either half alone would create either dead-added code or broken imports.

### Files migrated

- **`app/feats/entitlement_lifecycle_feat.py`** (new file, 120 lines) — Adds four FEAT functions:
  - `execute_use_item_immediate` — immediate-consume redemption
  - `execute_use_item_request` — request-approval redemption
  - `execute_approve_redemption` — teacher approves pending
  - `execute_reject_redemption` — teacher rejects pending
  
  All four decorated with `@requires_feat_context`. Exact match with reference.

- **`app/routes/api.py`** (+30/-49 = net -19 lines) — Four route handlers rewired to delegate to the new FEAT functions above. Route signatures unchanged; internals now dispatch to FEATs. Exact match with reference.

Diff summary: 2 files changed, 150 insertions, 49 deletions.

### Explicitly excluded

- **`app/feats/store_feat.py`** — Full content investigation confirmed: file did not exist on grid; on reference it exists solely to house one dead-added function (`execute_bulk_adjust_hall_pass_entitlements`) with zero callers even on the reference branch. No other symbols. No cross-imports from `entitlement_lifecycle_feat.py` or `api.py`. Excluded per methodology (do not land dead-added code; do not partially extract merely to preserve reference-branch composition). Deferred to whenever its route caller is scheduled.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

**Test approach:**

- **Exact-match verification:** `git diff feat-context-correction -- <path>` returns empty for both files.
- **Runtime import check:** `entitlement_lifecycle_feat` and `api` both import cleanly.
- **No orphaned dependency:** `api.py` does NOT reference `store_feat` or `execute_bulk_adjust_hall_pass_entitlements` — verified via grep.
- **Targeted pytest** — `pytest tests/test_entitlement_service.py tests/test_entitlement_read_service.py tests/test_phase8_a1_domain_primitives_entitlement.py`: **27 passed / 5 failed / 0 errors** in 116s.

**All 5 failures are pre-existing baseline debt** (verified per-test against `docs/TRACKING/PYTEST_BASELINE_dc5e0efb.md`):

| Test | Baseline status |
|---|---|
| `test_active_rent_grant_without_terminal_event` | IN BASELINE |
| `test_active_rent_grant_with_terminal_event_returns_none` | IN BASELINE |
| `test_exercisable_without_terminal_event` | IN BASELINE |
| `test_not_exercisable_with_consumed_event` | IN BASELINE |
| `test_terminal_event_none_when_no_terminal` | IN BASELINE |

Zero regressions introduced. Per the "green or understood" gate on the handoff doc §7: **understood** — persistent baseline debt in `test_phase8_a1_domain_primitives_entitlement.py` whose remediation slice hasn't landed on grid yet.

## Accessibility Validation

- [x] Not applicable: this PR does not touch template/UI scope covered by `INV-ARC-020`
- [ ] Applicable: this PR includes template/UI scope and the accessibility report below is complete

**Accessibility Scope**
Not applicable — Python route-handler internals + FEAT additions only. No template, layout, component, template CSS, or template JS touched.

**Accessibility Commands**
Not applicable.

**Accessibility Issues Found**
None.

**Accessibility Fixes Applied**
None.

**Remaining Accessibility Issues / Follow-up Risk**
None.

**Changelog Accessibility Entry**
- [x] N/A — no accessibility scope in this PR

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] If this PR touched template/UI scope, I completed the required accessibility validation report (N/A here)
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

**Stacked-PR ancestry:**

- Base: `feat/paste-staging-grid` at `e1d8eaf9` (post-PR-4)
- Target end state: `feat-context-correction` at `dc5e0efb`
- Baseline: `docs/TRACKING/PYTEST_BASELINE_dc5e0efb.md`

Stack progression:
- ✅ PR 0/1/2/3/4 merged
- 🟡 PR 5 STORE decorator-swap subset ([#1344](https://github.com/timwonderer/classroom-token-hub/pull/1344)) — independent, no file overlap with this PR
- 🟡 Docs handoff ([#1341](https://github.com/timwonderer/classroom-token-hub/pull/1341))
- 🟡 **PR 5b (this PR): Entitlement lifecycle FEATs + api.py route delegation**
- Next: PR 6 (ledger tranche — `ledger_resolution_feat.py`, `transaction_void_feat.py`)
- Then: PR 7 (prod tranche — `prod.py`, `attendance.py`)

**Deferred, not scheduled:**
- `store_feat.py` + `execute_bulk_adjust_hall_pass_entitlements` — awaiting its route caller
- CLASS→IDENTITY reassignment slice (identified in handoff §5)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added entitlement redemption workflows for immediate use, pending requests, approvals, and rejections.
  - Approved redemptions now consume eligible entitlements or record hall-pass redemptions.
  - Rejected requests are canceled without consuming entitlements.
- **Bug Fixes**
  - Redemption actions now process consistently and safely, preventing duplicate updates when requests are retried.
  - Existing validation and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->