### PR TITLE
PR 7: Extract prod.py decorator swap (1 file; attendance.py rejected as shim, deferred to Settings/Attendance slice)

### DIFF
--- a/app/feats/prod.py
+++ b/app/feats/prod.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from sqlalchemy import func
 
 from app.extensions import db
-from app.feats.base import feat_shell, get_correlation_id
+from app.feats.base import requires_feat_context, get_correlation_id
 from app.models import (
     AttendanceReasonCode,
     AttendanceSession,
@@ -209,7 +209,7 @@ def _calculate_attendance_seconds_since(
     return evaluation.elapsed_seconds
 
 
-@feat_shell("FEAT-PROD-001")
+@requires_feat_context("FEAT-PROD-001")
 def record_attendance_session(
     *,
     ctx: CanonicalContext,
@@ -263,7 +263,6 @@ def record_attendance_session(
     target_user_id = target_seat.user_id
 
     if status == "active":
-        from app.utils.canonical_temporal_resolver import canonical_temporal_resolver, CLASS_LEVEL_EVALUATION
         cle = canonical_temporal_resolver(
             CLASS_LEVEL_EVALUATION,
             canonical_execution_context=ctx,
@@ -323,7 +322,7 @@ def record_attendance_session(
     return AttendanceSessionResult(session=session)
 
 
-@feat_shell("FEAT-PROD-002")
+@requires_feat_context("FEAT-PROD-002")
 def record_hall_pass_log(
     *,
     ctx: CanonicalContext,
@@ -482,7 +481,7 @@ def _record_payroll_event_impl(
     return PayrollEventResult(payroll_event=event, ledger_transaction=tx)
 
 
-@feat_shell("FEAT-PROD-003")
+@requires_feat_context("FEAT-PROD-003")
 def record_payroll_event(
     *,
     ctx: CanonicalContext,
@@ -510,7 +509,7 @@ def record_payroll_event(
     )
 
 
-@feat_shell("FEAT-PROD-003")
+@requires_feat_context("FEAT-PROD-003")
 def record_payroll_reversal(
     *,
     ctx: CanonicalContext,


### PR DESCRIPTION
## PR Mode (Required – Select Exactly ONE)

- [x] Standard PR (Feature / Bug / Refactor / Docs / Performance)
- [ ] Audit PR (Read-Only, Documentation-Only – No Source Changes Allowed)

---

<details>
<summary>STANDARD PR SECTION (Click to expand)</summary>

## Schema Change Gate Classification (Required for schema changes)

- [ ] **EXPAND** – Additive, backward-compatible (no removals)
- [ ] **CONTRACT (CODE ONLY)** – Model attribute removal, DB schema unchanged
- [ ] **CONTRACT (DATABASE)** – Destructive migration only
- [x] **NON-MODEL CHANGE** – Comments, TODOs, or docstrings only; no structural model changes

## Description

**PR 7 of the FEAT-context-correction stack.** Extracts `app/feats/prod.py` from `feat-context-correction`. Byte-for-byte equivalent to reference (verified via `git diff feat-context-correction -- app/feats/prod.py` empty).

### File migrated

- **`app/feats/prod.py`** — 4 decorator swaps:
  - `record_attendance_session` (FEAT-PROD-001, MED blast)
  - `record_hall_pass_log` (FEAT-PROD-002, MED blast)
  - `record_payroll_event` (FEAT-PROD-003, HIGH blast)
  - `record_payroll_reversal` (FEAT-PROD-003, HIGH blast)
- Plus one import dedup: removes a local `from app.utils.canonical_temporal_resolver import canonical_temporal_resolver, CLASS_LEVEL_EVALUATION` inside `record_attendance_session` — that same import already exists at module level. The local shadow was causing an `UnboundLocalError` on the grid path (see test findings below).

Diff summary: 1 file changed, 5 insertions, 6 deletions.

Existing signatures on all 4 functions already required `correlation_id` and `idempotency_key` (no defaults), so **no compat shim was introduced by the reference for prod.py** — the HIGH-blast enforcement on `FEAT-PROD-003` is already correctly required by the current call surface.

### Intentional deviation from `feat-context-correction` — `attendance.py` rejected as shim

Reference adds `@requires_feat_context("FEAT-SETTINGS-001")` to three hall-pass helpers in `attendance.py` (`update_hall_pass_queue_settings`, `save_hall_pass_setup_config`, `rotate_teacher_hall_pass_verify_token`) PLUS optional `correlation_id` / `idempotency_key` kwargs (default `None`).

**Rejected as compatibility shim** for the same reasons as PR 6's `transaction_void_feat` rejection:
- The optional-defaults preserve call syntax for existing positional callers without updating them to canonical explicit args.
- Per standing rule ("No compat shims during migration — rewrite routes to canonical terminology directly"), the shim is prohibited.
- These three helpers are the exact same functions already identified in [PR 5b handoff §5](https://github.com/timwonderer/classroom-token-hub/pull/1341) as belonging to the deferred Settings/Attendance FEAT-context slice.

Consistent with PR 6's transaction-void disposition.

### Deferred migration slice (unchanged from PR 5b handoff §5)

- **Scope:** `app/feats/attendance.py` (3 hall-pass helpers) + `app/routes/api.py` (3 hall-pass route handlers).
- **Requirements:**
  1. Add `@requires_feat_context("FEAT-SETTINGS-001")` to the 3 helpers WITHOUT optional-defaults shims (kwargs-only, no defaults).
  2. Remove `@feat_shell("FEAT-SETTINGS-001")` from the 3 `api.py` route handlers (route becomes bare; helper owns context).
  3. Update all call sites to pass explicit `idempotency_key`.
  4. Verify with the 3 route paths in test.
- **Not scheduled. Not started in this stack.**

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added new tests for new functionality

**Test approach:**

- **Exact-match verification:** `git diff feat-context-correction -- app/feats/prod.py` returns empty.
- **Guardrail:** `python3 scripts/policy_guardrails.py --git-diff-base origin/feat/paste-staging-grid --git-diff-head HEAD` → `Policy guardrails: clean`.
- **Targeted pytest:** `pytest tests/dom/attendance/ tests/dom/class/test_payroll_settings_class_scope.py tests/dom/identity/test_attendance_log_page.py` — compared PR 7 vs pre-PR-7 grid state on the same suite:

| Metric | Grid (pre-PR-7) | PR 7 |
|---|---:|---:|
| Passed | 10 | 13 |
| Failed | 5 | 2 |
| Errors | 12 | 12 |

**PR 7 fixes 3 pre-existing failures** (net-positive change; zero regressions):

| Fixed test | Grid signature | PR 7 |
|---|---|---|
| `test_DOM_PROD_001__calculate_unpaid_attendance_seconds` | FAIL: `UnboundLocalError: canonical_temporal_resolver` | ✅ PASS |
| `test_DOM_PROD_001__calculate_period_attendance` | Same | ✅ PASS |
| `test_DOM_PROD_001__get_session_status` | Same | ✅ PASS |

Root cause: the local `from app.utils.canonical_temporal_resolver import canonical_temporal_resolver` inside `record_attendance_session` shadowed the intended module-level binding, causing an `UnboundLocalError` when other code paths in the same function referenced the name before the local import ran. The reference's dedup (moving the import out of the function body — the same import already existed at module level) resolves it.

**Remaining 14 failures** (2 fails + 12 errors) all have identical signatures on grid and PR 7 — pre-existing grid debt, unchanged by PR 7:
- 12 errors on `test_hall_pass_verify.py::*` — `Key (class_id) already exists` fixture collision
- 1 fail on `test_hall_pass_history_scoping.py` — same fixture collision
- 1 fail on `test_hall_pass_verify.py::test_post_verify_ambiguous` — same class

Zero regressions introduced.

## Accessibility Validation

- [x] Not applicable: this PR does not touch template/UI scope covered by `INV-ARC-020`

**Accessibility Scope:** Not applicable — Python decorator change only.
**Accessibility Commands:** Not applicable.
**Accessibility Issues Found:** None.
**Accessibility Fixes Applied:** None.
**Remaining Accessibility Issues / Follow-up Risk:** None.
**Changelog Accessibility Entry:** [x] N/A

## Database Migration Checklist

**Does this PR include a database migration?** [ ] Yes / [x] No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] If this PR touched template/UI scope, I completed the required accessibility validation report (N/A here)
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the [contributing guidelines](../CONTRIBUTING.md)

## Related Issues

Closes #

## Additional Notes

**Stacked-PR ancestry:**

- Base: `feat/paste-staging-grid` at `a8b6b1d0` (post-PR-6)
- Target end state: `feat-context-correction` at `dc5e0efb`
- Baseline: `docs/TRACKING/PYTEST_BASELINE_dc5e0efb.md`

Stack progression:
- ✅ PR 0/1/2/3/4/5/5b/6 merged
- 🟡 Docs handoff ([#1341](https://github.com/timwonderer/classroom-token-hub/pull/1341))
- 🟡 **PR 7 (this PR): Prod decorator swap (1 file, narrowed from 2)**
- Next: PR 8 (`FEAT-ANLY-001` → `FEAT-ITR-001` code-side rename)
- Then: Final cleanup (delete `@feat_shell` decorator once all sites migrated)

**Deferred slices (not scheduled):**
- **Settings/Attendance FEAT-context slice** (defined above and in PR 5b handoff §5) — required to fully migrate `attendance.py` + the 3 `api.py` hall-pass routes.
- **Ledger transaction-void slice** (defined in PR 6) — required to migrate `transaction_void_feat.py` + 3 `admin.py` void callers.
- CLASS→IDENTITY reassignment slice (identified in PR 2)
- `store_feat.py` dead-added function `execute_bulk_adjust_hall_pass_entitlements` (identified in PR 5)
- PendingAction concurrency ([#1346](https://github.com/timwonderer/classroom-token-hub/issues/1346))

</details>