### PR TITLE
PR 6: Extract ledger_resolution_feat decorator swap (1 file; transaction_void_feat rejected as shim, deferred)

### DIFF
--- a/app/feats/ledger_resolution_feat.py
+++ b/app/feats/ledger_resolution_feat.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 
 from app.extensions import db
-from app.feats.base import feat_shell
+from app.feats.base import requires_feat_context
 from app.models import ClassEconomy, Seat
 from app.services import ledger_service
 from app.models import _quantize_currency
@@ -53,7 +53,7 @@ def build_intended_ledger_plan(
     )
 
 
-@feat_shell("FEAT-LED-000")
+@requires_feat_context("FEAT-LED-000")
 def resolve_intended_ledger_plan(
     *,
     plan: IntendedLedgerPlan,
@@ -226,7 +226,7 @@ def _calculate_overdraft_fee_amount(*, seat, banking_settings, force: bool = Fal
     return Decimal("0.00")
 
 
-@feat_shell("FEAT-LED-000")
+@requires_feat_context("FEAT-LED-000")
 def apply_resolved_ledger_plan(
     *,
     resolved_plan: ResolvedLedgerPlan,


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Schema Change Gate Classification (Required for schema changes)

- [ ] **EXPAND** – Additive, backward-compatible (no removals)
- [ ] **CONTRACT (CODE ONLY)** – Model attribute removal, DB schema unchanged
- [ ] **CONTRACT (DATABASE)** – Destructive migration only
- [x] **NON-MODEL CHANGE** – Comments, TODOs, or docstrings only; no structural model changes

## Description

**PR 6 of the FEAT-context-correction stack.** Extracts one ledger-domain FEAT from `feat-context-correction`. Byte-for-byte equivalent to reference (verified via `git diff feat-context-correction -- app/feats/ledger_resolution_feat.py` empty).

### File migrated

- **`app/feats/ledger_resolution_feat.py`** — FEAT-LED-001 (overdraft fee application) + related monetary-resolution FEAT sites. Two decorator swaps for two `@feat_shell` sites.

Diff summary: 1 file changed, 3 insertions, 3 deletions.

### Intentional deviation from `feat-context-correction` — `transaction_void_feat.py` rejected as shim

Reference adds `@requires_feat_context("FEAT-LED-002")` to `execute_void_transaction()` PLUS optional `correlation_id` / `idempotency_key` kwargs (default `None`). **Rejected as a compatibility shim.**

**Why rejected:**

- `FEAT-LED-002` is registered as HIGH blast radius (`app/feats/base.py` FEAT_REGISTRY).
- `FEATContext` raises `FEATContextError` in non-production when `idempotency_key` is missing: `"FATAL: MANDATORY ID MISSING: HIGH blast radius FEAT FEAT-LED-002 requires an idempotency_key."`
- Existing callers (`admin.py:6885/8209/8258`) pass only `tx` positionally with no `idempotency_key`.
- The kwargs-with-defaults preserve call syntax but do NOT preserve executable behavior. Old callers would compile and static-analyze fine, then raise at runtime the moment the void endpoints are exercised in dev/test.
- Per standing rule ("No compat shims during migration — rewrite routes to canonical terminology directly"), the defaults are prohibited.

**Deferred migration slice definition:**

- **Scope:** `app/feats/transaction_void_feat.py` + three `admin.py` callers (`void_transaction:6885`, `void_payroll_transaction:8209`, `void_transactions_bulk:8258`).
- **Requirements:**
  1. Remove `correlation_id` / `idempotency_key` defaults from `execute_void_transaction` signature (no shim).
  2. Update every caller to pass explicit `idempotency_key` derived from the void's canonical scope (e.g., `feat:led:void:<class_id>:<tx_id>` or per the void's idempotency contract).
  3. Execute the affected route paths in verification (POST `/admin/void-transaction/<id>`, POST `/admin/payroll/transactions/<id>/void`, POST `/admin/payroll/transactions/void-bulk`).
- **Not scheduled. Not started in this stack.**

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

**Test approach:**

- **Exact-match verification:** `git diff feat-context-correction -- app/feats/ledger_resolution_feat.py` returns empty.
- **Guardrail:** `python3 scripts/policy_guardrails.py --git-diff-base origin/feat/paste-staging-grid --git-diff-head HEAD` → `Policy guardrails: clean`.
- **Targeted pytest:** `pytest tests/dom/ledger/ tests/dom/class/test_banking_core.py` — **7 passed / 8 failed**.

**All 8 failures are pre-existing baseline debt** (verified per-test against `docs/TRACKING/PYTEST_BASELINE_dc5e0efb.md`):

| Test | Baseline status |
|---|---|
| `test_DOM_LED_001__payroll_transactions_stay_class_scoped` | IN BASELINE |
| `test_DOM_LED_001__idempotent_transaction_reuses_existing_row_on_retry` | IN BASELINE |
| `test_DOM_LED_001__idempotent_transaction_recovers_from_integrity_race` | IN BASELINE |
| `test_DOM_LED_001__idempotent_transaction_rejects_non_idempotent_types` | IN BASELINE |
| `test_DOM_LED_001__idempotent_transaction_rejects_empty_keys[*]` (×3) | IN BASELINE |
| `test_DOM_LED_001__idempotent_transaction_rejects_oversize_keys` | IN BASELINE |

The 5 `test_banking_core.py` tests exercising `execute_void_transaction` all passed — grid behavior of the void path is preserved.

Zero regressions introduced by PR 6.

## Accessibility Validation

- [x] Not applicable: this PR does not touch template/UI scope covered by `INV-ARC-020`

**Accessibility Scope:** Not applicable — Python decorator change only.
**Accessibility Commands:** Not applicable.
**Accessibility Issues Found:** None.
**Accessibility Fixes Applied:** None.
**Remaining Accessibility Issues / Follow-up Risk:** None.
**Changelog Accessibility Entry:** [x] N/A

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] If this PR touched template/UI scope, I completed the required accessibility validation report (N/A here)
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

**Stacked-PR ancestry:**

- Base: `feat/paste-staging-grid` at `6afa9a83` (post-PR-5b)
- Target end state: `feat-context-correction` at `dc5e0efb`
- Baseline: `docs/TRACKING/PYTEST_BASELINE_dc5e0efb.md`

Stack progression:
- ✅ PR 0/1/2/3/4/5/5b merged
- 🟡 Docs handoff ([#1341](https://github.com/timwonderer/classroom-token-hub/pull/1341))
- 🟡 **PR 6 (this PR): Ledger decorator swap (1 file, narrowed from 2)**
- Next: PR 7 (prod tranche — `prod.py`, `attendance.py`)
- Then: PR 8 (`FEAT-ANLY-001` → `FEAT-ITR-001` code-side rename)
- Then: Final cleanup (delete `@feat_shell` decorator once all sites migrated)

**Deferred slices (not scheduled):**
- **transaction_void_feat + admin.py callers slice** (defined above) — required for the full ledger-domain migration; must not carry the compat shim from the reference.
- Settings/Attendance FEAT-context slice (identified in PR 5b — restores route→FEAT delegation for hall-pass settings)
- CLASS→IDENTITY reassignment slice (identified in PR 2)
- `store_feat.py` dead-added function `execute_bulk_adjust_hall_pass_entitlements` (identified in PR 5)
- PendingAction concurrency ([#1346](https://github.com/timwonderer/classroom-token-hub/issues/1346))

</details>